### PR TITLE
Add optional message description for manual consumer/producer definition

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ConsumerChannelScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ConsumerChannelScanner.java
@@ -85,6 +85,7 @@ public class ConsumerChannelScanner implements ChannelsScanner {
         return Message.builder()
                 .name(payloadType.getName())
                 .title(modelName)
+                .description(consumerData.getDescription())
                 .payload(PayloadReference.fromModelName(modelName))
                 .build();
     }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ProducerChannelScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ProducerChannelScanner.java
@@ -85,6 +85,7 @@ public class ProducerChannelScanner implements ChannelsScanner {
         return Message.builder()
                 .name(payloadType.getName())
                 .title(modelName)
+                .description(producerData.getDescription())
                 .payload(PayloadReference.fromModelName(modelName))
                 .build();
     }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ConsumerData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ConsumerData.java
@@ -25,6 +25,11 @@ public class ConsumerData {
     protected String channelName;
 
     /**
+     * Optional, additional information about the channel and/or its message
+     */
+    protected String description;
+
+    /**
      * The channel binding of the producer.
      * <br>
      * For example:

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ProducerData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ProducerData.java
@@ -22,6 +22,11 @@ public class ProducerData {
     protected String channelName;
 
     /**
+     * Optional, additional information about the channel and its message
+     */
+    protected String description;
+
+    /**
      * The channel binding of the producer.
      * <br>
      * For example:

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
@@ -26,6 +26,11 @@ public class Message {
      */
     private String title;
 
+    /**
+     * A human-friendly description for the message.
+     */
+    private String description;
+
     private PayloadReference payload;
 
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
@@ -9,6 +9,7 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ConsumerChanne
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ProducerChannelScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.ConsumerData;
 import io.github.stavshamir.springwolf.asyncapi.types.ProducerData;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
 import io.github.stavshamir.springwolf.schemas.DefaultSchemasService;
 import org.junit.Test;
@@ -47,12 +48,14 @@ public class DefaultAsyncApiServiceTest {
 
             ProducerData kafkaProducerData = ProducerData.builder()
                     .channelName("producer-topic")
+                    .description("producer-topic-description")
                     .payloadType(String.class)
                     .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                     .build();
 
             ConsumerData kafkaConsumerData = ConsumerData.builder()
                     .channelName("consumer-topic")
+                    .description("consumer-topic-description")
                     .payloadType(String.class)
                     .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding())).build();
 
@@ -99,6 +102,8 @@ public class DefaultAsyncApiServiceTest {
 
         final ChannelItem channel = actualChannels.get("producer-topic");
         assertThat(channel.getSubscribe()).isNotNull();
+        final Message message = (Message) channel.getSubscribe().getMessage();
+        assertThat(message.getDescription()).isEqualTo("producer-topic-description");
     }
 
     @Test
