### PR TITLE
IndexOutOfBoundsException when using bindings instead of queues #38

### DIFF
--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/RabbitChannelsScanner.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/RabbitChannelsScanner.java
@@ -40,7 +40,9 @@ public class RabbitChannelsScanner extends AbstractChannelScanner<RabbitListener
         List<String> resolvedQueues = Arrays.stream(annotation.queues())
                 .map(resolver::resolveStringValue)
                 .collect(toList());
-
+        resolvedQueues.addAll(Arrays.stream(annotation.bindings())
+                .map(bind -> bind.value().name())
+                .collect(toList()));
         log.debug("Found queues: {}", String.join(", ", resolvedQueues));
         return resolvedQueues.get(0);
     }


### PR DESCRIPTION
according to the documentation bindings and queues are mutually exclusive so the list will contain the one that was decalred.