### PR TITLE
Issue #24 PR - Still in Progress

### DIFF
--- a/.github/workflows/springwolf-stomp.yml
+++ b/.github/workflows/springwolf-stomp.yml
@@ -1,0 +1,33 @@
+name: springwolf-kafka
+
+on:
+  push:
+    branches: 
+      - master
+    paths:
+      - '.github/workflows/springwolf-kafka.yml'
+      - 'springwolf-core/**'
+      - 'springwolf-plugins/springwolf-kafka-plugin/**'
+      - 'springwolf-examples/springwolf-kafka-example/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run unit tests
+        run: ./gradlew -p springwolf-plugins/springwolf-kafka-plugin test
+
+      - name: Run integration tests
+        run: ./gradlew -p springwolf-examples/springwolf-kafka-example test

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ include (
         'springwolf-core',
         'springwolf-plugins:springwolf-amqp-plugin',
         'springwolf-plugins:springwolf-kafka-plugin',
+        'springwolf-plugins:springwolf-stomp-plugin',
         'springwolf-examples:springwolf-kafka-example',
         'springwolf-examples:springwolf-amqp-example'
 )

--- a/springwolf-plugins/springwolf-stomp-plugin/README.md
+++ b/springwolf-plugins/springwolf-stomp-plugin/README.md
@@ -1,0 +1,84 @@
+# Springwolf Kafka Plugin
+
+##### Automated documentation for Spring Boot application with Kafka consumers
+
+### Table Of Contents
+
+- [About](#about)
+- [Usage](#usage)
+    - [Dependencies](#dependencies)
+    - [Configuration class](#configuration-class)
+- [Verify](#verify)
+- [Example Project](#example-project)
+
+### About
+
+This plugin generates an [AsyncAPI document](https://www.asyncapi.com/) from:
+- `@KafkaListener` methods
+- `@KafkaHandler` methods in classes annotated with `@KafkaListener`
+
+### Usage
+
+Add the following dependencies and configuration class to enable this plugin.
+
+#### Dependencies
+
+```groovy
+dependencies {
+    // Provides the documentation API    
+    implementation 'io.github.springwolf:springwolf-kafka:0.4.0'
+
+    // Provides the UI - optional (recommended)
+    runtimeOnly 'io.github.springwolf:springwolf-ui:0.4.0'
+}
+```
+
+### Configuration class
+
+Add a configuration class and provide a `AsyncApiDocket` bean:
+
+```java
+
+@Configuration
+@EnableAsyncApi
+public class AsyncApiConfiguration {
+
+    private final static String BOOTSTRAP_SERVERS = "localhost:9092"; // Change to your actual bootstrap server
+
+    @Bean
+    public AsyncApiDocket asyncApiDocket() {
+        Info info = Info.builder()
+                .version("1.0.0")
+                .title("Springwolf example project")
+                .build();
+
+        // Producers are not picked up automatically - if you want them to be included in the asyncapi doc and the UI,
+        // you will need to build a ProducerData and register it in the docket (line 65)
+        ProducerData exampleProducerData = ProducerData.builder()
+                .channelName("example-producer-topic")
+                .binding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .payloadType(ExamplePayloadDto.class)
+                .build();
+
+        return AsyncApiDocket.builder()
+                .basePackage("io.github.stavshamir.springwolf.example.consumers") // Change to your actual base package of listeners
+                .info(info)
+                .server("kafka", Server.builder().protocol("kafka").url(BOOTSTRAP_SERVERS).build())
+                .producer(exampleProducerData)
+                .build();
+    }
+
+}
+```
+
+The basePackage field must be set with the name of the package containing the classes to be scanned for `@KafkaListener`
+annotated methods.
+
+#### Verify
+
+If you have included the UI dependency, access it with the following url: `localhost:8080/springwolf/asyncapi-ui.html`.
+If not, try the following endpoint: `localhost:8080/springwolf/docs`.
+
+### Example Project
+
+See [springwolf-kafka-example](https://github.com/springwolf/springwolf-core/tree/master/springwolf-examples/springwolf-kafka-example).

--- a/springwolf-plugins/springwolf-stomp-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-stomp-plugin/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'java'
     id 'java-library'
     id 'maven'
     id 'signing'
@@ -9,8 +8,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
 }
 
-group = 'io.github.springwolf'
-version = '0.4.0' + (Boolean.valueOf(System.getProperty('snapshot')) ? '-SNAPSHOT' : '')
+group 'io.github.springwolf'
+version '0.4.0'
 sourceCompatibility = 1.8
 
 repositories {
@@ -18,31 +17,22 @@ repositories {
 }
 
 dependencies {
-    api 'com.asyncapi:asyncapi-core:1.0.0-EAP'
-
-    implementation 'io.swagger:swagger-inflector:2.0.5'
+    api project(':springwolf-core')
 
     implementation 'org.springframework:spring-web'
-    implementation 'org.springframework:spring-context'
-    implementation 'org.springframework:spring-messaging'
-    implementation 'org.springframework.boot:spring-boot-autoconfigure'
+    implementation 'org.springframework:spring-messaging:5.3.14'
 
     implementation 'com.google.guava:guava:27.0.1-jre'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.4'
-    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2'
 
-    compileOnly 'org.projectlombok:lombok:1.18.22'
-    annotationProcessor 'org.projectlombok:lombok:1.18.22'
+    compileOnly 'org.projectlombok:lombok:1.18.4'
+    annotationProcessor 'org.projectlombok:lombok:1.18.4'
 
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
 
-    testImplementation 'org.projectlombok:lombok:1.18.22'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.22'
+    testCompile 'org.projectlombok:lombok:1.18.4'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.4'
 
-    testImplementation 'org.assertj:assertj-core:3.21.0'
-
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.amqp:spring-rabbit'
-    testImplementation 'org.springframework.kafka:spring-kafka'
+    testCompile('org.assertj:assertj-core:3.11.1')
 }
 
 jar.enabled = true
@@ -83,7 +73,7 @@ def pomConfig = {
     }
 
     scm {
-        url 'https://github.com/stavshamir/springwolf'
+        url 'https://github.com/springwolf/springwolf-core'
     }
 }
 
@@ -101,13 +91,14 @@ publishing {
             }
 
             groupId project.group
-            artifactId 'springwolf-core'
+            artifactId 'springwolf-stomp'
             version project.version
+
             pom.withXml {
                 def root = asNode()
-                root.appendNode('description', 'Automated JSON API documentation for async APIs (Kafka etc.) interfaces built with Spring')
-                root.appendNode('name', 'springwolf-core')
-                root.appendNode('url', 'https://github.com/stavshamir/springwolf')
+                root.appendNode('description', 'Automated JSON API documentation for default STOMP Listeners built with Spring')
+                root.appendNode('name', 'springwolf-stomp')
+                root.appendNode('url', 'https://github.com/springwolf/springwolf-core')
                 root.children().last() + pomConfig
 
                 def pomFile = file("${project.buildDir}/generated-pom.xml")

--- a/springwolf-plugins/springwolf-stomp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/SpringwolfStompController.java
+++ b/springwolf-plugins/springwolf-stomp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/SpringwolfStompController.java
@@ -1,0 +1,28 @@
+package io.github.stavshamir.springwolf.asyncapi;
+
+import io.github.stavshamir.springwolf.producer.SpringwolfStompProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/springwolf/stomp")
+@RequiredArgsConstructor
+public class SpringwolfStompController {
+
+    private final SpringwolfStompProducer stompProducer;
+
+    @PostMapping("/publish")
+    public void publish(@RequestParam String topic, @RequestBody Map<String, Object> payload) {
+        if (!stompProducer.isEnabled()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Stomp producer is not enabled");
+        }
+        stompProducer.send(topic, payload);
+    }
+
+}

--- a/springwolf-plugins/springwolf-stomp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/MessageMappingChannelScanner.java
+++ b/springwolf-plugins/springwolf-stomp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/MessageMappingChannelScanner.java
@@ -1,0 +1,121 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
+
+import com.asyncapi.v2.binding.OperationBinding;
+import com.asyncapi.v2.binding.stomp.STOMPOperationBinding;
+import com.google.common.collect.ImmutableMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringValueResolver;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Map;
+
+
+/**
+ * Notes about STOMP-Specific problems/Implementation
+ * (Spring Docs - https://docs.spring.io/spring-framework/docs/current/reference/html/web.html#websocket-stomp-message-mapping)
+ *
+ * @MessageMapping is only one of potential "Input" options, @ConnectMapping and @SubscriptionMapping are also valid.
+ * Likely will use another Channel-Scanner for those two, since their AsyncAPI conversion is likely different.
+ *
+ * A confirmation that that the ProducerData handles STOMP is still required, but I think it will be fine.
+ *
+ * From my understanding @SendTo and @SendToUser are only valid for @COMMANDMapping functions/Classes
+ * A @Service Helper Class should work just fine for helping support all the Mapping Annotations for these then.
+ */
+@Service
+@RequiredArgsConstructor
+public class MessageMappingChannelScanner extends AbstractChannelScanner<MessageMapping>
+        implements ChannelsScanner, EmbeddedValueResolverAware {
+
+
+    private StringValueResolver resolver;
+
+    @Override
+    public void setEmbeddedValueResolver(StringValueResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    protected Class<MessageMapping> getListenerAnnotationClass() {
+        return MessageMapping.class;
+    }
+
+    @Override
+    protected String getChannelName(MessageMapping annotation) {
+        // I need to check if Channels can Chain @MessageMapping in a @Controller. For Example
+        //
+        // @Controller
+        // @MessageMapping("/shared")
+        // public ExampleMessageController {
+        //
+        //   @MessageMapping("/foo") // Is this "/shared/foo"?
+        //   public String getBar() { return "bar"; }
+        //
+        // }
+
+        if (annotation.value().length > 0) {
+            return annotation.value()[0];
+        }
+        return "";
+    }
+
+    @Override
+    protected Map<String, ? extends OperationBinding> buildOperationBinding(MessageMapping annotation) {
+        return ImmutableMap.of("stomp", new STOMPOperationBinding()); //STOMPOperationBinding hasn't be implemented, I'll look into doing it myself.
+    }
+
+    @Override
+    protected Class<?> getPayloadType(Method method) {
+        String methodName = String.format("%s::%s", method.getDeclaringClass().getSimpleName(), method.getName());
+
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        switch (parameterTypes.length) {
+            case 0:
+                // Message Mapping can have 0 Arguments and be fine.
+                throw new IllegalArgumentException("Message methods must not have 0 parameters: " + methodName);
+            case 1:
+                // Additional Parameters like @Header, @Headers, and @DestinationVariable are legal for STOMP.
+                return parameterTypes[0];
+            default:
+                // Likely will remove the private and use this for specifically finding the @Payload, return null if none?
+                return getPayloadType(parameterTypes, method.getParameterAnnotations(), methodName);
+        }
+    }
+
+    // Merge into the protected? But remove the IllegalArgumentException.
+    private Class<?> getPayloadType(Class<?>[] parameterTypes, Annotation[][] parameterAnnotations, String methodName) {
+        int payloadAnnotatedParameterIndex = getPayloadAnnotatedParameterIndex(parameterAnnotations);
+
+        if (payloadAnnotatedParameterIndex == -1) {
+            String msg = "Expected Payload Annotation for MessageMapping, "
+                    + "but none was found: "
+                    + methodName;
+
+            throw new IllegalArgumentException(msg);
+        }
+
+        return parameterTypes[payloadAnnotatedParameterIndex];
+    }
+
+    // We can keep this, maybe swap it to include an Annotation Type?
+    // Then we can do anyMatch(annotation -> annotation instanceof targetAnnotation)
+    private int getPayloadAnnotatedParameterIndex(Annotation[][] parameterAnnotations) {
+        for (int i = 0, length = parameterAnnotations.length; i < length; i++) {
+            Annotation[] annotations = parameterAnnotations[i];
+            boolean hasPayloadAnnotation = Arrays.stream(annotations)
+                    .anyMatch(annotation -> annotation instanceof Payload);
+
+            if (hasPayloadAnnotation) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/springwolf-plugins/springwolf-stomp-plugin/src/main/java/io/github/stavshamir/springwolf/producer/SpringwolfStompProducer.java
+++ b/springwolf-plugins/springwolf-stomp-plugin/src/main/java/io/github/stavshamir/springwolf/producer/SpringwolfStompProducer.java
@@ -1,0 +1,27 @@
+package io.github.stavshamir.springwolf.producer;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+public class SpringwolfStompProducer {
+
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
+    @Getter
+    private boolean isEnabled = true;
+
+    public SpringwolfStompProducer(@Autowired SimpMessagingTemplate simpMessagingTemplate) {
+        this.simpMessagingTemplate = simpMessagingTemplate;
+    }
+
+    public void send(String topic, Map<String, Object> payload) {
+        simpMessagingTemplate.convertAndSend(topic, payload);
+    }
+}

--- a/springwolf-plugins/springwolf-stomp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/MessageMappingChannelScannerTest.java
+++ b/springwolf-plugins/springwolf-stomp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/MessageMappingChannelScannerTest.java
@@ -1,0 +1,250 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
+
+import com.asyncapi.v2.binding.OperationBinding;
+import com.asyncapi.v2.binding.stomp.STOMPOperationBinding;
+import com.asyncapi.v2.model.channel.ChannelItem;
+import com.asyncapi.v2.model.channel.operation.Operation;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import io.github.stavshamir.springwolf.asyncapi.scanners.components.ComponentsScanner;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
+import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
+import io.github.stavshamir.springwolf.schemas.DefaultSchemasService;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {MessageMappingChannelScanner.class, DefaultSchemasService.class})
+@TestPropertySource(properties = "stomp.topics.test=test-topic")
+public class MessageMappingChannelScannerTest {
+
+    private static final String TOPIC = "test-topic";
+    @Autowired
+    private MessageMappingChannelScanner messageMappingChannelScanner;
+    @MockBean
+    private ComponentsScanner componentsScanner;
+    @MockBean
+    private AsyncApiDocket asyncApiDocket;
+    @Value("${stomp.topics.test}")
+    private String topicFromProperties;
+
+    @Before
+    public void setUp() throws Exception {
+        when(asyncApiDocket.getBasePackage())
+                .thenReturn("Does not matter - will be set by component scanner mock");
+    }
+
+    private void setClassToScan(Class<?> classToScan) {
+        Set<Class<?>> classesToScan = singleton(classToScan);
+        when(componentsScanner.scanForComponents(anyString())).thenReturn(classesToScan);
+    }
+
+    @Test
+    public void scan_componentHasNoMessageMappingMethods() {
+        setClassToScan(ClassWithoutMessageMappingAnnotation.class);
+
+        Map<String, ChannelItem> channels = messageMappingChannelScanner.scan();
+
+        assertThat(channels)
+                .isEmpty();
+    }
+
+    @Test
+    public void scan_componentHasMessageMappingMethods_hardCodedTopic() {
+        // Given a class with methods annotated with KafkaListener, whose topics attribute is hard coded
+        setClassToScan(ClassWithMessageMappingAnnotationHardCodedTopic.class);
+
+        // When scan is called
+        Map<String, ChannelItem> actualChannels = messageMappingChannelScanner.scan();
+
+        // Then the returned collection contains the channel
+        Message message = Message.builder()
+                .name(SimpleFoo.class.getName())
+                .title(SimpleFoo.class.getSimpleName())
+                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                .build();
+
+        Operation operation = Operation.builder()
+                .bindings(ImmutableMap.of("stomp", new STOMPOperationBinding()))
+                .message(message)
+                .build();
+
+        ChannelItem expectedChannel = ChannelItem.builder().publish(operation).build();
+
+        assertThat(actualChannels)
+                .containsExactly(Maps.immutableEntry(TOPIC, expectedChannel));
+    }
+
+    @Test
+    public void scan_componentHasMessageMappingMethods_embeddedValueTopic() {
+        // Given a class with methods annotated with KafkaListener, whose topics attribute is an embedded value
+        setClassToScan(ClassWithMessageMappingAnnotationsEmbeddedValueTopic.class);
+
+        // When scan is called
+        Map<String, ChannelItem> actualChannels = messageMappingChannelScanner.scan();
+
+        // Then the returned collection contains the channel
+        Message message = Message.builder()
+                .name(SimpleFoo.class.getName())
+                .title(SimpleFoo.class.getSimpleName())
+                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                .build();
+
+        Operation operation = Operation.builder()
+                .bindings(ImmutableMap.of("stomp", new STOMPOperationBinding()))
+                .message(message)
+                .build();
+
+        ChannelItem expectedChannel = ChannelItem.builder().publish(operation).build();
+
+        assertThat(actualChannels)
+                .containsExactly(Maps.immutableEntry(TOPIC, expectedChannel));
+    }
+
+    @Test
+    public void scan_componentHasMessageMappingMethods_withSendTo() {
+        // Given a class with methods annotated with KafkaListener, with a group id
+        setClassToScan(ClassWithMessageMappingAnnotationAndSendTo.class);
+
+        // When scan is called
+        Map<String, ChannelItem> actualChannels = messageMappingChannelScanner.scan();
+
+        // Then the returned collection contains a correct binding
+        Map<String, ? extends OperationBinding> actualBindings = actualChannels.get(TOPIC)
+                .getPublish()
+                .getBindings();
+
+        assertThat(actualBindings).isNotNull();
+        STOMPOperationBinding stomp = (STOMPOperationBinding) actualBindings.get("stomp");
+        assertThat(stomp).isNotNull();
+//        assertThat(stomp.getGroupId()) Asserting properties AFTER creating STOMPOperationBinding
+//                .isEqualTo(ClassWithKafkaListenerAnnotationWithGroupId.GROUP_ID);
+    }
+
+    @Test
+    public void scan_componentHasMessageMappingMethods_multipleParamsWithoutPayloadAnnotation() {
+        // Given a class with a method annotated with KafkaListener:
+        // - The method has more than one parameter
+        // - No parameter is annotated with @Payload
+        setClassToScan(ClassWithMessageMappingAnnotationMultipleParamsWithoutPayloadAnnotation.class);
+
+        // Then an exception is thrown when scan is called
+        assertThatThrownBy(() -> messageMappingChannelScanner.scan())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+
+    @Test
+    public void scan_componentHasMessageMappingMethods_multipleParamsWithPayloadAnnotation() {
+        // Given a class with a method annotated with KafkaListener:
+        // - The method has more than one parameter
+        // - There is a parameter is annotated with @Payload
+        setClassToScan(ClassWithMessageMappingAnnotationMultipleParamsWithPayloadAnnotation.class);
+
+        // When scan is called
+        Map<String, ChannelItem> actualChannels = messageMappingChannelScanner.scan();
+
+        // Then the returned collection contains the channel, and the payload is of the parameter annotated with @Payload
+        Message message = Message.builder()
+                .name(SimpleFoo.class.getName())
+                .title(SimpleFoo.class.getSimpleName())
+                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                .build();
+
+        Operation operation = Operation.builder()
+                .bindings(ImmutableMap.of("stomp", new STOMPOperationBinding()))
+                .message(message)
+                .build();
+
+        ChannelItem expectedChannel = ChannelItem.builder().publish(operation).build();
+
+        assertThat(actualChannels)
+                .containsExactly(Maps.immutableEntry(TOPIC, expectedChannel));
+    }
+
+    private static class ClassWithoutMessageMappingAnnotation {
+
+        private void methodWithoutAnnotation() {
+        }
+
+    }
+
+    private static class ClassWithMessageMappingAnnotationHardCodedTopic {
+
+        @MessageMapping(value = {TOPIC})
+        private void methodWithAnnotation(SimpleFoo payload) {
+        }
+
+        private void methodWithoutAnnotation() {
+        }
+
+    }
+
+    private static class ClassWithMessageMappingAnnotationsEmbeddedValueTopic {
+
+        @MessageMapping(value = "${stomp.topics.test}")
+        private void methodWithAnnotation1(SimpleFoo payload) {
+        }
+
+    }
+
+    private static class ClassWithMessageMappingAnnotationAndSendTo {
+
+        private static final String GROUP_ID = "test-group-id";
+
+        @MessageMapping(value = {TOPIC})
+        @SendTo("/group")
+        private void methodWithAnnotation(SimpleFoo payload) {
+        }
+
+        private void methodWithoutAnnotation() {
+        }
+
+    }
+
+    private static class ClassWithMessageMappingAnnotationMultipleParamsWithoutPayloadAnnotation {
+
+        @MessageMapping(value = {TOPIC})
+        private void methodWithAnnotation(SimpleFoo payload, String anotherParam) {
+        }
+
+    }
+
+    private static class ClassWithMessageMappingAnnotationMultipleParamsWithPayloadAnnotation {
+
+        @MessageMapping(value = {TOPIC})
+        private void methodWithAnnotation(String anotherParam, @Payload SimpleFoo payload) {
+        }
+
+    }
+
+    @Data
+    @NoArgsConstructor
+    private static class SimpleFoo {
+        private String s;
+        private boolean b;
+    }
+
+}


### PR DESCRIPTION
- Updated Modules to include stomp-plugin within the plugins module.
- Added spring-messaging to the core's Gradle build.
- Laid out a Skeleton for Handling @MessageMapping
- Laid out a Testing Skeleton for Handling @MessageMapping

Notes:
 The STOMP-Plugin's `main` and `test` packages were copied from the kafka-plugin, and converted to the @MessageMapping's Skeleton.
 MessageMappingChannelScanner has my notes for the Implementation for the overall Protocol into the Plugin.