@@ -111,6 +116,8 @@ public class DefaultAsyncApiServiceTest {
 
         final ChannelItem channel = actualChannels.get("consumer-topic");
         assertThat(channel.getPublish()).isNotNull();
+        final Message message = (Message) channel.getPublish().getMessage();
+        assertThat(message.getDescription()).isEqualTo("consumer-topic-description");
     }
 
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ConsumerChannelScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ConsumerChannelScannerTest.java
@@ -40,8 +40,10 @@ public class ConsumerChannelScannerTest {
     public void allFieldsConsumerData() {
         // Given a consumer data with all fields set
         String channelName = "example-consumer-topic-foo1";
+        String description = channelName + "-description";
         ConsumerData consumerData = ConsumerData.builder()
                 .channelName(channelName)
+                .description(description)
                 .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
                 .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .payloadType(ExamplePayloadDto.class)
@@ -60,6 +62,7 @@ public class ConsumerChannelScannerTest {
                 .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .message(Message.builder()
                         .name(ExamplePayloadDto.class.getName())
+                        .description(description)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .build())
@@ -95,9 +98,12 @@ public class ConsumerChannelScannerTest {
     public void multipleConsumersForSameTopic() {
         // Given a multiple ConsumerData objects for the same topic
         String channelName = "example-consumer-topic";
+        String description1 = channelName + "-description1";
+        String description2 = channelName + "-description2";
 
         ConsumerData consumerData1 = ConsumerData.builder()
                 .channelName(channelName)
+                .description(description1)
                 .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
                 .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .payloadType(ExamplePayloadDto.class)
@@ -105,6 +111,7 @@ public class ConsumerChannelScannerTest {
 
         ConsumerData consumerData2 = ConsumerData.builder()
                 .channelName(channelName)
+                .description(description2)
                 .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
                 .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .payloadType(AnotherExamplePayloadDto.class)
@@ -123,11 +130,13 @@ public class ConsumerChannelScannerTest {
         Set<Message> messages = ImmutableSet.of(
                 Message.builder()
                         .name(ExamplePayloadDto.class.getName())
+                        .description(description1)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .build(),
                 Message.builder()
                         .name(AnotherExamplePayloadDto.class.getName())
+                        .description(description2)
                         .title(AnotherExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(AnotherExamplePayloadDto.class.getSimpleName()))
                         .build()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ProducerChannelScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ProducerChannelScannerTest.java
@@ -40,8 +40,10 @@ public class ProducerChannelScannerTest {
     public void allFieldsProducerData() {
         // Given a producer data with all fields set
         String channelName = "example-producer-topic-foo1";
+        String description = channelName + "-description";
         ProducerData producerData = ProducerData.builder()
                 .channelName(channelName)
+                .description(description)
                 .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
                 .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .payloadType(ExamplePayloadDto.class)
@@ -60,6 +62,7 @@ public class ProducerChannelScannerTest {
                 .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .message(Message.builder()
                         .name(ExamplePayloadDto.class.getName())
+                        .description(description)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .build())
@@ -95,9 +98,12 @@ public class ProducerChannelScannerTest {
     public void multipleProducersForSameTopic() {
         // Given a multiple ProducerData objects for the same topic
         String channelName = "example-producer-topic";
+        String description1 = channelName + "-description1";
+        String description2 = channelName + "-description2";
 
         ProducerData producerData1 = ProducerData.builder()
                 .channelName(channelName)
+                .description(description1)
                 .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
                 .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .payloadType(ExamplePayloadDto.class)
@@ -105,6 +111,7 @@ public class ProducerChannelScannerTest {
 
         ProducerData producerData2 = ProducerData.builder()
                 .channelName(channelName)
+                .description(description2)
                 .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
                 .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .payloadType(AnotherExamplePayloadDto.class)
@@ -123,11 +130,13 @@ public class ProducerChannelScannerTest {
         Set<Message> messages = ImmutableSet.of(
                 Message.builder()
                         .name(ExamplePayloadDto.class.getName())
+                        .description(description1)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .build(),
                 Message.builder()
                         .name(AnotherExamplePayloadDto.class.getName())
+                        .description(description2)
                         .title(AnotherExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(AnotherExamplePayloadDto.class.getSimpleName()))
                         .build()

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
@@ -39,6 +39,7 @@ public class AsyncApiConfiguration {
 
         AmqpProducerData exampleProducer = AmqpProducerData.amqpProducerDataBuilder()
                 .queueName("example-producer-channel")
+                .description("example-producer-channel-description")
                 .exchangeName("example-topic-exchange")
                 .routingKey("example-topic-routing-key")
                 .payloadType(AnotherPayloadDto.class)
@@ -46,6 +47,7 @@ public class AsyncApiConfiguration {
 
         AmqpConsumerData exampleManuallyDefinedConsumer = AmqpConsumerData.amqpConsumerDataBuilder()
                 .queueName("example-manual-consumer-channel")
+                .description("example-manual-consumer-channel-description")
                 .exchangeName("example-consumer-topic-exchange")
                 .routingKey("example-consumer-topic-routing-key")
                 .payloadType(AnotherPayloadDto.class)

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -129,6 +129,7 @@
           "message": {
             "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
             "title": "AnotherPayloadDto",
+            "description": "example-manual-consumer-channel-description",
             "payload": {
               "$ref": "#/components/schemas/AnotherPayloadDto"
             }
@@ -204,6 +205,7 @@
           "message": {
             "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
             "title": "AnotherPayloadDto",
+            "description": "example-producer-channel-description",
             "payload": {
               "$ref": "#/components/schemas/AnotherPayloadDto"
             }

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
@@ -39,11 +39,13 @@ public class AsyncApiConfiguration {
 
         KafkaProducerData anotherProducerData = KafkaProducerData.kafkaProducerDataBuilder()
                 .topicName(PRODUCER_TOPIC)
+                .description("Custom, optional description for this produced to topic")
                 .payloadType(AnotherPayloadDto.class)
                 .build();
 
         KafkaConsumerData manuallyConfiguredConsumer = KafkaConsumerData.kafkaConsumerDataBuilder()
                 .topicName(CONSUMER_TOPIC)
+                .description("Custom, optional description for this consumed topic")
                 .payloadType(ExamplePayloadDto.class)
                 .build();
 

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -70,6 +70,7 @@
               {
                 "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
                 "title": "AnotherPayloadDto",
+                "description": "Custom, optional description for this produced to topic",
                 "payload": {
                   "$ref": "#/components/schemas/AnotherPayloadDto"
                 }
@@ -89,6 +90,7 @@
           "message": {
             "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
             "title": "ExamplePayloadDto",
+            "description": "Custom, optional description for this consumed topic",
             "payload": {
               "$ref": "#/components/schemas/ExamplePayloadDto"
             }

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AmqpConsumerData.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AmqpConsumerData.java
@@ -10,8 +10,9 @@ import java.util.Collections;
 public class AmqpConsumerData extends ConsumerData {
 
     @Builder(builderMethodName = "amqpConsumerDataBuilder")
-    public AmqpConsumerData(String queueName, String exchangeName, String routingKey, Class<?> payloadType) {
+    public AmqpConsumerData(String queueName, String exchangeName, String routingKey, Class<?> payloadType, String description) {
         this.channelName = queueName;
+        this.description = description;
 
         AMQPChannelBinding.ExchangeProperties exchangeProperties = new AMQPChannelBinding.ExchangeProperties();
         exchangeProperties.setName(exchangeName);

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AmqpProducerData.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AmqpProducerData.java
@@ -10,8 +10,9 @@ import java.util.Collections;
 public class AmqpProducerData extends ProducerData {
 
     @Builder(builderMethodName = "amqpProducerDataBuilder")
-    public AmqpProducerData(String queueName, String exchangeName, String routingKey, Class<?> payloadType) {
+    public AmqpProducerData(String queueName, String exchangeName, String routingKey, Class<?> payloadType, String description) {
         this.channelName = queueName;
+        this.description = description;
 
         AMQPChannelBinding.ExchangeProperties exchangeProperties = new AMQPChannelBinding.ExchangeProperties();
         exchangeProperties.setName(exchangeName);

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/KafkaConsumerData.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/KafkaConsumerData.java
@@ -7,8 +7,9 @@ import lombok.Builder;
 
 public class KafkaConsumerData extends ConsumerData {
     @Builder(builderMethodName = "kafkaConsumerDataBuilder")
-    public KafkaConsumerData(String topicName, Class<?> payloadType) {
+    public KafkaConsumerData(String topicName, Class<?> payloadType, String description) {
         this.channelName = topicName;
+        this.description = description;
         this.channelBinding = ImmutableMap.of("kafka", new KafkaChannelBinding());
         this.payloadType = payloadType;
         this.operationBinding = ImmutableMap.of("kafka", new KafkaOperationBinding());

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/KafkaProducerData.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/KafkaProducerData.java
@@ -8,8 +8,9 @@ import lombok.Builder;
 public class KafkaProducerData extends ProducerData {
 
     @Builder(builderMethodName = "kafkaProducerDataBuilder")
-    public KafkaProducerData(String topicName, Class<?> payloadType) {
+    public KafkaProducerData(String topicName, Class<?> payloadType, String description) {
         this.channelName = topicName;
+        this.description = description;
         this.channelBinding = ImmutableMap.of("kafka", new KafkaChannelBinding());
         this.payloadType = payloadType;
         this.operationBinding = ImmutableMap.of("kafka", new KafkaOperationBinding());


### PR DESCRIPTION
Allow to set a optional description on the async api message object
spec: https://www.asyncapi.com/docs/reference/specification/v2.0.0#messageObject

Demo code for kafka and amqp examples was added as well

Related change in springwolf-ui will follow