### PR TITLE
feat: Format asyncapi.json with 2 spaces

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
@@ -4,21 +4,23 @@ import com.asyncapi.v2.binding.kafka.KafkaChannelBinding;
 import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.PrettyPrinter;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.serializers.KafkaChannelBindingSerializer;
 import io.github.stavshamir.springwolf.asyncapi.serializers.KafkaOperationBindingSerializer;
 import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
-import java.util.Map;
 
 @Service
 public class DefaultAsyncApiSerializerService implements AsyncApiSerializerService {
 
     private final ObjectMapper jsonMapper = new ObjectMapper();
+    private PrettyPrinter printer = new DefaultPrettyPrinter().withObjectIndenter(new DefaultIndenter("  ", DefaultIndenter.SYS_LF));
 
     @PostConstruct
     void postConstruct() {
@@ -35,7 +37,21 @@ public class DefaultAsyncApiSerializerService implements AsyncApiSerializerServi
 
     @Override
     public String toJsonString(AsyncAPI asyncAPI) throws JsonProcessingException {
-        return jsonMapper.writeValueAsString(asyncAPI);
+        return jsonMapper.writer(printer).writeValueAsString(asyncAPI);
+    }
+
+    /**
+     * Allows to customize the used objectMapper
+     */
+    public ObjectMapper getObjectMapper() {
+        return jsonMapper;
+    }
+
+    /**
+     * Allows to override the used PrettyPrinter
+     */
+    public void setPrettyPrinter(PrettyPrinter prettyPrinter) {
+        printer = prettyPrinter;
     }
 
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsService.java
@@ -3,18 +3,15 @@ package io.github.stavshamir.springwolf.asyncapi;
 import com.asyncapi.v2.model.channel.ChannelItem;
 import com.asyncapi.v2.model.channel.operation.Operation;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
-import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-
-import static java.util.stream.Collectors.toMap;
 
 @Slf4j
 @Service
@@ -22,7 +19,7 @@ import static java.util.stream.Collectors.toMap;
 public class DefaultChannelsService implements ChannelsService {
 
     private final Set<? extends ChannelsScanner> channelsScanners;
-    private final Map<String, ChannelItem> channels = new HashMap<>();
+    private final Map<String, ChannelItem> channels = new TreeMap<>();
 
     @PostConstruct
     void findChannels() {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeaders.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeaders.java
@@ -2,9 +2,9 @@ package io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message
 
 import io.swagger.v3.oas.models.media.Schema;
 
-import java.util.HashMap;
+import java.util.TreeMap;
 
-public class AsyncHeaders extends HashMap<String, Schema> {
+public class AsyncHeaders extends TreeMap<String, Schema> {
     /**
      * Per default, if no headers are explicitly defined, NOT_DOCUMENTED is used.
      * There can be headers, but don't have to be.

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasService.java
@@ -25,7 +25,7 @@ public class DefaultSchemasService implements SchemasService {
     private final ModelConverters converter = ModelConverters.getInstance();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private final Map<String, Schema> definitions = new HashMap<>();
+    private final Map<String, Schema> definitions = new TreeMap<>();
 
     public DefaultSchemasService(Optional<List<ModelConverter>> externalModelConverters) {
         externalModelConverters.ifPresent(converters -> converters.forEach(converter::addConverter));

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerServiceTest.java
@@ -94,9 +94,10 @@ public class DefaultAsyncApiSerializerServiceTest {
                 .build();
 
         String actual = serializer.toJsonString(asyncapi);
+        System.out.println("Got: " + actual);
         InputStream s = this.getClass().getResourceAsStream("/asyncapi/asyncapi.json");
         String expected = IOUtils.toString(s, StandardCharsets.UTF_8);
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
     }
 
     @Data

--- a/springwolf-core/src/test/resources/asyncapi/asyncapi.json
+++ b/springwolf-core/src/test/resources/asyncapi/asyncapi.json
@@ -1,66 +1,64 @@
 {
-    "asyncapi": "2.0.0",
-    "info": {
-      "title": "AsyncAPI Sample App",
-      "description": "This is a sample server.",
-      "termsOfService": "http://asyncapi.org/terms/",
-      "contact": {
-        "name": "API Support",
-        "url": "http://www.asyncapi.org/support",
-        "email": "support@asyncapi.org"
-      },
-      "license": {
-        "name": "Apache 2.0",
-        "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-      },
-      "version": "1.0.1"
+  "asyncapi" : "2.0.0",
+  "info" : {
+    "title" : "AsyncAPI Sample App",
+    "version" : "1.0.1",
+    "description" : "This is a sample server.",
+    "termsOfService" : "http://asyncapi.org/terms/",
+    "contact" : {
+      "name" : "API Support",
+      "url" : "http://www.asyncapi.org/support",
+      "email" : "support@asyncapi.org"
     },
-    "defaultContentType": "application/json",
-    "servers": {
-      "production": {
-        "url": "development.gigantic-server.com",
-        "description": "Development server",
-        "protocol": "kafka",
-        "protocolVersion": "1.0.0"
-      }
-    },
-    "channels": {
-      "new-user": {
-        "description": "This channel is used to exchange messages about users signing up",
-        "subscribe": {
-          "message": {
-            "name": "io.github.stavshamir.springwolf.ExamplePayload",
-            "title": "Example Payload",
-            "payload": {
-              "$ref": "#/components/schemas/ExamplePayload"
+    "license" : {
+      "name" : "Apache 2.0",
+      "url" : "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "defaultContentType" : "application/json",
+  "servers" : {
+    "production" : {
+      "url" : "development.gigantic-server.com",
+      "protocol" : "kafka",
+      "protocolVersion" : "1.0.0",
+      "description" : "Development server"
+    }
+  },
+  "channels" : {
+    "new-user" : {
+      "description" : "This channel is used to exchange messages about users signing up",
+      "subscribe" : {
+        "operationId" : "new-user_listenerMethod_subscribe",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "kafka" : {
+            "groupId" : {
+              "type" : "string",
+              "enum" : [ "myGroupId" ]
             }
-          },
-          "description": "Auto-generated description",
-          "operationId": "new-user_listenerMethod_subscribe",
-          "bindings": {
-            "kafka": {
-              "groupId": {
-                "type": "string",
-                "enum": [
-                  "myGroupId"
-                ]
-              }
-            }
+          }
+        },
+        "message" : {
+          "name" : "io.github.stavshamir.springwolf.ExamplePayload",
+          "title" : "Example Payload",
+          "payload" : {
+            "$ref" : "#/components/schemas/ExamplePayload"
           }
         }
       }
-    },
-    "components": {
-      "schemas": {
-        "ExamplePayload": {
-          "type": "object",
-          "properties": {
-            "s": {
-              "type": "string"
-            }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "ExamplePayload" : {
+        "type" : "object",
+        "properties" : {
+          "s" : {
+            "type" : "string"
           }
         }
       }
-    },
-    "tags": []
+    }
+  },
+  "tags" : [ ]
 }

--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTests.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTests.java
@@ -35,6 +35,6 @@ public class ApiIntegrationTests {
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expected = IOUtils.toString(s, StandardCharsets.UTF_8);
 
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
     }
 }

--- a/springwolf-examples/springwolf-amqp-example/src/test/kotlin/io/github/stavshamir/springwolf/example/ApiIntegrationWithDockerTests.kt
+++ b/springwolf-examples/springwolf-amqp-example/src/test/kotlin/io/github/stavshamir/springwolf/example/ApiIntegrationWithDockerTests.kt
@@ -47,7 +47,7 @@ class ApiIntegrationWithDockerTests {
 
         print(actual)
 
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE)
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER)
     }
 
 }

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -1,333 +1,312 @@
 {
-    "asyncapi": "2.0.0",
-    "info": {
-      "title": "Springwolf example project - AMQP",
-      "contact": {
-        "name": "springwolf",
-        "url": "https://github.com/springwolf/springwolf-core",
-        "email": "example@example.com"
-      },
-      "description": "Springwolf example project to demonstrate springwolfs abilities",
-      "license": {
-        "name": "Apache License 2.0"
-      },
-      "version": "1.0.0"
+  "asyncapi" : "2.0.0",
+  "info" : {
+    "title" : "Springwolf example project - AMQP",
+    "version" : "1.0.0",
+    "description" : "Springwolf example project to demonstrate springwolfs abilities",
+    "contact" : {
+      "name" : "springwolf",
+      "url" : "https://github.com/springwolf/springwolf-core",
+      "email" : "example@example.com"
     },
-    "servers": {
-      "amqp": {
-        "url": "amqp:5672",
-        "protocol": "amqp"
-      }
-    },
-    "channels": {
-      "example-bindings-queue": {
-        "bindings": {
-          "amqp": {
-            "is": "routingKey",
-            "exchange": {
-              "name": "name",
-              "autoDelete": false
-            }
+    "license" : {
+      "name" : "Apache License 2.0"
+    }
+  },
+  "servers" : {
+    "amqp" : {
+      "url" : "amqp:5672",
+      "protocol" : "amqp"
+    }
+  },
+  "channels" : {
+    "another-queue" : {
+      "publish" : {
+        "operationId" : "another-queue_publish_receiveAnotherPayload",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "amqp" : {
+            "expiration" : 0,
+            "cc" : [ "another-queue" ],
+            "priority" : 0,
+            "deliveryMode" : 0,
+            "mandatory" : false,
+            "timestamp" : false,
+            "ack" : false
           }
         },
-        "publish": {
-          "bindings": {
-            "amqp": {
-              "cc": [
-                ""
-              ],
-              "expiration": 0,
-              "priority": 0,
-              "deliveryMode": 0,
-              "mandatory": false,
-              "timestamp": false,
-              "ack": false
-            }
+        "message" : {
+          "name" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title" : "AnotherPayloadDto",
+          "payload" : {
+            "$ref" : "#/components/schemas/AnotherPayloadDto"
           },
-          "description": "Auto-generated description",
-          "operationId": "example-bindings-queue_publish_bindingsExample",
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/HeadersNotDocumented"
-            }
+          "headers" : {
+            "$ref" : "#/components/schemas/HeadersNotDocumented"
           }
         }
       },
-      "example-topic-queue": {
-        "bindings": {
-          "amqp": {
-            "is": "routingKey",
-            "exchange": {
-              "name": "example-topic-exchange",
-              "autoDelete": false
-            }
-          }
-        },
-        "publish": {
-          "bindings": {
-            "amqp": {
-              "cc": [
-                "example-topic-routing-key"
-              ],
-              "expiration": 0,
-              "priority": 0,
-              "deliveryMode": 0,
-              "mandatory": false,
-              "timestamp": false,
-              "ack": false
-            }
-          },
-          "description": "Auto-generated description",
-          "operationId": "example-topic-queue_publish_bindingsBeanExample",
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/HeadersNotDocumented"
-            }
-          }
-        }
-      },
-      "another-queue": {
-        "bindings": {
-          "amqp": {
-            "is": "routingKey",
-            "exchange": {
-              "name": "",
-              "autoDelete": false
-            }
-          }
-        },
-        "publish": {
-          "bindings": {
-            "amqp": {
-              "cc": [
-                "another-queue"
-              ],
-              "expiration": 0,
-              "priority": 0,
-              "deliveryMode": 0,
-              "mandatory": false,
-              "timestamp": false,
-              "ack": false
-            }
-          },
-          "description": "Auto-generated description",
-          "operationId": "another-queue_publish_receiveAnotherPayload",
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/HeadersNotDocumented"
-            }
-          }
-        }
-      },
-      "example-manual-consumer-channel": {
-        "publish": {
-          "bindings": {
-            "amqp": {
-              "expiration": 0,
-              "cc": [
-                "example-consumer-topic-routing-key"
-              ],
-              "priority": 0,
-              "deliveryMode": 0,
-              "mandatory": false,
-              "timestamp": false,
-              "ack": false
-            }
-          },
-          "description": "Auto-generated description",
-          "operationId": "example-manual-consumer-channel_publish",
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "description": "example-manual-consumer-channel-description",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/HeadersNotDocumented"
-            }
-          }
-        },
-        "bindings": {
-          "amqp": {
-            "is": "routingKey",
-            "exchange": {
-              "name": "example-consumer-topic-exchange",
-              "autoDelete": false
-            }
-          }
-        }
-      },
-      "example-queue": {
-        "bindings": {
-          "amqp": {
-            "is": "routingKey",
-            "exchange": {
-              "name": "",
-              "autoDelete": false
-            }
-          }
-        },
-        "publish": {
-          "bindings": {
-            "amqp": {
-              "cc": [
-                "example-queue"
-              ],
-              "expiration": 0,
-              "priority": 0,
-              "deliveryMode": 0,
-              "mandatory": false,
-              "timestamp": false,
-              "ack": false
-            }
-          },
-          "description": "Auto-generated description",
-          "operationId": "example-queue_publish_receiveExamplePayload",
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-            "title": "ExamplePayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/ExamplePayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/HeadersNotDocumented"
-            }
-          }
-        }
-      },
-      "example-producer-channel": {
-        "bindings": {
-          "amqp": {
-            "is": "routingKey",
-            "exchange": {
-              "name": "example-topic-exchange",
-              "autoDelete": false
-            }
-          }
-        },
-        "subscribe": {
-          "bindings": {
-            "amqp": {
-              "cc": [
-                "example-topic-routing-key"
-              ],
-              "expiration": 0,
-              "priority": 0,
-              "deliveryMode": 0,
-              "mandatory": false,
-              "timestamp": false,
-              "ack": false
-            }
-          },
-          "description": "Auto-generated description",
-          "operationId": "example-producer-channel_subscribe",
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "description": "example-producer-channel-description",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/HeadersNotDocumented"
-            }
+      "bindings" : {
+        "amqp" : {
+          "is" : "routingKey",
+          "exchange" : {
+            "name" : "",
+            "autoDelete" : false
           }
         }
       }
     },
-    "components": {
-      "schemas": {
-        "HeadersNotDocumented": {
-          "type": "object",
-          "properties": {},
-          "example": {},
-          "exampleSetFlag": true
+    "example-bindings-queue" : {
+      "publish" : {
+        "operationId" : "example-bindings-queue_publish_bindingsExample",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "amqp" : {
+            "expiration" : 0,
+            "cc" : [ "" ],
+            "priority" : 0,
+            "deliveryMode" : 0,
+            "mandatory" : false,
+            "timestamp" : false,
+            "ack" : false
+          }
         },
-        "AnotherPayloadDto": {
-          "required": [
-            "example"
-          ],
-          "type": "object",
-          "properties": {
-            "foo": {
-              "type": "string",
-              "description": "Foo field",
-              "example": "bar",
-              "exampleSetFlag": true
-            },
-            "example": {
-              "$ref": "#/components/schemas/ExamplePayloadDto",
-              "exampleSetFlag": false
-            }
+        "message" : {
+          "name" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title" : "AnotherPayloadDto",
+          "payload" : {
+            "$ref" : "#/components/schemas/AnotherPayloadDto"
           },
-          "description": "Another payload model",
-          "example": {
-            "foo": "bar",
-            "example": {
-              "someString": "some string value",
-              "someLong": 5,
-              "someEnum": "FOO2"
-            }
-          },
-          "exampleSetFlag": true
-        },
-        "ExamplePayloadDto": {
-          "required": [
-            "someEnum",
-            "someString"
-          ],
-          "type": "object",
-          "properties": {
-            "someString": {
-              "type": "string",
-              "description": "Some string field",
-              "example": "some string value",
-              "exampleSetFlag": true
-            },
-            "someLong": {
-              "type": "integer",
-              "description": "Some long field",
-              "format": "int64",
-              "example": 5,
-              "exampleSetFlag": true
-            },
-            "someEnum": {
-              "type": "string",
-              "description": "Some enum field",
-              "example": "FOO2",
-              "exampleSetFlag": true,
-              "enum": [
-                "FOO1",
-                "FOO2",
-                "FOO3"
-              ]
-            }
-          },
-          "description": "Example payload model",
-          "example": {
-            "someString": "some string value",
-            "someLong": 5,
-            "someEnum": "FOO2"
-          },
-          "exampleSetFlag": true
+          "headers" : {
+            "$ref" : "#/components/schemas/HeadersNotDocumented"
+          }
+        }
+      },
+      "bindings" : {
+        "amqp" : {
+          "is" : "routingKey",
+          "exchange" : {
+            "name" : "name",
+            "autoDelete" : false
+          }
         }
       }
     },
-    "tags": []
+    "example-manual-consumer-channel" : {
+      "publish" : {
+        "operationId" : "example-manual-consumer-channel_publish",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "amqp" : {
+            "expiration" : 0,
+            "cc" : [ "example-consumer-topic-routing-key" ],
+            "priority" : 0,
+            "deliveryMode" : 0,
+            "mandatory" : false,
+            "timestamp" : false,
+            "ack" : false
+          }
+        },
+        "message" : {
+          "name" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title" : "AnotherPayloadDto",
+          "description" : "example-manual-consumer-channel-description",
+          "payload" : {
+            "$ref" : "#/components/schemas/AnotherPayloadDto"
+          },
+          "headers" : {
+            "$ref" : "#/components/schemas/HeadersNotDocumented"
+          }
+        }
+      },
+      "bindings" : {
+        "amqp" : {
+          "is" : "routingKey",
+          "exchange" : {
+            "name" : "example-consumer-topic-exchange",
+            "autoDelete" : false
+          }
+        }
+      }
+    },
+    "example-producer-channel" : {
+      "subscribe" : {
+        "operationId" : "example-producer-channel_subscribe",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "amqp" : {
+            "expiration" : 0,
+            "cc" : [ "example-topic-routing-key" ],
+            "priority" : 0,
+            "deliveryMode" : 0,
+            "mandatory" : false,
+            "timestamp" : false,
+            "ack" : false
+          }
+        },
+        "message" : {
+          "name" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title" : "AnotherPayloadDto",
+          "description" : "example-producer-channel-description",
+          "payload" : {
+            "$ref" : "#/components/schemas/AnotherPayloadDto"
+          },
+          "headers" : {
+            "$ref" : "#/components/schemas/HeadersNotDocumented"
+          }
+        }
+      },
+      "bindings" : {
+        "amqp" : {
+          "is" : "routingKey",
+          "exchange" : {
+            "name" : "example-topic-exchange",
+            "autoDelete" : false
+          }
+        }
+      }
+    },
+    "example-queue" : {
+      "publish" : {
+        "operationId" : "example-queue_publish_receiveExamplePayload",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "amqp" : {
+            "expiration" : 0,
+            "cc" : [ "example-queue" ],
+            "priority" : 0,
+            "deliveryMode" : 0,
+            "mandatory" : false,
+            "timestamp" : false,
+            "ack" : false
+          }
+        },
+        "message" : {
+          "name" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+          "title" : "ExamplePayloadDto",
+          "payload" : {
+            "$ref" : "#/components/schemas/ExamplePayloadDto"
+          },
+          "headers" : {
+            "$ref" : "#/components/schemas/HeadersNotDocumented"
+          }
+        }
+      },
+      "bindings" : {
+        "amqp" : {
+          "is" : "routingKey",
+          "exchange" : {
+            "name" : "",
+            "autoDelete" : false
+          }
+        }
+      }
+    },
+    "example-topic-queue" : {
+      "publish" : {
+        "operationId" : "example-topic-queue_publish_bindingsBeanExample",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "amqp" : {
+            "expiration" : 0,
+            "cc" : [ "example-topic-routing-key" ],
+            "priority" : 0,
+            "deliveryMode" : 0,
+            "mandatory" : false,
+            "timestamp" : false,
+            "ack" : false
+          }
+        },
+        "message" : {
+          "name" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title" : "AnotherPayloadDto",
+          "payload" : {
+            "$ref" : "#/components/schemas/AnotherPayloadDto"
+          },
+          "headers" : {
+            "$ref" : "#/components/schemas/HeadersNotDocumented"
+          }
+        }
+      },
+      "bindings" : {
+        "amqp" : {
+          "is" : "routingKey",
+          "exchange" : {
+            "name" : "example-topic-exchange",
+            "autoDelete" : false
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "AnotherPayloadDto" : {
+        "required" : [ "example" ],
+        "type" : "object",
+        "properties" : {
+          "foo" : {
+            "type" : "string",
+            "description" : "Foo field",
+            "example" : "bar",
+            "exampleSetFlag" : true
+          },
+          "example" : {
+            "$ref" : "#/components/schemas/ExamplePayloadDto",
+            "exampleSetFlag" : false
+          }
+        },
+        "description" : "Another payload model",
+        "example" : {
+          "foo" : "bar",
+          "example" : {
+            "someString" : "some string value",
+            "someLong" : 5,
+            "someEnum" : "FOO2"
+          }
+        },
+        "exampleSetFlag" : true
+      },
+      "ExamplePayloadDto" : {
+        "required" : [ "someEnum", "someString" ],
+        "type" : "object",
+        "properties" : {
+          "someString" : {
+            "type" : "string",
+            "description" : "Some string field",
+            "example" : "some string value",
+            "exampleSetFlag" : true
+          },
+          "someLong" : {
+            "type" : "integer",
+            "description" : "Some long field",
+            "format" : "int64",
+            "example" : 5,
+            "exampleSetFlag" : true
+          },
+          "someEnum" : {
+            "type" : "string",
+            "description" : "Some enum field",
+            "example" : "FOO2",
+            "exampleSetFlag" : true,
+            "enum" : [ "FOO1", "FOO2", "FOO3" ]
+          }
+        },
+        "description" : "Example payload model",
+        "example" : {
+          "someString" : "some string value",
+          "someLong" : 5,
+          "someEnum" : "FOO2"
+        },
+        "exampleSetFlag" : true
+      },
+      "HeadersNotDocumented" : {
+        "type" : "object",
+        "properties" : { },
+        "example" : { },
+        "exampleSetFlag" : true
+      }
+    }
+  },
+  "tags" : [ ]
 }

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTests.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTests.java
@@ -42,6 +42,6 @@ public class ApiIntegrationTests {
         // When running with EmbeddedKafka, localhost is used as hostname
         String expected = expectedWithoutServersKafkaUrlPatch.replace("\"kafka:29092\"", "\"localhost:29092\"");
 
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
     }
 }

--- a/springwolf-examples/springwolf-kafka-example/src/test/kotlin/io/github/stavshamir/springwolf/example/ApiIntegrationWithDockerTests.kt
+++ b/springwolf-examples/springwolf-kafka-example/src/test/kotlin/io/github/stavshamir/springwolf/example/ApiIntegrationWithDockerTests.kt
@@ -45,7 +45,7 @@ class ApiIntegrationWithDockerTests {
         val s: InputStream = this.javaClass.getResourceAsStream("/asyncapi.json")
         val expected: String = IOUtils.toString(s, StandardCharsets.UTF_8)
 
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE)
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER)
 
     }
 

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -1,377 +1,342 @@
 {
-    "asyncapi": "2.0.0",
-    "info": {
-      "title": "Springwolf example project - Kafka",
-      "contact": {
-        "name": "springwolf",
-        "url": "https://github.com/springwolf/springwolf-core",
-        "email": "example@example.com"
-      },
-      "description": "Springwolf example project to demonstrate springwolfs abilities",
-      "license": {
-        "name": "Apache License 2.0"
-      },
-      "version": "1.0.0"
+  "asyncapi" : "2.0.0",
+  "info" : {
+    "title" : "Springwolf example project - Kafka",
+    "version" : "1.0.0",
+    "description" : "Springwolf example project to demonstrate springwolfs abilities",
+    "contact" : {
+      "name" : "springwolf",
+      "url" : "https://github.com/springwolf/springwolf-core",
+      "email" : "example@example.com"
     },
-    "servers": {
-      "kafka": {
-        "url": "kafka:29092",
-        "protocol": "kafka"
+    "license" : {
+      "name" : "Apache License 2.0"
+    }
+  },
+  "servers" : {
+    "kafka" : {
+      "url" : "kafka:29092",
+      "protocol" : "kafka"
+    }
+  },
+  "channels" : {
+    "another-topic" : {
+      "publish" : {
+        "operationId" : "another-topic_publish_receiveAnotherPayload",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "kafka" : {
+            "groupId" : {
+              "type" : "string",
+              "enum" : [ "example-group-id" ]
+            }
+          }
+        },
+        "message" : {
+          "name" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+          "title" : "AnotherPayloadDto",
+          "payload" : {
+            "$ref" : "#/components/schemas/AnotherPayloadDto"
+          },
+          "headers" : {
+            "$ref" : "#/components/schemas/HeadersNotDocumented"
+          }
+        }
+      },
+      "bindings" : {
+        "kafka" : { }
       }
     },
-    "channels": {
-      "another-topic": {
-        "publish": {
-          "bindings": {
-            "kafka": {
-              "groupId": {
-                "type": "string",
-                "enum": [
-                  "example-group-id"
-                ]
-              }
-            }
-          },
-          "description": "Auto-generated description",
-          "operationId": "another-topic_publish_receiveAnotherPayload",
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "title": "AnotherPayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/AnotherPayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/HeadersNotDocumented"
-            }
-          }
+    "example-consumer-topic" : {
+      "publish" : {
+        "operationId" : "example-consumer-topic_publish",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "kafka" : { }
         },
-        "bindings": {
-          "kafka": {}
+        "message" : {
+          "name" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+          "title" : "ExamplePayloadDto",
+          "description" : "Custom, optional description for this consumed topic",
+          "payload" : {
+            "$ref" : "#/components/schemas/ExamplePayloadDto"
+          },
+          "headers" : {
+            "$ref" : "#/components/schemas/HeadersNotDocumented"
+          }
         }
       },
-      "example-topic": {
-        "publish": {
-          "bindings": {
-            "kafka": {}
-          },
-          "description": "Auto-generated description",
-          "operationId": "example-topic_publish_receiveExamplePayload",
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-            "title": "ExamplePayloadDto",
-            "payload": {
-              "$ref": "#/components/schemas/ExamplePayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/HeadersNotDocumented"
-            }
-          }
-        },
-        "bindings": {
-          "kafka": {}
-        }
-      },
-      "example-producer-topic": {
-        "subscribe": {
-          "bindings": {
-            "kafka": {}
-          },
-          "description": "Auto-generated description",
-          "operationId": "example-producer-topic_subscribe",
-          "message": {
-            "oneOf": [
-              {
-                "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-                "title": "ExamplePayloadDto",
-                "payload": {
-                  "$ref": "#/components/schemas/ExamplePayloadDto"
-                },
-                "headers": {
-                  "$ref": "#/components/schemas/SpringDefaultHeaders"
-                }
-              },
-              {
-                "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-                "title": "AnotherPayloadDto",
-                "description": "Custom, optional description for this produced to topic",
-                "payload": {
-                  "$ref": "#/components/schemas/AnotherPayloadDto"
-                },
-                "headers": {
-                  "$ref": "#/components/schemas/CloudEventHeadersForAnotherPayloadDtoEndpoint"
-                }
-              }
-            ]
-          }
-        },
-        "bindings": {
-          "kafka": {}
-        }
-      },
-      "example-consumer-topic": {
-        "publish": {
-          "bindings": {
-            "kafka": {}
-          },
-          "description": "Auto-generated description",
-          "operationId": "example-consumer-topic_publish",
-          "message": {
-            "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-            "title": "ExamplePayloadDto",
-            "description": "Custom, optional description for this consumed topic",
-            "payload": {
-              "$ref": "#/components/schemas/ExamplePayloadDto"
-            },
-            "headers": {
-              "$ref": "#/components/schemas/HeadersNotDocumented"
-            }
-          }
-        },
-        "bindings": {
-          "kafka": {}
-        }
-      },
-      "multi-payload-topic": {
-        "publish": {
-          "bindings": {
-            "kafka": {}
-          },
-          "description": "Auto-generated description",
-          "operationId": "receiveMonetaryAmount_publish",
-          "message": {
-            "oneOf": [
-              {
-                "name": "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-                "title": "ExamplePayloadDto",
-                "payload": {
-                  "$ref": "#/components/schemas/ExamplePayloadDto"
-                },
-                "headers": {
-                  "$ref": "#/components/schemas/HeadersNotDocumented"
-                }
-              },
-              {
-                "name": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-                "title": "AnotherPayloadDto",
-                "payload": {
-                  "$ref": "#/components/schemas/AnotherPayloadDto"
-                },
-                "headers": {
-                  "$ref": "#/components/schemas/HeadersNotDocumented"
-                }
-              },
-              {
-                "name": "javax.money.MonetaryAmount",
-                "title": "MonetaryAmount",
-                "payload": {
-                  "$ref": "#/components/schemas/MonetaryAmount"
-                },
-                "headers": {
-                  "$ref": "#/components/schemas/HeadersNotDocumented"
-                }
-              }
-            ]
-          }
-        },
-        "bindings": {
-          "kafka": {}
-        }
+      "bindings" : {
+        "kafka" : { }
       }
     },
-    "components": {
-      "schemas": {
-        "MonetaryAmount": {
-          "type": "object",
-          "properties": {
-            "amount": {
-              "type": "number",
-              "example": 99.99,
-              "exampleSetFlag": true
-            },
-            "currency": {
-              "type": "string",
-              "example": "USD",
-              "exampleSetFlag": true
-            }
-          },
-          "example": {
-            "amount": 99.99,
-            "currency": "USD"
-          },
-          "exampleSetFlag": true
+    "example-producer-topic" : {
+      "subscribe" : {
+        "operationId" : "example-producer-topic_subscribe",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "kafka" : { }
         },
-        "ExamplePayloadDto": {
-          "required": [
-            "someEnum",
-            "someString"
-          ],
-          "type": "object",
-          "properties": {
-            "someString": {
-              "type": "string",
-              "description": "Some string field",
-              "example": "some string value",
-              "exampleSetFlag": true
+        "message" : {
+          "oneOf" : [ {
+            "name" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+            "title" : "ExamplePayloadDto",
+            "payload" : {
+              "$ref" : "#/components/schemas/ExamplePayloadDto"
             },
-            "someLong": {
-              "type": "integer",
-              "description": "Some long field",
-              "format": "int64",
-              "example": 5,
-              "exampleSetFlag": true
-            },
-            "someEnum": {
-              "type": "string",
-              "description": "Some enum field",
-              "example": "FOO2",
-              "exampleSetFlag": true,
-              "enum": [
-                "FOO1",
-                "FOO2",
-                "FOO3"
-              ]
+            "headers" : {
+              "$ref" : "#/components/schemas/SpringDefaultHeaders"
             }
-          },
-          "description": "Example payload model",
-          "example": {
-            "someString": "some string value",
-            "someLong": 5,
-            "someEnum": "FOO2"
-          },
-          "exampleSetFlag": true
-        },
-        "CloudEventHeadersForAnotherPayloadDtoEndpoint": {
-          "type": "object",
-          "properties": {
-            "ce_specversion": {
-              "type": "string",
-              "description": "CloudEvent Spec Version Header",
-              "example": "1.0",
-              "exampleSetFlag": true,
-              "enum": [
-                "1.0"
-              ]
+          }, {
+            "name" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+            "title" : "AnotherPayloadDto",
+            "description" : "Custom, optional description for this produced to topic",
+            "payload" : {
+              "$ref" : "#/components/schemas/AnotherPayloadDto"
             },
-            "ce_time": {
-              "type": "string",
-              "description": "CloudEvent Time Header",
-              "example": "2015-07-20T15:49:04-07:00",
-              "exampleSetFlag": true,
-              "enum": [
-                "2015-07-20T15:49:04-07:00"
-              ]
-            },
-            "content-type": {
-              "type": "string",
-              "description": "CloudEvent Content-Type Header",
-              "example": "application/json",
-              "exampleSetFlag": true,
-              "enum": [
-                "application/json"
-              ]
-            },
-            "ce_id": {
-              "type": "string",
-              "description": "CloudEvent Id Header",
-              "example": "1234-1234-1234",
-              "exampleSetFlag": true,
-              "enum": [
-                "1234-1234-1234"
-              ]
-            },
-            "ce_type": {
-              "type": "string",
-              "description": "CloudEvent Payload Type Header",
-              "example": "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint",
-              "exampleSetFlag": true,
-              "enum": [
-                "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint"
-              ]
-            },
-            "ce_source": {
-              "type": "string",
-              "description": "CloudEvent Source Header",
-              "example": "springwolf-kafka-example/anotherPayloadDtoEndpoint",
-              "exampleSetFlag": true,
-              "enum": [
-                "springwolf-kafka-example/anotherPayloadDtoEndpoint"
-              ]
-            },
-            "ce_subject": {
-              "type": "string",
-              "description": "CloudEvent Subject Header",
-              "example": "Test Subject",
-              "exampleSetFlag": true,
-              "enum": [
-                "Test Subject"
-              ]
+            "headers" : {
+              "$ref" : "#/components/schemas/CloudEventHeadersForAnotherPayloadDtoEndpoint"
             }
-          },
-          "example": {
-            "ce_specversion": "1.0",
-            "ce_time": "2015-07-20T15:49:04-07:00",
-            "content-type": "application/json",
-            "ce_id": "1234-1234-1234",
-            "ce_type": "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint",
-            "ce_source": "springwolf-kafka-example/anotherPayloadDtoEndpoint",
-            "ce_subject": "Test Subject"
-          },
-          "exampleSetFlag": true
-        },
-        "HeadersNotDocumented": {
-          "type": "object",
-          "properties": {},
-          "example": {},
-          "exampleSetFlag": true
-        },
-        "AnotherPayloadDto": {
-          "required": [
-            "example"
-          ],
-          "type": "object",
-          "properties": {
-            "foo": {
-              "type": "string",
-              "description": "Foo field",
-              "example": "bar",
-              "exampleSetFlag": true
-            },
-            "example": {
-              "$ref": "#/components/schemas/ExamplePayloadDto",
-              "exampleSetFlag": false
-            }
-          },
-          "description": "Another payload model",
-          "example": {
-            "foo": "bar",
-            "example": {
-              "someString": "some string value",
-              "someLong": 5,
-              "someEnum": "FOO2"
-            }
-          },
-          "exampleSetFlag": true
-        },
-        "SpringDefaultHeaders": {
-          "type": "object",
-          "properties": {
-            "__TypeId__": {
-              "type": "string",
-              "description": "Spring Type Id Header",
-              "example": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-              "exampleSetFlag": true,
-              "enum": [
-                "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-                "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
-              ]
-            }
-          },
-          "example": {
-            "__TypeId__": "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
-          },
-          "exampleSetFlag": true
+          } ]
         }
+      },
+      "bindings" : {
+        "kafka" : { }
       }
     },
-    "tags": []
+    "example-topic" : {
+      "publish" : {
+        "operationId" : "example-topic_publish_receiveExamplePayload",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "kafka" : { }
+        },
+        "message" : {
+          "name" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+          "title" : "ExamplePayloadDto",
+          "payload" : {
+            "$ref" : "#/components/schemas/ExamplePayloadDto"
+          },
+          "headers" : {
+            "$ref" : "#/components/schemas/HeadersNotDocumented"
+          }
+        }
+      },
+      "bindings" : {
+        "kafka" : { }
+      }
+    },
+    "multi-payload-topic" : {
+      "publish" : {
+        "operationId" : "receiveMonetaryAmount_publish",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "kafka" : { }
+        },
+        "message" : {
+          "oneOf" : [ {
+            "name" : "javax.money.MonetaryAmount",
+            "title" : "MonetaryAmount",
+            "payload" : {
+              "$ref" : "#/components/schemas/MonetaryAmount"
+            },
+            "headers" : {
+              "$ref" : "#/components/schemas/HeadersNotDocumented"
+            }
+          }, {
+            "name" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+            "title" : "ExamplePayloadDto",
+            "payload" : {
+              "$ref" : "#/components/schemas/ExamplePayloadDto"
+            },
+            "headers" : {
+              "$ref" : "#/components/schemas/HeadersNotDocumented"
+            }
+          }, {
+            "name" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+            "title" : "AnotherPayloadDto",
+            "payload" : {
+              "$ref" : "#/components/schemas/AnotherPayloadDto"
+            },
+            "headers" : {
+              "$ref" : "#/components/schemas/HeadersNotDocumented"
+            }
+          } ]
+        }
+      },
+      "bindings" : {
+        "kafka" : { }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "AnotherPayloadDto" : {
+        "required" : [ "example" ],
+        "type" : "object",
+        "properties" : {
+          "foo" : {
+            "type" : "string",
+            "description" : "Foo field",
+            "example" : "bar",
+            "exampleSetFlag" : true
+          },
+          "example" : {
+            "$ref" : "#/components/schemas/ExamplePayloadDto",
+            "exampleSetFlag" : false
+          }
+        },
+        "description" : "Another payload model",
+        "example" : {
+          "foo" : "bar",
+          "example" : {
+            "someString" : "some string value",
+            "someLong" : 5,
+            "someEnum" : "FOO2"
+          }
+        },
+        "exampleSetFlag" : true
+      },
+      "CloudEventHeadersForAnotherPayloadDtoEndpoint" : {
+        "type" : "object",
+        "properties" : {
+          "ce_id" : {
+            "type" : "string",
+            "description" : "CloudEvent Id Header",
+            "example" : "1234-1234-1234",
+            "exampleSetFlag" : true,
+            "enum" : [ "1234-1234-1234" ]
+          },
+          "ce_source" : {
+            "type" : "string",
+            "description" : "CloudEvent Source Header",
+            "example" : "springwolf-kafka-example/anotherPayloadDtoEndpoint",
+            "exampleSetFlag" : true,
+            "enum" : [ "springwolf-kafka-example/anotherPayloadDtoEndpoint" ]
+          },
+          "ce_specversion" : {
+            "type" : "string",
+            "description" : "CloudEvent Spec Version Header",
+            "example" : "1.0",
+            "exampleSetFlag" : true,
+            "enum" : [ "1.0" ]
+          },
+          "ce_subject" : {
+            "type" : "string",
+            "description" : "CloudEvent Subject Header",
+            "example" : "Test Subject",
+            "exampleSetFlag" : true,
+            "enum" : [ "Test Subject" ]
+          },
+          "ce_time" : {
+            "type" : "string",
+            "description" : "CloudEvent Time Header",
+            "example" : "2015-07-20T15:49:04-07:00",
+            "exampleSetFlag" : true,
+            "enum" : [ "2015-07-20T15:49:04-07:00" ]
+          },
+          "ce_type" : {
+            "type" : "string",
+            "description" : "CloudEvent Payload Type Header",
+            "example" : "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint",
+            "exampleSetFlag" : true,
+            "enum" : [ "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint" ]
+          },
+          "content-type" : {
+            "type" : "string",
+            "description" : "CloudEvent Content-Type Header",
+            "example" : "application/json",
+            "exampleSetFlag" : true,
+            "enum" : [ "application/json" ]
+          }
+        },
+        "example" : {
+          "ce_id" : "1234-1234-1234",
+          "ce_source" : "springwolf-kafka-example/anotherPayloadDtoEndpoint",
+          "ce_specversion" : "1.0",
+          "ce_subject" : "Test Subject",
+          "ce_time" : "2015-07-20T15:49:04-07:00",
+          "ce_type" : "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint",
+          "content-type" : "application/json"
+        },
+        "exampleSetFlag" : true
+      },
+      "ExamplePayloadDto" : {
+        "required" : [ "someEnum", "someString" ],
+        "type" : "object",
+        "properties" : {
+          "someString" : {
+            "type" : "string",
+            "description" : "Some string field",
+            "example" : "some string value",
+            "exampleSetFlag" : true
+          },
+          "someLong" : {
+            "type" : "integer",
+            "description" : "Some long field",
+            "format" : "int64",
+            "example" : 5,
+            "exampleSetFlag" : true
+          },
+          "someEnum" : {
+            "type" : "string",
+            "description" : "Some enum field",
+            "example" : "FOO2",
+            "exampleSetFlag" : true,
+            "enum" : [ "FOO1", "FOO2", "FOO3" ]
+          }
+        },
+        "description" : "Example payload model",
+        "example" : {
+          "someString" : "some string value",
+          "someLong" : 5,
+          "someEnum" : "FOO2"
+        },
+        "exampleSetFlag" : true
+      },
+      "HeadersNotDocumented" : {
+        "type" : "object",
+        "properties" : { },
+        "example" : { },
+        "exampleSetFlag" : true
+      },
+      "MonetaryAmount" : {
+        "type" : "object",
+        "properties" : {
+          "amount" : {
+            "type" : "number",
+            "example" : 99.99,
+            "exampleSetFlag" : true
+          },
+          "currency" : {
+            "type" : "string",
+            "example" : "USD",
+            "exampleSetFlag" : true
+          }
+        },
+        "example" : {
+          "amount" : 99.99,
+          "currency" : "USD"
+        },
+        "exampleSetFlag" : true
+      },
+      "SpringDefaultHeaders" : {
+        "type" : "object",
+        "properties" : {
+          "__TypeId__" : {
+            "type" : "string",
+            "description" : "Spring Type Id Header",
+            "example" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
+            "exampleSetFlag" : true,
+            "enum" : [ "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto", "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto" ]
+          }
+        },
+        "example" : {
+          "__TypeId__" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
+        },
+        "exampleSetFlag" : true
+      }
+    }
+  },
+  "tags" : [ ]
 }


### PR DESCRIPTION
Json output uses 2 space indentation as discussed in discord. As a side effect, there is a space after the colon seperator now - see the json to review.

Add methods to customize objectmapper and printer (to allow easier configuration kotlin, i.e. JavaTimeModule)
Use TreeMap to created sorted map structures in json output
test: Update asyncapi.json (using test output. Better diffs for future fields added, since it is sorted)