### PR TITLE
Update AsyncApiService.java

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/AsyncApiService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/AsyncApiService.java
@@ -1,7 +1,9 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
 import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
+import org.springframework.stereotype.Service;
 
+@Service
 public interface AsyncApiService {
 
     AsyncAPI getAsyncAPI();


### PR DESCRIPTION
Added @service  annotation in order to resolve below error 

nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'asyncApiController' defined in URL [jar:file:/home/vcap/app/BOOT-INF/lib/springwolf-core-0.2.0.jar!/io/github/stavshamir/springwolf/asyncapi/AsyncApiController.class]: Unsatisfied dependency expressed through constructor parameter 0; nested exception is org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'defaultAsyncApiService' defined in URL [jar:file:/home/vcap/app/BOOT-INF/lib/springwolf-core-0.2.0.jar!/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.class]: Unsatisfied dependency expressed through constructor parameter 1; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'defaultChannelsService': Invocation of init method failed; nested exception is java.lang.IllegalArgumentException: Only single parameter KafkaListener methods are supported