### PR TITLE
feat: Use swagger Schema annotation in springwolf-kafka-example

### DIFF
--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.google.guava:guava:27.0.1-jre'
     implementation 'org.javamoney:moneta:1.4.2'
+    implementation 'io.swagger.core.v3:swagger-core:2.2.0'
 
     testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     testImplementation 'org.jetbrains.kotlin:kotlin-reflect'

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/dtos/AnotherPayloadDto.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/dtos/AnotherPayloadDto.java
@@ -1,8 +1,14 @@
 package io.github.stavshamir.springwolf.example.dtos;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Another payload model")
 public class AnotherPayloadDto {
 
+    @Schema(description = "Foo field", example = "bar")
     private String foo;
+
+    @Schema(description = "Example field", required = true)
     private ExamplePayloadDto example;
 
     public String getFoo() {

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/dtos/ExamplePayloadDto.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/dtos/ExamplePayloadDto.java
@@ -1,9 +1,16 @@
 package io.github.stavshamir.springwolf.example.dtos;
 
-public class ExamplePayloadDto {
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "Example payload model")
+public class ExamplePayloadDto {
+    @Schema(description = "Some string field", example = "some string value", required = true)
     private String someString;
+
+    @Schema(description = "Some long field", example = "5")
     private long someLong;
+
+    @Schema(description = "Some enum field", example = "FOO2", required = true)
     private ExampleEnum someEnum;
 
     public String getSomeString() {

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -159,20 +159,30 @@
           "exampleSetFlag": true
         },
         "ExamplePayloadDto": {
+          "required": [
+            "someEnum",
+            "someString"
+          ],
           "type": "object",
           "properties": {
             "someString": {
               "type": "string",
-              "exampleSetFlag": false
+              "description": "Some string field",
+              "example": "some string value",
+              "exampleSetFlag": true
             },
             "someLong": {
               "type": "integer",
+              "description": "Some long field",
               "format": "int64",
-              "exampleSetFlag": false
+              "example": 5,
+              "exampleSetFlag": true
             },
             "someEnum": {
               "type": "string",
-              "exampleSetFlag": false,
+              "description": "Some enum field",
+              "example": "FOO2",
+              "exampleSetFlag": true,
               "enum": [
                 "FOO1",
                 "FOO2",
@@ -180,31 +190,38 @@
               ]
             }
           },
+          "description": "Example payload model",
           "example": {
-            "someString": "string",
-            "someLong": 0,
-            "someEnum": "FOO1"
+            "someString": "some string value",
+            "someLong": 5,
+            "someEnum": "FOO2"
           },
           "exampleSetFlag": true
         },
         "AnotherPayloadDto": {
+          "required": [
+            "example"
+          ],
           "type": "object",
           "properties": {
             "foo": {
               "type": "string",
-              "exampleSetFlag": false
+              "description": "Foo field",
+              "example": "bar",
+              "exampleSetFlag": true
             },
             "example": {
               "$ref": "#/components/schemas/ExamplePayloadDto",
               "exampleSetFlag": false
             }
           },
+          "description": "Another payload model",
           "example": {
-            "foo": "string",
+            "foo": "bar",
             "example": {
-              "someString": "string",
-              "someLong": 0,
-              "someEnum": "FOO1"
+              "someString": "some string value",
+              "someLong": 5,
+              "someEnum": "FOO2"
             }
           },
           "exampleSetFlag": true


### PR DESCRIPTION
This adds the same schema annotations + dependency as in springwolf-amqp-example

Relates to: https://github.com/springwolf/springwolf-core/issues/35
Relates to: https://github.com/springwolf/springwolf-core/pull/66