### PR TITLE
Annotation for publisher and subscriber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 springwolf-core/build/
 springwolf-ui/build/
 springwolf-examples/springwolf-amqp-example/build/
+springwolf-examples/springwolf-cloud-stream-example/build/
 springwolf-examples/springwolf-kafka-example/build/
 springwolf-plugins/springwolf-amqp-plugin/build/
+springwolf-plugins/springwolf-cloud-stream-plugin/build/
 springwolf-plugins/springwolf-kafka-plugin/build/
 springwolf-add-ons/springwolf-common-model-converters/build/
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
@@ -1,5 +1,6 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
+import com.asyncapi.v2.binding.amqp.AMQPOperationBinding;
 import com.asyncapi.v2.binding.kafka.KafkaChannelBinding;
 import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -11,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.github.stavshamir.springwolf.asyncapi.serializers.EmptyChannelBindingSerializer;
 import io.github.stavshamir.springwolf.asyncapi.serializers.EmptyOperationBindingSerializer;
+import io.github.stavshamir.springwolf.asyncapi.serializers.AmqpOperationBindingSerializer;
 import io.github.stavshamir.springwolf.asyncapi.serializers.KafkaChannelBindingSerializer;
 import io.github.stavshamir.springwolf.asyncapi.serializers.KafkaOperationBindingSerializer;
 import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
@@ -36,6 +38,7 @@ public class DefaultAsyncApiSerializerService implements AsyncApiSerializerServi
         SimpleModule module = new SimpleModule();
         module.addSerializer(EmptyChannelBinding.class, new EmptyChannelBindingSerializer());
         module.addSerializer(EmptyOperationBinding.class, new EmptyOperationBindingSerializer());
+        module.addSerializer(AMQPOperationBinding.class, new AmqpOperationBindingSerializer());
         module.addSerializer(KafkaChannelBinding.class, new KafkaChannelBindingSerializer());
         module.addSerializer(KafkaOperationBinding.class, new KafkaOperationBindingSerializer());
         jsonMapper.registerModule(module);

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsService.java
@@ -1,57 +1,40 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
 import com.asyncapi.v2.model.channel.ChannelItem;
-import com.asyncapi.v2.model.channel.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelMerger;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class DefaultChannelsService implements ChannelsService {
 
-    private final Set<? extends ChannelsScanner> channelsScanners;
+    private final List<? extends ChannelsScanner> channelsScanners;
     private final Map<String, ChannelItem> channels = new TreeMap<>();
 
     @PostConstruct
     void findChannels() {
+        List<Map.Entry<String, ChannelItem>> foundChannelItems = new ArrayList<>();
 
         for (ChannelsScanner scanner : channelsScanners) {
             try {
                 Map<String, ChannelItem> channels = scanner.scan();
-                processFoundChannels(channels);
+                foundChannelItems.addAll(channels.entrySet());
             } catch (Exception e) {
                 log.error("An error was encountered during channel scanning with {}: {}", scanner, e.getMessage());
             }
         }
-    }
 
-    private void processFoundChannels(Map<String, ChannelItem> foundChannels) {
-        for (Map.Entry<String, ChannelItem> foundChannel: foundChannels.entrySet()) {
-            if (!this.channels.containsKey(foundChannel.getKey())) {
-                this.channels.put(foundChannel.getKey(), foundChannel.getValue());
-            } else {
-                ChannelItem existingChannel = this.channels.get(foundChannel.getKey());
-
-                Operation subscribeOperation = foundChannel.getValue().getSubscribe();
-                if(subscribeOperation != null) {
-                    existingChannel.setSubscribe(subscribeOperation);
-                }
-
-                Operation publishOperation = foundChannel.getValue().getPublish();
-                if(publishOperation != null) {
-                    existingChannel.setPublish(publishOperation);
-                }
-            }
-        }
+        this.channels.putAll(ChannelMerger.merge(foundChannelItems));
     }
 
     @Override

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMerger.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMerger.java
@@ -1,0 +1,50 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
+
+import com.asyncapi.v2.model.channel.ChannelItem;
+import com.asyncapi.v2.model.channel.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.MessageHelper;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
+
+import java.util.*;
+import java.util.function.Function;
+
+import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.toMessageObjectOrComposition;
+
+public class ChannelMerger {
+
+    public static Map<String, ChannelItem> merge(List<Map.Entry<String, ChannelItem>> channelEntries) {
+        Map<String, ChannelItem> mergedChannels = new TreeMap<>();
+
+        for (Map.Entry<String, ChannelItem> entry : channelEntries) {
+            if (!mergedChannels.containsKey(entry.getKey())) {
+                mergedChannels.put(entry.getKey(), entry.getValue());
+            } else {
+                ChannelItem channelItem = mergedChannels.get(entry.getKey());
+                channelItem.setPublish(mergeOperation(channelItem, entry.getValue(), ChannelItem::getPublish));
+                channelItem.setSubscribe(mergeOperation(channelItem, entry.getValue(), ChannelItem::getSubscribe));
+            }
+        }
+
+        return mergedChannels;
+    }
+
+    private static Operation mergeOperation(ChannelItem channelItem, ChannelItem otherChannelItem, Function<ChannelItem, Operation> getOperation) {
+        Set<Message> mergedMessages = getChannelMessages(channelItem, getOperation);
+        Set<Message> currentEntryMessages = getChannelMessages(otherChannelItem, getOperation);
+        mergedMessages.addAll(currentEntryMessages);
+
+        Operation operation = getOperation.apply(channelItem) != null ? getOperation.apply(channelItem) : getOperation.apply(otherChannelItem);
+        if (!mergedMessages.isEmpty()) {
+            operation.setMessage(toMessageObjectOrComposition(mergedMessages));
+        }
+        return operation;
+    }
+
+    private static Set<Message> getChannelMessages(ChannelItem channelItem, Function<ChannelItem, Operation> getOperation) {
+        return Optional
+                .ofNullable(getOperation.apply(channelItem))
+                .map(Operation::getMessage)
+                .map(MessageHelper::messageObjectToSet)
+                .orElseGet(TreeSet::new);
+    }
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMerger.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMerger.java
@@ -10,8 +10,22 @@ import java.util.function.Function;
 
 import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.toMessageObjectOrComposition;
 
+
+/**
+ * Util to merge multiple {@link ChannelItem}s
+ */
 public class ChannelMerger {
 
+    /**
+     * Merges multiple channelItems by channel name
+     * <p>
+     * Given two channelItems for the same channel name, the first seen ChannelItem is used
+     * If an operation is null, the next non-null operation is used
+     * Messages within operations are merged
+     *
+     * @param channelEntries Ordered pairs of channel name to ChannelItem
+     * @return A map of channelName to a single ChannelItem
+     */
     public static Map<String, ChannelItem> merge(List<Map.Entry<String, ChannelItem>> channelEntries) {
         Map<String, ChannelItem> mergedChannels = new TreeMap<>();
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelPriority.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelPriority.java
@@ -1,0 +1,28 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncSubscriber;
+import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
+
+public class ChannelPriority {
+    /**
+     * Manual defined channels have the highest priority
+     * <p>
+     * Example: Definition via {@link AsyncApiDocket}
+     */
+    public static final int MANUAL_DEFINED = 1;
+
+    /**
+     * Definition via custom annotations
+     * <p>
+     * Example: {@link AsyncPublisher}, {@link AsyncSubscriber}
+     */
+    public static final int ASYNC_ANNOTATION = 2;
+
+    /**
+     * Definitions found via spring listener annotations are used last.
+     * <p>
+     * Examples: Plugins like KafkaListener, etc
+     */
+    public static final int AUTO_DISCOVERED = 3;
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
@@ -4,6 +4,7 @@ import com.asyncapi.v2.binding.ChannelBinding;
 import com.asyncapi.v2.binding.OperationBinding;
 import com.asyncapi.v2.model.channel.ChannelItem;
 import com.asyncapi.v2.model.channel.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
@@ -11,6 +12,7 @@ import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.HeaderReference;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 
 import java.util.List;
 import java.util.Map;
@@ -20,10 +22,13 @@ import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.toMessageOb
 import static java.util.stream.Collectors.*;
 
 @Slf4j
+@Order(value = ChannelPriority.MANUAL_DEFINED)
 public abstract class AbstractOperationDataScanner implements ChannelsScanner {
 
     protected abstract SchemasService getSchemaService();
+
     protected abstract List<OperationData> getOperationData();
+
     protected abstract OperationData.OperationType getOperationType();
 
     @Override
@@ -64,9 +69,9 @@ public abstract class AbstractOperationDataScanner implements ChannelsScanner {
 
         ChannelItem.ChannelItemBuilder channelBuilder = ChannelItem.builder()
                 .bindings(channelBinding);
-        switch(getOperationType()) {
+        switch (getOperationType()) {
             case PUBLISH:
-                channelBuilder =  channelBuilder.publish(operation);
+                channelBuilder = channelBuilder.publish(operation);
                 break;
             case SUBSCRIBE:
                 channelBuilder = channelBuilder.subscribe(operation);

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProcessedOperationBinding.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProcessedOperationBinding.java
@@ -1,0 +1,10 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata;
+
+import com.asyncapi.v2.binding.OperationBinding;
+import lombok.Data;
+
+@Data
+public class ProcessedOperationBinding {
+     private final String type;
+     private final OperationBinding binding;
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtil.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtil.java
@@ -1,0 +1,54 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import com.asyncapi.v2.binding.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProcessedOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaderSchema;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
+import org.springframework.util.StringUtils;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.groupingBy;
+
+class AsyncAnnotationScannerUtil {
+    public static AsyncHeaders getAsyncHeaders(AsyncOperation op) {
+        if (op.headers().values().length == 0) {
+            return AsyncHeaders.NOT_DOCUMENTED;
+        }
+
+        AsyncHeaders headers = new AsyncHeaders(op.headers().schemaName());
+        Arrays.stream(op.headers().values()).collect(groupingBy(AsyncOperation.Headers.Header::name))
+                .forEach((key, value) -> {
+                    List<String> descriptions = value.stream().map(AsyncOperation.Headers.Header::description).filter(it -> !"".equals(it)).sorted().collect(Collectors.toList());
+                    List<String> values = value.stream().map(AsyncOperation.Headers.Header::value).sorted().collect(Collectors.toList());
+                    headers.addHeader(
+                            AsyncHeaderSchema
+                                    .headerBuilder()
+                                    .headerName(key)
+                                    .description(descriptions.stream().findFirst().orElse(null))
+                                    .enumValue(values)
+                                    .example(values.stream().findFirst().orElse(null))
+                                    .build()
+                    );
+                });
+
+        return headers;
+    }
+
+    public static String nullIfEmpty(String stringValue) {
+        return StringUtils.isEmpty(stringValue) ? null : stringValue;
+    }
+
+    public static Map<String, OperationBinding> processBindingFromAnnotation(Method method, List<OperationBindingProcessor> operationBindingProcessors) {
+        return operationBindingProcessors.stream()
+                .map(operationBindingProcessor -> operationBindingProcessor.process(method))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toMap(ProcessedOperationBinding::getType, ProcessedOperationBinding::getBinding));
+    }
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncOperation.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncOperation.java
@@ -5,9 +5,15 @@ import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaderSchema;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
  * Annotation is mapped to {@link OperationData}
  */
+@Retention(RetentionPolicy.CLASS)
+@Target({})
 public @interface AsyncOperation {
     /**
      * Mapped to {@link OperationData#getChannelName()}
@@ -29,6 +35,8 @@ public @interface AsyncOperation {
      */
     Headers headers() default @Headers();
 
+    @Retention(RetentionPolicy.CLASS)
+    @Target({})
     @interface Headers {
         /**
          * Mapped to {@link AsyncHeaders#getSchemaName()}
@@ -37,6 +45,8 @@ public @interface AsyncOperation {
 
         Header[] values() default {};
 
+        @Retention(RetentionPolicy.CLASS)
+        @Target({})
         @interface Header {
             /**
              * Mapped to {@link AsyncHeaderSchema#getHeaderName()}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncOperation.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncOperation.java
@@ -1,0 +1,57 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+
+import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaderSchema;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
+
+/**
+ * Annotation is mapped to {@link OperationData}
+ */
+public @interface AsyncOperation {
+    /**
+     * Mapped to {@link OperationData#getChannelName()}
+     */
+    String channelName();
+
+    /**
+     * Mapped to {@link OperationData#getDescription()}
+     */
+    String description() default "";
+
+    /**
+     * Mapped to {@link OperationData#getPayloadType()}
+     */
+    Class<?> payloadType() default Object.class;
+
+    /**
+     * Mapped to {@link OperationData#getHeaders()}
+     */
+    Headers headers() default @Headers();
+
+    @interface Headers {
+        /**
+         * Mapped to {@link AsyncHeaders#getSchemaName()}
+         */
+        String schemaName() default "";
+
+        Header[] values() default {};
+
+        @interface Header {
+            /**
+             * Mapped to {@link AsyncHeaderSchema#getHeaderName()}
+             */
+            String name();
+
+            /**
+             * Mapped to {@link AsyncHeaderSchema#getDescription()} ()}
+             */
+            String description() default "";
+
+            /**
+             * Mapped to {@link AsyncHeaderSchema#getDefault()}
+             */
+            String value();
+        }
+    }
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisher.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisher.java
@@ -1,7 +1,6 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
 
 import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
-import io.github.stavshamir.springwolf.asyncapi.types.ProducerData;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -9,7 +8,23 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation is mapped to {@link ProducerData}
+ * {@code @AsyncPublisher} is a method-level annotation to document springwolf publishers.
+ * To document listeners, use {@link AsyncSubscriber}.
+ * <p>
+ * The fields channel, description, payload and headers are part of {@link AsyncOperation}
+ * and behaves identical to {@link io.github.stavshamir.springwolf.asyncapi.types.ProducerData}.
+ * If no {@link AsyncOperation#payloadType()} is passed, the payload type is extracted from the signature of the method.
+ * Add {@link org.springframework.messaging.handler.annotation.Payload} to the payload argument, if the method has more than one argument.
+ * <p>
+ * Add an operation binding with one of the protocol specific operation binding annotation ({@code AmqpAsyncOperationBinding}, {@code KafkaAsyncOperationBinding}) on the same method.
+ * <pre class="code">
+ *     &#064;AsyncPublisher(operation = &#064;AsyncOperation(
+ *             channelName = "topic-name",
+ *             ...
+ *     ))
+ *     &#064;KafkaAsyncOperationBinding
+ *     public void sendMessage(MonetaryAmount payload) { ... }
+ * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisher.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisher.java
@@ -1,0 +1,21 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
+import io.github.stavshamir.springwolf.asyncapi.types.ProducerData;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation is mapped to {@link ProducerData}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.METHOD})
+public @interface AsyncPublisher {
+    /**
+     * Mapped to {@link OperationData}
+     */
+    AsyncOperation operation();
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
@@ -10,8 +10,10 @@ import io.github.stavshamir.springwolf.asyncapi.types.ProducerData;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringValueResolver;
 
 import java.lang.reflect.Method;
 import java.util.*;
@@ -23,12 +25,17 @@ import static java.util.stream.Collectors.toSet;
 @RequiredArgsConstructor
 @Component
 @Order(value = ChannelPriority.ASYNC_ANNOTATION)
-public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanner {
-
+public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanner implements EmbeddedValueResolverAware {
+    private StringValueResolver resolver;
     private final ComponentClassScanner componentClassScanner;
     private final SchemasService schemasService;
 
     private final List<OperationBindingProcessor> operationBindingProcessors;
+
+    @Override
+    public void setEmbeddedValueResolver(StringValueResolver resolver) {
+        this.resolver = resolver;
+    }
 
     @Override
     protected SchemasService getSchemaService() {
@@ -66,8 +73,8 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
         Class<?> payloadType = op.payloadType() != Object.class ? op.payloadType() :
                 SpringPayloadAnnotationTypeExtractor.getPayloadType(method);
         return ProducerData.builder()
-                .channelName(op.channelName())
-                .description(AsyncAnnotationScannerUtil.nullIfEmpty(op.description()))
+                .channelName(resolver.resolveStringValue(op.channelName()))
+                .description(resolver.resolveStringValue(op.description()))
                 .headers(AsyncAnnotationScannerUtil.getAsyncHeaders(op))
                 .payloadType(payloadType)
                 .operationBinding(operationBindings)

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
@@ -1,0 +1,81 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import com.asyncapi.v2.binding.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.SpringPayloadAnnotationTypeExtractor;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.AbstractOperationDataScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
+import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
+import io.github.stavshamir.springwolf.asyncapi.types.ProducerData;
+import io.github.stavshamir.springwolf.schemas.SchemasService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toSet;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+@Order(value = ChannelPriority.ASYNC_ANNOTATION)
+public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanner {
+
+    private final ComponentClassScanner componentClassScanner;
+    private final SchemasService schemasService;
+
+    private final List<OperationBindingProcessor> operationBindingProcessors;
+
+    @Override
+    protected SchemasService getSchemaService() {
+        return this.schemasService;
+    }
+
+    @Override
+    protected List<OperationData> getOperationData() {
+        return componentClassScanner.scan().stream()
+                .map(this::getAnnotatedMethods)
+                .flatMap(Collection::stream)
+                .map(this::mapMethodToOperationData)
+                .collect(Collectors.toList());
+    }
+
+    private Set<Method> getAnnotatedMethods(Class<?> type) {
+        Class<AsyncPublisher> annotationClass = AsyncPublisher.class;
+        log.debug("Scanning class \"{}\" for @\"{}\" annotated methods", type.getName(), annotationClass.getName());
+
+        return Arrays.stream(type.getDeclaredMethods())
+                .filter(method -> method.isAnnotationPresent(annotationClass))
+                .collect(toSet());
+    }
+
+    private OperationData mapMethodToOperationData(Method method) {
+        log.debug("Mapping method \"{}\" to channels", method.getName());
+
+        Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processBindingFromAnnotation(method, operationBindingProcessors);
+
+        Class<AsyncPublisher> annotationClass = AsyncPublisher.class;
+        AsyncPublisher annotation = Optional.of(method.getAnnotation(annotationClass))
+                .orElseThrow(() -> new IllegalArgumentException("Method must be annotated with " + annotationClass.getName()));
+
+        AsyncOperation op = annotation.operation();
+        Class<?> payloadType = op.payloadType() != Object.class ? op.payloadType() :
+                SpringPayloadAnnotationTypeExtractor.getPayloadType(method);
+        return ProducerData.builder()
+                .channelName(op.channelName())
+                .description(AsyncAnnotationScannerUtil.nullIfEmpty(op.description()))
+                .headers(AsyncAnnotationScannerUtil.getAsyncHeaders(op))
+                .payloadType(payloadType)
+                .operationBinding(operationBindings)
+                .build();
+    }
+
+    @Override
+    protected OperationData.OperationType getOperationType() {
+        return OperationData.OperationType.SUBSCRIBE;
+    }
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncSubscriber.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncSubscriber.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
 
-import io.github.stavshamir.springwolf.asyncapi.types.ConsumerData;
 import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
 
 import java.lang.annotation.ElementType;
@@ -9,7 +8,24 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation is mapped to {@link ConsumerData}
+ * {@code @AsyncSubscriber} is a method-level annotation to document springwolf listeners.
+ * To document producers, use {@link AsyncPublisher}.
+ * <p>
+ * The fields channel, description, payload and headers are part of {@link AsyncOperation}
+ * and behaves identical to {@link io.github.stavshamir.springwolf.asyncapi.types.ConsumerData}.
+ * If no {@link AsyncOperation#payloadType()} is passed, the payload type is extracted from the signature of the method.
+ * Add {@link org.springframework.messaging.handler.annotation.Payload} to the payload argument, if the method has more than one argument.
+ * <p>
+ * Add an operation binding with one of the protocol specific operation binding annotation ({@code AmqpAsyncOperationBinding}, {@code KafkaAsyncOperationBinding}) on the same method.
+ * <pre class="code">
+ *     &#064;KafkaListener
+ *     &#064;AsyncSubscriber(operation = &#064;AsyncOperation(
+ *             channelName = "topic-name",
+ *             ...
+ *     ))
+ *     &#064;KafkaAsyncOperationBinding
+ *     public void receiveMessage(MonetaryAmount payload) { ... }
+ * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncSubscriber.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncSubscriber.java
@@ -1,0 +1,21 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import io.github.stavshamir.springwolf.asyncapi.types.ConsumerData;
+import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation is mapped to {@link ConsumerData}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.METHOD})
+public @interface AsyncSubscriber {
+    /**
+     * Mapped to {@link OperationData}
+     */
+    AsyncOperation operation();
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncSubscriberAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncSubscriberAnnotationScanner.java
@@ -1,0 +1,81 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import com.asyncapi.v2.binding.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.SpringPayloadAnnotationTypeExtractor;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.AbstractOperationDataScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
+import io.github.stavshamir.springwolf.asyncapi.types.ConsumerData;
+import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
+import io.github.stavshamir.springwolf.schemas.SchemasService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toSet;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+@Order(value = ChannelPriority.ASYNC_ANNOTATION)
+public class AsyncSubscriberAnnotationScanner extends AbstractOperationDataScanner {
+
+    private final ComponentClassScanner componentClassScanner;
+    private final SchemasService schemasService;
+
+    private final List<OperationBindingProcessor> operationBindingProcessors;
+
+    @Override
+    protected SchemasService getSchemaService() {
+        return this.schemasService;
+    }
+
+    @Override
+    protected List<OperationData> getOperationData() {
+        return componentClassScanner.scan().stream()
+                .map(this::getAnnotatedMethods)
+                .flatMap(Collection::stream)
+                .map(this::mapMethodToOperationData)
+                .collect(Collectors.toList());
+    }
+
+    private Set<Method> getAnnotatedMethods(Class<?> type) {
+        Class<AsyncSubscriber> annotationClass = AsyncSubscriber.class;
+        log.debug("Scanning class \"{}\" for @\"{}\" annotated methods", type.getName(), annotationClass.getName());
+
+        return Arrays.stream(type.getDeclaredMethods())
+                .filter(method -> method.isAnnotationPresent(annotationClass))
+                .collect(toSet());
+    }
+
+    private OperationData mapMethodToOperationData(Method method) {
+        log.debug("Mapping method \"{}\" to channels", method.getName());
+
+        Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processBindingFromAnnotation(method, operationBindingProcessors);
+
+        Class<AsyncSubscriber> annotationClass = AsyncSubscriber.class;
+        AsyncSubscriber annotation = Optional.of(method.getAnnotation(annotationClass))
+                .orElseThrow(() -> new IllegalArgumentException("Method must be annotated with " + annotationClass.getName()));
+
+        AsyncOperation op = annotation.operation();
+        Class<?> payloadType = op.payloadType() != Object.class ? op.payloadType() :
+                SpringPayloadAnnotationTypeExtractor.getPayloadType(method);
+        return ConsumerData.builder()
+                .channelName(op.channelName())
+                .description(AsyncAnnotationScannerUtil.nullIfEmpty(op.description()))
+                .headers(AsyncAnnotationScannerUtil.getAsyncHeaders(op))
+                .payloadType(payloadType)
+                .operationBinding(operationBindings)
+                .build();
+    }
+
+    @Override
+    protected OperationData.OperationType getOperationType() {
+        return OperationData.OperationType.PUBLISH;
+    }
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/OperationBindingProcessor.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/OperationBindingProcessor.java
@@ -1,0 +1,18 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProcessedOperationBinding;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public interface OperationBindingProcessor {
+
+    /**
+     * Process the methods annotated with {@link AsyncPublisher} and {@link AsyncSubscriber}
+     * for protocol specific operationBinding annotations, method parameters, etc
+     *
+     * @param method The method being annotated
+     * @return An operation binding, if found
+     */
+    Optional<ProcessedOperationBinding> process(Method method);
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/AmqpOperationBindingSerializer.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/AmqpOperationBindingSerializer.java
@@ -1,0 +1,43 @@
+package io.github.stavshamir.springwolf.asyncapi.serializers;
+
+
+import com.asyncapi.v2.binding.amqp.AMQPOperationBinding;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class AmqpOperationBindingSerializer extends StdSerializer<AMQPOperationBinding> {
+
+    public AmqpOperationBindingSerializer() {
+        this(null);
+    }
+
+    public AmqpOperationBindingSerializer(Class<AMQPOperationBinding> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(AMQPOperationBinding value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartObject();
+
+        gen.writeNumberField("expiration", value.getExpiration());
+
+        if (value.getCc() != null) {
+            gen.writeArrayFieldStart("cc");
+            for (String cc : value.getCc()) {
+                gen.writeString(cc);
+            }
+            gen.writeEndArray();
+        }
+
+        gen.writeNumberField("priority", value.getPriority());
+        gen.writeNumberField("deliveryMode", value.getDeliveryMode());
+        gen.writeBooleanField("mandatory", value.isMandatory());
+        gen.writeBooleanField("timestamp", value.isTimestamp());
+        gen.writeBooleanField("ack", value.isAck());
+
+        gen.writeEndObject();
+    }
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/KafkaOperationBindingSerializer.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/KafkaOperationBindingSerializer.java
@@ -33,8 +33,7 @@ public class KafkaOperationBindingSerializer extends StdSerializer<KafkaOperatio
         gen.writeFieldName("groupId");
         gen.writeStartObject();
         gen.writeStringField("type", "string");
-        gen.writeFieldName("enum");
-        gen.writeStartArray();
+        gen.writeArrayFieldStart("enum");
         gen.writeString((String) value.getGroupId());
         gen.writeEndArray();
         gen.writeEndObject();

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ConsumerData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ConsumerData.java
@@ -46,7 +46,7 @@ public class ConsumerData implements OperationData {
     protected Class<?> payloadType;
 
     /**
-     * The class object of the headers published by this consumer.
+     * The message headers, usually describing the payload.
      */
     @Builder.Default
     protected AsyncHeaders headers = AsyncHeaders.NOT_DOCUMENTED;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/OperationData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/OperationData.java
@@ -6,12 +6,38 @@ import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.
 
 import java.util.Map;
 
+/**
+ * Generic, internal interface used by springwolf scanners to process listener and producer data.
+ */
 public interface OperationData {
+    /**
+     * The name of the channel (topic, queue etc.).
+     */
     String getChannelName();
+
+    /**
+     * Optional, additional information about the channel and/or its message
+     */
     String getDescription();
+
+    /**
+     * The channel binding.
+     */
     Map<String, ? extends ChannelBinding> getChannelBinding();
+
+    /**
+     * The class object of the payload.
+     */
     Class<?> getPayloadType();
+
+    /**
+     * The message headers, usually describing the payload.
+     */
     AsyncHeaders getHeaders();
+
+    /**
+     * The operation binding.
+     */
     Map<String, ? extends OperationBinding> getOperationBinding();
 
     enum OperationType {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
@@ -2,7 +2,6 @@ package io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message
 
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.HeaderReference;
 import lombok.*;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Describes a message received on a given channel and operation.
@@ -14,7 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 @EqualsAndHashCode(of = {"name"})
 @NoArgsConstructor
 @AllArgsConstructor
-public class Message implements Comparable<Message> {
+public class Message {
 
     /**
      * A machine-friendly name for the message.
@@ -34,13 +33,4 @@ public class Message implements Comparable<Message> {
     private PayloadReference payload;
 
     private HeaderReference headers;
-
-
-    @Override
-    public int compareTo(Message o) {
-        if (o == null) {
-            return 1;
-        }
-        return StringUtils.compare(this.name, o.name);
-    }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
@@ -1,10 +1,8 @@
 package io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message;
 
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.HeaderReference;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Describes a message received on a given channel and operation.
@@ -13,9 +11,10 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @Builder
+@EqualsAndHashCode(of = {"name"})
 @NoArgsConstructor
 @AllArgsConstructor
-public class Message {
+public class Message implements Comparable<Message> {
 
     /**
      * A machine-friendly name for the message.
@@ -35,4 +34,13 @@ public class Message {
     private PayloadReference payload;
 
     private HeaderReference headers;
+
+
+    @Override
+    public int compareTo(Message o) {
+        if (o == null) {
+            return 1;
+        }
+        return StringUtils.compare(this.name, o.name);
+    }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeaderSchema.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeaderSchema.java
@@ -11,6 +11,7 @@ public class AsyncHeaderSchema extends StringSchema {
     private final String headerName;
     
     public AsyncHeaderSchema(String headerName){
+        super();
         this.headerName = headerName;
     }
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
@@ -1,0 +1,87 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
+
+
+import com.asyncapi.v2.model.channel.ChannelItem;
+import com.asyncapi.v2.model.channel.operation.Operation;
+import com.google.common.collect.Maps;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ChannelMergerTest {
+
+
+    @Test
+    public void shouldNotMergeDifferentChannelNames() {
+        // given
+        String channelName1 = "channel1";
+        String channelName2 = "channel2";
+        Operation publishOperation = Operation.builder().operationId("publisher").build();
+        Operation subscribeOperation = Operation.builder().operationId("subscribe").build();
+        ChannelItem publisherChannel = ChannelItem.builder().publish(publishOperation).build();
+        ChannelItem subscriberChannel = ChannelItem.builder().subscribe(subscribeOperation).build();
+
+        // when
+        Map<String, ChannelItem> mergedChannels = ChannelMerger.merge(Arrays.asList(
+                Maps.immutableEntry(channelName1, publisherChannel),
+                Maps.immutableEntry(channelName2, subscriberChannel)));
+
+        // then
+        assertThat(mergedChannels).hasSize(2)
+                .hasEntrySatisfying(channelName1, it -> {
+                    assertThat(it.getPublish()).isEqualTo(publishOperation);
+                    assertThat(it.getSubscribe()).isNull();
+                })
+                .hasEntrySatisfying(channelName2, it -> {
+                    assertThat(it.getPublish()).isNull();
+                    assertThat(it.getSubscribe()).isEqualTo(subscribeOperation);
+                });
+    }
+
+    @Test
+    public void shouldMergePublisherAndSubscriberIntoOneChannel() {
+        // given
+        String channelName = "channel";
+        Operation publishOperation = Operation.builder().operationId("publisher").build();
+        Operation subscribeOperation = Operation.builder().operationId("subscribe").build();
+        ChannelItem publisherChannel = ChannelItem.builder().publish(publishOperation).build();
+        ChannelItem subscriberChannel = ChannelItem.builder().subscribe(subscribeOperation).build();
+
+        // when
+        Map<String, ChannelItem> mergedChannels = ChannelMerger.merge(Arrays.asList(
+                Maps.immutableEntry(channelName, publisherChannel),
+                Maps.immutableEntry(channelName, subscriberChannel)));
+
+        // then
+        assertThat(mergedChannels).hasSize(1)
+                .hasEntrySatisfying(channelName, it -> {
+                    assertThat(it.getPublish()).isEqualTo(publishOperation);
+                    assertThat(it.getSubscribe()).isEqualTo(subscribeOperation);
+                });
+    }
+
+    @Test
+    public void shouldUseFirstOperationFound() {
+        // given
+        String channelName = "channel";
+        Operation publishOperation1 = Operation.builder().operationId("publisher1").build();
+        Operation publishOperation2 = Operation.builder().operationId("publisher2").build();
+        ChannelItem publisherChannel1 = ChannelItem.builder().publish(publishOperation1).build();
+        ChannelItem publisherChannel2 = ChannelItem.builder().publish(publishOperation2).build();
+
+        // when
+        Map<String, ChannelItem> mergedChannels = ChannelMerger.merge(Arrays.asList(
+                Maps.immutableEntry(channelName, publisherChannel1),
+                Maps.immutableEntry(channelName, publisherChannel2)));
+
+        // then
+        assertThat(mergedChannels).hasSize(1)
+                .hasEntrySatisfying(channelName, it -> {
+                    assertThat(it.getPublish()).isEqualTo(publishOperation1);
+                    assertThat(it.getSubscribe()).isNull();
+                });
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
@@ -1,0 +1,165 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import com.asyncapi.v2.model.channel.ChannelItem;
+import com.asyncapi.v2.model.channel.operation.Operation;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.HeaderReference;
+import io.github.stavshamir.springwolf.schemas.DefaultSchemasService;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.EMPTY_MAP;
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {AsyncPublisherAnnotationScanner.class, DefaultSchemasService.class, TestOperationBindingProcessor.class})
+public class AsyncPublisherAnnotationScannerTest {
+
+    @Autowired
+    private AsyncPublisherAnnotationScanner channelScanner;
+
+    @MockBean
+    private ComponentClassScanner componentClassScanner;
+
+    private void setClassToScan(Class<?> classToScan) {
+        Set<Class<?>> classesToScan = singleton(classToScan);
+        when(componentClassScanner.scan()).thenReturn(classesToScan);
+    }
+
+    @Test
+    public void scan_componentHasNoPublisherMethods() {
+        setClassToScan(ClassWithoutPublisherAnnotation.class);
+
+        Map<String, ChannelItem> channels = channelScanner.scan();
+
+        assertThat(channels).isEmpty();
+    }
+
+
+    @Test
+    public void scan_componentHasPublisherMethod() {
+        // Given a class with methods annotated with AsyncPublisher, where only the channel-name is set
+        setClassToScan(ClassWithPublisherAnnotation.class);
+
+        // When scan is called
+        Map<String, ChannelItem> actualChannels = channelScanner.scan();
+
+        // Then the returned collection contains the channel
+        Message message = Message.builder()
+                .name(SimpleFoo.class.getName())
+                .title(SimpleFoo.class.getSimpleName())
+                .description(null)
+                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .build();
+
+        Operation operation = Operation.builder()
+                .description("Auto-generated description")
+                .operationId("test-channel_subscribe")
+                .bindings(EMPTY_MAP)
+                .message(message)
+                .build();
+
+        ChannelItem expectedChannel = ChannelItem.builder()
+                .bindings(null)
+                .subscribe(operation)
+                .build();
+
+        assertThat(actualChannels)
+                .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
+    }
+
+    @Test
+    public void scan_componentHasPublisherMethodWithAllAttributes() {
+        // Given a class with method annotated with AsyncPublisher, where all attributes are set
+        setClassToScan(ClassWithPublisherAnnotationWithAllAttributes.class);
+
+        // When scan is called
+        Map<String, ChannelItem> actualChannels = channelScanner.scan();
+
+        // Then the returned collection contains the channel
+        Message message = Message.builder()
+                .name(SimpleFoo.class.getName())
+                .title(SimpleFoo.class.getSimpleName())
+                .description("description")
+                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                .headers(HeaderReference.fromModelName("TestSchema"))
+                .build();
+
+        Operation operation = Operation.builder()
+                .description("Auto-generated description")
+                .operationId("test-channel_subscribe")
+                .bindings(ImmutableMap.of(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING))
+                .message(message)
+                .build();
+
+        ChannelItem expectedChannel = ChannelItem.builder()
+                .bindings(null)
+                .subscribe(operation)
+                .build();
+
+        assertThat(actualChannels)
+                .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
+    }
+
+
+    private static class ClassWithoutPublisherAnnotation {
+
+        private void methodWithoutAnnotation() {
+        }
+    }
+
+    private static class ClassWithPublisherAnnotation {
+
+        @AsyncPublisher(operation = @AsyncOperation(
+                channelName = "test-channel"
+        ))
+        private void methodWithAnnotation(SimpleFoo payload) {
+        }
+
+        private void methodWithoutAnnotation() {
+        }
+
+    }
+
+    private static class ClassWithPublisherAnnotationWithAllAttributes {
+
+        @AsyncPublisher(operation = @AsyncOperation(
+                channelName = "test-channel",
+                description = "description",
+                headers = @AsyncOperation.Headers(
+                        schemaName = "TestSchema",
+                        values = {@AsyncOperation.Headers.Header(name = "header", value = "value")}
+                )
+        ))
+        @TestOperationBindingProcessor.TestOperationBinding()
+        private void methodWithAnnotation(SimpleFoo payload) {
+        }
+
+        private void methodWithoutAnnotation() {
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    private static class SimpleFoo {
+        private String s;
+        private boolean b;
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Map;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = {AsyncPublisherAnnotationScanner.class, DefaultSchemasService.class, TestOperationBindingProcessor.class})
+@TestPropertySource(properties = {"test.property.test-channel=test-channel", "test.property.description=description"})
 public class AsyncPublisherAnnotationScannerTest {
 
     @Autowired
@@ -141,8 +143,8 @@ public class AsyncPublisherAnnotationScannerTest {
     private static class ClassWithPublisherAnnotationWithAllAttributes {
 
         @AsyncPublisher(operation = @AsyncOperation(
-                channelName = "test-channel",
-                description = "description",
+                channelName = "${test.property.test-channel}",
+                description = "${test.property.description}",
                 headers = @AsyncOperation.Headers(
                         schemaName = "TestSchema",
                         values = {@AsyncOperation.Headers.Header(name = "header", value = "value")}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncSubscriberAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncSubscriberAnnotationScannerTest.java
@@ -1,0 +1,165 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import com.asyncapi.v2.model.channel.ChannelItem;
+import com.asyncapi.v2.model.channel.operation.Operation;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.HeaderReference;
+import io.github.stavshamir.springwolf.schemas.DefaultSchemasService;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.EMPTY_MAP;
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {AsyncSubscriberAnnotationScanner.class, DefaultSchemasService.class, TestOperationBindingProcessor.class})
+public class AsyncSubscriberAnnotationScannerTest {
+
+    @Autowired
+    private AsyncSubscriberAnnotationScanner channelScanner;
+
+    @MockBean
+    private ComponentClassScanner componentClassScanner;
+
+    private void setClassToScan(Class<?> classToScan) {
+        Set<Class<?>> classesToScan = singleton(classToScan);
+        when(componentClassScanner.scan()).thenReturn(classesToScan);
+    }
+
+    @Test
+    public void scan_componentHasNoListenerMethods() {
+        setClassToScan(ClassWithoutSubscriberAnnotation.class);
+
+        Map<String, ChannelItem> channels = channelScanner.scan();
+
+        assertThat(channels).isEmpty();
+    }
+
+
+    @Test
+    public void scan_componentHasListenerMethod() {
+        // Given a class with methods annotated with AsyncSubscriber, where only the channel-name is set
+        setClassToScan(ClassWithListenerAnnotation.class);
+
+        // When scan is called
+        Map<String, ChannelItem> actualChannels = channelScanner.scan();
+
+        // Then the returned collection contains the channel
+        Message message = Message.builder()
+                .name(SimpleFoo.class.getName())
+                .title(SimpleFoo.class.getSimpleName())
+                .description(null)
+                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .build();
+
+        Operation operation = Operation.builder()
+                .description("Auto-generated description")
+                .operationId("test-channel_publish")
+                .bindings(EMPTY_MAP)
+                .message(message)
+                .build();
+
+        ChannelItem expectedChannel = ChannelItem.builder()
+                .bindings(null)
+                .publish(operation)
+                .build();
+
+        assertThat(actualChannels)
+                .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
+    }
+
+    @Test
+    public void scan_componentHasListenerMethodWithAllAttributes() {
+        // Given a class with method annotated with AsyncSubscriber, where all attributes are set
+        setClassToScan(ClassWithListenerAnnotationWithAllAttributes.class);
+
+        // When scan is called
+        Map<String, ChannelItem> actualChannels = channelScanner.scan();
+
+        // Then the returned collection contains the channel
+        Message message = Message.builder()
+                .name(SimpleFoo.class.getName())
+                .title(SimpleFoo.class.getSimpleName())
+                .description("description")
+                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                .headers(HeaderReference.fromModelName("TestSchema"))
+                .build();
+
+        Operation operation = Operation.builder()
+                .description("Auto-generated description")
+                .operationId("test-channel_publish")
+                .bindings(ImmutableMap.of(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING))
+                .message(message)
+                .build();
+
+        ChannelItem expectedChannel = ChannelItem.builder()
+                .bindings(null)
+                .publish(operation)
+                .build();
+
+        assertThat(actualChannels)
+                .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
+    }
+
+
+    private static class ClassWithoutSubscriberAnnotation {
+
+        private void methodWithoutAnnotation() {
+        }
+    }
+
+    private static class ClassWithListenerAnnotation {
+
+        @AsyncSubscriber(operation = @AsyncOperation(
+                channelName = "test-channel"
+        ))
+        private void methodWithAnnotation(SimpleFoo payload) {
+        }
+
+        private void methodWithoutAnnotation() {
+        }
+
+    }
+
+    private static class ClassWithListenerAnnotationWithAllAttributes {
+
+        @AsyncSubscriber(operation = @AsyncOperation(
+                channelName = "test-channel",
+                description = "description",
+                headers = @AsyncOperation.Headers(
+                        schemaName = "TestSchema",
+                        values = {@AsyncOperation.Headers.Header(name = "header", value = "value")}
+                )
+        ))
+        @TestOperationBindingProcessor.TestOperationBinding()
+        private void methodWithAnnotation(SimpleFoo payload) {
+        }
+
+        private void methodWithoutAnnotation() {
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    private static class SimpleFoo {
+        private String s;
+        private boolean b;
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncSubscriberAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncSubscriberAnnotationScannerTest.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Map;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = {AsyncSubscriberAnnotationScanner.class, DefaultSchemasService.class, TestOperationBindingProcessor.class})
+@TestPropertySource(properties = {"test.property.test-channel=test-channel", "test.property.description=description"})
 public class AsyncSubscriberAnnotationScannerTest {
 
     @Autowired
@@ -141,8 +143,8 @@ public class AsyncSubscriberAnnotationScannerTest {
     private static class ClassWithListenerAnnotationWithAllAttributes {
 
         @AsyncSubscriber(operation = @AsyncOperation(
-                channelName = "test-channel",
-                description = "description",
+                channelName = "${test.property.test-channel}",
+                description = "${test.property.description}",
                 headers = @AsyncOperation.Headers(
                         schemaName = "TestSchema",
                         values = {@AsyncOperation.Headers.Header(name = "header", value = "value")}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/TestOperationBindingProcessor.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/TestOperationBindingProcessor.java
@@ -1,0 +1,29 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import com.asyncapi.v2.binding.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProcessedOperationBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class TestOperationBindingProcessor implements OperationBindingProcessor {
+    public final static String TYPE = "testType";
+    public final static OperationBinding BINDING = new OperationBinding();
+
+    @Override
+    public Optional<ProcessedOperationBinding> process(Method method) {
+        if (method.isAnnotationPresent(TestOperationBinding.class)) {
+            return Optional.of(new ProcessedOperationBinding(TYPE, BINDING));
+        }
+        return Optional.empty();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(value = {ElementType.METHOD})
+    public @interface TestOperationBinding {
+    }
+}

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
@@ -59,7 +59,7 @@ public class AsyncApiConfiguration {
                 .build();
 
         return AsyncApiDocket.builder()
-                .basePackage("io.github.stavshamir.springwolf.example.consumers")
+                .basePackage("io.github.stavshamir.springwolf.example")
                 .info(info)
                 .server("amqp", amqp)
                 .producer(exampleProducer)

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/producers/ExampleProducer.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/producers/ExampleProducer.java
@@ -1,0 +1,21 @@
+package io.github.stavshamir.springwolf.example.producers;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AmqpAsyncOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
+import io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExampleProducer {
+
+    @AsyncPublisher(operation = @AsyncOperation(
+            channelName = "example-producer-channel-publisher",
+            description = "Custom, optional description defined in the AsyncPublisher annotation"
+    ))
+    @AmqpAsyncOperationBinding()
+    public void sendMessage(ExamplePayloadDto msg) {
+        // send
+    }
+
+}

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -166,6 +166,34 @@
         }
       }
     },
+    "example-producer-channel-publisher" : {
+      "subscribe" : {
+        "operationId" : "example-producer-channel-publisher_subscribe",
+        "description" : "Auto-generated description",
+        "bindings" : {
+          "amqp" : {
+            "expiration" : 0,
+            "cc" : [ ],
+            "priority" : 0,
+            "deliveryMode" : 0,
+            "mandatory" : false,
+            "timestamp" : false,
+            "ack" : false
+          }
+        },
+        "message" : {
+          "name" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
+          "title" : "ExamplePayloadDto",
+          "description" : "Custom, optional description defined in the AsyncPublisher annotation",
+          "payload" : {
+            "$ref" : "#/components/schemas/ExamplePayloadDto"
+          },
+          "headers" : {
+            "$ref" : "#/components/schemas/HeadersNotDocumented"
+          }
+        }
+      }
+    },
     "example-queue" : {
       "publish" : {
         "operationId" : "example-queue_publish_receiveExamplePayload",
@@ -249,7 +277,8 @@
             "type" : "string",
             "description" : "Foo field",
             "example" : "bar",
-            "exampleSetFlag" : true
+            "exampleSetFlag" : true,
+            "types" : [ "string" ]
           },
           "example" : {
             "$ref" : "#/components/schemas/ExamplePayloadDto",
@@ -275,20 +304,23 @@
             "type" : "string",
             "description" : "Some string field",
             "example" : "some string value",
-            "exampleSetFlag" : true
+            "exampleSetFlag" : true,
+            "types" : [ "string" ]
           },
           "someLong" : {
             "type" : "integer",
             "description" : "Some long field",
             "format" : "int64",
             "example" : 5,
-            "exampleSetFlag" : true
+            "exampleSetFlag" : true,
+            "types" : [ "integer" ]
           },
           "someEnum" : {
             "type" : "string",
             "description" : "Some enum field",
             "example" : "FOO2",
             "exampleSetFlag" : true,
+            "types" : [ "string" ],
             "enum" : [ "FOO1", "FOO2", "FOO3" ]
           }
         },
@@ -304,7 +336,8 @@
         "type" : "object",
         "properties" : { },
         "example" : { },
-        "exampleSetFlag" : true
+        "exampleSetFlag" : true,
+        "types" : [ "object" ]
       }
     }
   },

--- a/springwolf-examples/springwolf-kafka-example/docker-compose.yml
+++ b/springwolf-examples/springwolf-kafka-example/docker-compose.yml
@@ -1,16 +1,16 @@
 version: '3'
 services:
-  app:
-    image: stavshamir/springwolf-kafka-example:0.9.0
-    links:
-      - kafka
-    environment:
-      BOOTSTRAP_SERVER: kafka:29092
-    ports:
-      - "8080:8080"
-    depends_on:
-      - kafka
-      - zookeeper
+#  app:
+#    image: stavshamir/springwolf-kafka-example:0.9.0
+#    links:
+#      - kafka
+#    environment:
+#      BOOTSTRAP_SERVER: kafka:29092
+#    ports:
+#      - "8080:8080"
+#    depends_on:
+#      - kafka
+#      - zookeeper
 
   zookeeper:
     image: confluentinc/cp-zookeeper:latest

--- a/springwolf-examples/springwolf-kafka-example/docker-compose.yml
+++ b/springwolf-examples/springwolf-kafka-example/docker-compose.yml
@@ -1,22 +1,22 @@
 version: '3'
 services:
-#  app:
-#    image: stavshamir/springwolf-kafka-example:0.9.0
-#    links:
-#      - kafka
-#    environment:
-#      BOOTSTRAP_SERVER: kafka:29092
-#    ports:
-#      - "8080:8080"
-#    depends_on:
-#      - kafka
-#      - zookeeper
+  app:
+    image: stavshamir/springwolf-kafka-example:0.9.0
+    links:
+      - kafka
+    environment:
+      BOOTSTRAP_SERVER: kafka:29092
+    ports:
+      - "8080:8080"
+    depends_on:
+      - kafka
+      - zookeeper
 
   zookeeper:
     image: confluentinc/cp-zookeeper:latest
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 
+      ZOOKEEPER_TICK_TIME:
 
   kafka:
     image: confluentinc/cp-kafka:latest

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
@@ -8,7 +8,6 @@ import io.github.stavshamir.springwolf.asyncapi.types.KafkaConsumerData;
 import io.github.stavshamir.springwolf.asyncapi.types.KafkaProducerData;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeadersForCloudEventsBuilder;
-import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeadersForSpringKafkaBuilder;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
 import io.github.stavshamir.springwolf.configuration.EnableAsyncApi;
 import io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto;
@@ -20,7 +19,6 @@ import org.springframework.http.MediaType;
 
 import static io.github.stavshamir.springwolf.example.configuration.KafkaConfiguration.CONSUMER_TOPIC;
 import static io.github.stavshamir.springwolf.example.configuration.KafkaConfiguration.PRODUCER_TOPIC;
-import static java.util.Arrays.asList;
 
 @Configuration
 @EnableAsyncApi
@@ -59,18 +57,8 @@ public class AsyncApiConfiguration {
                 .basePackage("io.github.stavshamir.springwolf.example")
                 .info(info)
                 .server("kafka", Server.builder().protocol("kafka").url(BOOTSTRAP_SERVERS).build())
-                .consumer(manuallyConfiguredConsumer)
                 .producer(anotherProducerData)
-                .build();
-    }
-
-    private static AsyncHeaders createSpringKafkaDefaultHeaders() {
-        return new AsyncHeadersForSpringKafkaBuilder()
-                .withTypeIdHeader(
-                        "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-                        asList("io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-                                "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto")
-                )
+                .consumer(manuallyConfiguredConsumer)
                 .build();
     }
 

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
@@ -42,12 +42,6 @@ public class AsyncApiConfiguration {
                 .license(License.builder().name("Apache License 2.0").build())
                 .build();
 
-        KafkaProducerData exampleProducerData = KafkaProducerData.kafkaProducerDataBuilder()
-                .topicName(PRODUCER_TOPIC)
-                .payloadType(ExamplePayloadDto.class)
-                .headers(createSpringKafkaDefaultHeaders())
-                .build();
-
         KafkaProducerData anotherProducerData = KafkaProducerData.kafkaProducerDataBuilder()
                 .topicName(PRODUCER_TOPIC)
                 .description("Custom, optional description for this produced to topic")
@@ -62,12 +56,11 @@ public class AsyncApiConfiguration {
                 .build();
 
         return AsyncApiDocket.builder()
-                .basePackage("io.github.stavshamir.springwolf.example.consumers")
+                .basePackage("io.github.stavshamir.springwolf.example")
                 .info(info)
                 .server("kafka", Server.builder().protocol("kafka").url(BOOTSTRAP_SERVERS).build())
-                .producer(exampleProducerData)
-                .producer(anotherProducerData)
                 .consumer(manuallyConfiguredConsumer)
+                .producer(anotherProducerData)
                 .build();
     }
 

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/consumers/ExampleClassLevelKafkaListener.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/consumers/ExampleClassLevelKafkaListener.java
@@ -1,5 +1,8 @@
 package io.github.stavshamir.springwolf.example.consumers;
 
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncSubscriber;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding;
 import io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto;
 import io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto;
 import org.slf4j.Logger;
@@ -9,6 +12,8 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 import javax.money.MonetaryAmount;
+
+import static org.springframework.kafka.support.converter.AbstractJavaTypeMapper.DEFAULT_CLASSID_FIELD_NAME;
 
 
 @Service
@@ -28,6 +33,25 @@ public class ExampleClassLevelKafkaListener {
     }
 
     @KafkaHandler
+    @AsyncSubscriber(operation = @AsyncOperation(
+            channelName = "multi-payload-topic",
+            description = "Override description in the AsyncSubscriber annotation",
+            headers = @AsyncOperation.Headers(
+                    schemaName = "SpringKafkaDefaultHeaders-MonetaryAmount",
+                    values = {
+                            @AsyncOperation.Headers.Header(
+                                    name = DEFAULT_CLASSID_FIELD_NAME,
+                                    description = "Spring Type Id Header",
+                                    value = "javax.money.MonetaryAmount"
+                            ),
+                    }
+            )
+    ))
+    @KafkaAsyncOperationBinding(
+            bindingVersion = "1",
+            clientId = "foo-clientId",
+            groupId = "foo-groupId"
+    )
     public void receiveMonetaryAmount(MonetaryAmount payload) {
         logger.info("Received new message in multi-payload-topic: {}", payload.toString());
     }

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/consumers/ExampleClassLevelKafkaListener.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/consumers/ExampleClassLevelKafkaListener.java
@@ -35,7 +35,7 @@ public class ExampleClassLevelKafkaListener {
     @KafkaHandler
     @AsyncSubscriber(operation = @AsyncOperation(
             channelName = "multi-payload-topic",
-            description = "Override description in the AsyncSubscriber annotation",
+            description = "Override description in the AsyncSubscriber annotation with servers at ${kafka.bootstrap.servers}",
             headers = @AsyncOperation.Headers(
                     schemaName = "SpringKafkaDefaultHeaders-MonetaryAmount",
                     values = {
@@ -50,7 +50,7 @@ public class ExampleClassLevelKafkaListener {
     @KafkaAsyncOperationBinding(
             bindingVersion = "1",
             clientId = "foo-clientId",
-            groupId = "foo-groupId"
+            groupId = "#{'foo-groupId'}"
     )
     public void receiveMonetaryAmount(MonetaryAmount payload) {
         logger.info("Received new message in multi-payload-topic: {}", payload.toString());

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/consumers/ExampleConsumer.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/consumers/ExampleConsumer.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.example.consumers;
 
-import io.github.stavshamir.springwolf.example.dtos.*;
+import io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto;
+import io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/producers/ExampleProducer.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/producers/ExampleProducer.java
@@ -38,8 +38,7 @@ public class ExampleProducer {
     ))
     @KafkaAsyncOperationBinding(
             bindingVersion = "1",
-            clientId = "foo-clientId",
-            groupId = "foo-groupId"
+            clientId = "foo-clientId"
     )
     public void sendMessage(ExamplePayloadDto msg) {
         kafkaTemplate.send(PRODUCER_TOPIC, msg);

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/producers/ExampleProducer.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/producers/ExampleProducer.java
@@ -1,11 +1,15 @@
 package io.github.stavshamir.springwolf.example.producers;
 
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding;
 import io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 import static io.github.stavshamir.springwolf.example.configuration.KafkaConfiguration.PRODUCER_TOPIC;
+import static org.springframework.kafka.support.converter.AbstractJavaTypeMapper.DEFAULT_CLASSID_FIELD_NAME;
 
 @Component
 public class ExampleProducer {
@@ -13,6 +17,28 @@ public class ExampleProducer {
     @Autowired
     private KafkaTemplate<String, ExamplePayloadDto> kafkaTemplate;
 
+    @AsyncPublisher(operation = @AsyncOperation(
+            channelName = PRODUCER_TOPIC,
+            description = "Custom, optional description defined in the AsyncPublisher annotation",
+            headers = @AsyncOperation.Headers(
+                    schemaName = "SpringKafkaDefaultHeaders",
+                    values = {
+                            @AsyncOperation.Headers.Header(
+                                    name = DEFAULT_CLASSID_FIELD_NAME,
+                                    value = "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto"
+                            ),
+                            @AsyncOperation.Headers.Header(
+                                    name = DEFAULT_CLASSID_FIELD_NAME,
+                                    value = "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
+                            ),
+                    }
+            )
+    ))
+    @KafkaAsyncOperationBinding(
+            bindingVersion = "1",
+            clientId = "foo-clientId",
+            groupId = "foo-groupId"
+    )
     public void sendMessage(ExamplePayloadDto msg) {
         kafkaTemplate.send(PRODUCER_TOPIC, msg);
     }

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/producers/ExampleProducer.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/producers/ExampleProducer.java
@@ -25,10 +25,12 @@ public class ExampleProducer {
                     values = {
                             @AsyncOperation.Headers.Header(
                                     name = DEFAULT_CLASSID_FIELD_NAME,
+                                    description = "Spring Type Id Header",
                                     value = "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto"
                             ),
                             @AsyncOperation.Headers.Header(
                                     name = DEFAULT_CLASSID_FIELD_NAME,
+                                    description = "Spring Type Id Header",
                                     value = "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
                             ),
                     }

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTests.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTests.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.example;
 
-import lombok.val;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,6 +41,8 @@ public class ApiIntegrationTests {
         // When running with EmbeddedKafka, localhost is used as hostname
         String expected = expectedWithoutServersKafkaUrlPatch.replace("\"kafka:29092\"", "\"localhost:29092\"");
 
+
+        // STRICT
         JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
     }
 }

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTests.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTests.java
@@ -20,7 +20,7 @@ import java.nio.charset.StandardCharsets;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {SpringwolfExampleApplication.class}, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@EmbeddedKafka(partitions = 1, brokerProperties = { "listeners=PLAINTEXT://localhost:29092", "port=29092" })
+@EmbeddedKafka(partitions = 1, brokerProperties = {"listeners=PLAINTEXT://localhost:29092", "port=29092"})
 @DirtiesContext
 public class ApiIntegrationTests {
 
@@ -41,8 +41,6 @@ public class ApiIntegrationTests {
         // When running with EmbeddedKafka, localhost is used as hostname
         String expected = expectedWithoutServersKafkaUrlPatch.replace("\"kafka:29092\"", "\"localhost:29092\"");
 
-
-        // STRICT
         JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
     }
 }

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTests.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTests.java
@@ -39,7 +39,7 @@ public class ApiIntegrationTests {
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expectedWithoutServersKafkaUrlPatch = IOUtils.toString(s, StandardCharsets.UTF_8);
         // When running with EmbeddedKafka, localhost is used as hostname
-        String expected = expectedWithoutServersKafkaUrlPatch.replace("\"kafka:29092\"", "\"localhost:29092\"");
+        String expected = expectedWithoutServersKafkaUrlPatch.replace("kafka:29092", "localhost:29092");
 
         JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
     }

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -15,7 +15,7 @@
   },
   "servers" : {
     "kafka" : {
-      "url" : "kafka:29092",
+      "url" : "localhost:29092",
       "protocol" : "kafka"
     }
   },
@@ -91,6 +91,7 @@
           }, {
             "name" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
             "title" : "ExamplePayloadDto",
+            "description" : "Custom, optional description defined in the AsyncPublisher annotation",
             "payload" : {
               "$ref" : "#/components/schemas/ExamplePayloadDto"
             },
@@ -128,10 +129,15 @@
     },
     "multi-payload-topic" : {
       "publish" : {
-        "operationId" : "ExampleClassLevelKafkaListener_publish",
+        "operationId" : "multi-payload-topic_publish",
         "description" : "Auto-generated description",
         "bindings" : {
-          "kafka" : { }
+          "kafka" : {
+            "groupId" : {
+              "type" : "string",
+              "enum" : [ "foo-groupId" ]
+            }
+          }
         },
         "message" : {
           "oneOf" : [ {
@@ -155,6 +161,7 @@
           }, {
             "name" : "javax.money.MonetaryAmount",
             "title" : "MonetaryAmount",
+            "description" : "Override description in the AsyncSubscriber annotation",
             "payload" : {
               "$ref" : "#/components/schemas/MonetaryAmount"
             },
@@ -163,9 +170,6 @@
             }
           } ]
         }
-      },
-      "bindings" : {
-        "kafka" : { }
       }
     }
   },
@@ -179,7 +183,8 @@
             "type" : "string",
             "description" : "Foo field",
             "example" : "bar",
-            "exampleSetFlag" : true
+            "exampleSetFlag" : true,
+            "types" : [ "string" ]
           },
           "example" : {
             "$ref" : "#/components/schemas/ExamplePayloadDto",
@@ -205,6 +210,7 @@
             "description" : "CloudEvent Id Header",
             "example" : "1234-1234-1234",
             "exampleSetFlag" : true,
+            "types" : [ "string" ],
             "enum" : [ "1234-1234-1234" ]
           },
           "ce_source" : {
@@ -212,6 +218,7 @@
             "description" : "CloudEvent Source Header",
             "example" : "springwolf-kafka-example/anotherPayloadDtoEndpoint",
             "exampleSetFlag" : true,
+            "types" : [ "string" ],
             "enum" : [ "springwolf-kafka-example/anotherPayloadDtoEndpoint" ]
           },
           "ce_specversion" : {
@@ -219,6 +226,7 @@
             "description" : "CloudEvent Spec Version Header",
             "example" : "1.0",
             "exampleSetFlag" : true,
+            "types" : [ "string" ],
             "enum" : [ "1.0" ]
           },
           "ce_subject" : {
@@ -226,6 +234,7 @@
             "description" : "CloudEvent Subject Header",
             "example" : "Test Subject",
             "exampleSetFlag" : true,
+            "types" : [ "string" ],
             "enum" : [ "Test Subject" ]
           },
           "ce_time" : {
@@ -233,6 +242,7 @@
             "description" : "CloudEvent Time Header",
             "example" : "2015-07-20T15:49:04-07:00",
             "exampleSetFlag" : true,
+            "types" : [ "string" ],
             "enum" : [ "2015-07-20T15:49:04-07:00" ]
           },
           "ce_type" : {
@@ -240,6 +250,7 @@
             "description" : "CloudEvent Payload Type Header",
             "example" : "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint",
             "exampleSetFlag" : true,
+            "types" : [ "string" ],
             "enum" : [ "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint" ]
           },
           "content-type" : {
@@ -247,6 +258,7 @@
             "description" : "CloudEvent Content-Type Header",
             "example" : "application/json",
             "exampleSetFlag" : true,
+            "types" : [ "string" ],
             "enum" : [ "application/json" ]
           }
         },
@@ -259,7 +271,8 @@
           "ce_type" : "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint",
           "content-type" : "application/json"
         },
-        "exampleSetFlag" : true
+        "exampleSetFlag" : true,
+        "types" : [ "object" ]
       },
       "ExamplePayloadDto" : {
         "required" : [ "someEnum", "someString" ],
@@ -269,20 +282,23 @@
             "type" : "string",
             "description" : "Some string field",
             "example" : "some string value",
-            "exampleSetFlag" : true
+            "exampleSetFlag" : true,
+            "types" : [ "string" ]
           },
           "someLong" : {
             "type" : "integer",
             "description" : "Some long field",
             "format" : "int64",
             "example" : 5,
-            "exampleSetFlag" : true
+            "exampleSetFlag" : true,
+            "types" : [ "integer" ]
           },
           "someEnum" : {
             "type" : "string",
             "description" : "Some enum field",
             "example" : "FOO2",
             "exampleSetFlag" : true,
+            "types" : [ "string" ],
             "enum" : [ "FOO1", "FOO2", "FOO3" ]
           }
         },
@@ -298,7 +314,8 @@
         "type" : "object",
         "properties" : { },
         "example" : { },
-        "exampleSetFlag" : true
+        "exampleSetFlag" : true,
+        "types" : [ "object" ]
       },
       "MonetaryAmount" : {
         "type" : "object",
@@ -306,12 +323,14 @@
           "amount" : {
             "type" : "number",
             "example" : 99.99,
-            "exampleSetFlag" : true
+            "exampleSetFlag" : true,
+            "types" : [ "number" ]
           },
           "currency" : {
             "type" : "string",
             "example" : "USD",
-            "exampleSetFlag" : true
+            "exampleSetFlag" : true,
+            "types" : [ "string" ]
           }
         },
         "example" : {
@@ -325,16 +344,17 @@
         "properties" : {
           "__TypeId__" : {
             "type" : "string",
-            "description" : "Spring Type Id Header",
             "example" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
             "exampleSetFlag" : true,
-            "enum" : [ "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto", "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto" ]
+            "types" : [ "string" ],
+            "enum" : [ "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto", "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto" ]
           }
         },
         "example" : {
           "__TypeId__" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
         },
-        "exampleSetFlag" : true
+        "exampleSetFlag" : true,
+        "types" : [ "object" ]
       },
       "SpringKafkaDefaultHeaders-AnotherPayloadDto" : {
         "type" : "object",
@@ -344,13 +364,15 @@
             "description" : "Spring Type Id Header",
             "example" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
             "exampleSetFlag" : true,
+            "types" : [ "string" ],
             "enum" : [ "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto" ]
           }
         },
         "example" : {
           "__TypeId__" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
         },
-        "exampleSetFlag" : true
+        "exampleSetFlag" : true,
+        "types" : [ "object" ]
       },
       "SpringKafkaDefaultHeaders-ExamplePayloadDto" : {
         "type" : "object",
@@ -360,13 +382,15 @@
             "description" : "Spring Type Id Header",
             "example" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
             "exampleSetFlag" : true,
+            "types" : [ "string" ],
             "enum" : [ "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto" ]
           }
         },
         "example" : {
           "__TypeId__" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto"
         },
-        "exampleSetFlag" : true
+        "exampleSetFlag" : true,
+        "types" : [ "object" ]
       },
       "SpringKafkaDefaultHeaders-MonetaryAmount" : {
         "type" : "object",
@@ -376,13 +400,15 @@
             "description" : "Spring Type Id Header",
             "example" : "javax.money.MonetaryAmount",
             "exampleSetFlag" : true,
+            "types" : [ "string" ],
             "enum" : [ "javax.money.MonetaryAmount" ]
           }
         },
         "example" : {
           "__TypeId__" : "javax.money.MonetaryAmount"
         },
-        "exampleSetFlag" : true
+        "exampleSetFlag" : true,
+        "types" : [ "object" ]
       }
     }
   },

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -15,7 +15,7 @@
   },
   "servers" : {
     "kafka" : {
-      "url" : "localhost:29092",
+      "url" : "kafka:29092",
       "protocol" : "kafka"
     }
   },
@@ -344,6 +344,7 @@
         "properties" : {
           "__TypeId__" : {
             "type" : "string",
+            "description" : "Spring Type Id Header",
             "example" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
             "exampleSetFlag" : true,
             "types" : [ "string" ],

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -161,7 +161,7 @@
           }, {
             "name" : "javax.money.MonetaryAmount",
             "title" : "MonetaryAmount",
-            "description" : "Override description in the AsyncSubscriber annotation",
+            "description" : "Override description in the AsyncSubscriber annotation with servers at kafka:29092",
             "payload" : {
               "$ref" : "#/components/schemas/MonetaryAmount"
             },

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScanner.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScanner.java
@@ -5,11 +5,13 @@ import com.asyncapi.v2.binding.OperationBinding;
 import com.asyncapi.v2.binding.amqp.AMQPChannelBinding;
 import com.asyncapi.v2.binding.amqp.AMQPOperationBinding;
 import com.google.common.collect.ImmutableMap;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringValueResolver;
 
@@ -24,6 +26,7 @@ import java.util.stream.Stream;
 
 @Slf4j
 @Service
+@Order(value = ChannelPriority.AUTO_DISCOVERED)
 public class MethodLevelRabbitListenerScanner extends AbstractMethodLevelListenerScanner<RabbitListener>
         implements ChannelsScanner, EmbeddedValueResolverAware {
 

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AmqpOperationBindingProcessor.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AmqpOperationBindingProcessor.java
@@ -1,0 +1,37 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata;
+
+import com.asyncapi.v2.binding.amqp.AMQPOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AmqpAsyncOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.OperationBindingProcessor;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class AmqpOperationBindingProcessor implements OperationBindingProcessor {
+
+    @Override
+    public Optional<ProcessedOperationBinding> process(Method method) {
+        return Arrays.stream(method.getAnnotations())
+                .filter(annotation -> annotation instanceof AmqpAsyncOperationBinding)
+                .map(annotation -> (AmqpAsyncOperationBinding) annotation)
+                .findAny()
+                .map(this::mapToOperationBinding);
+    }
+
+    private ProcessedOperationBinding mapToOperationBinding(AmqpAsyncOperationBinding bindingAnnotation) {
+        AMQPOperationBinding kafkaOperationBinding = AMQPOperationBinding.builder()
+                .expiration(bindingAnnotation.expiration())
+                .cc(Arrays.asList(bindingAnnotation.cc()))
+                .priority(bindingAnnotation.priority())
+                .deliveryMode(bindingAnnotation.deliveryMode())
+                .mandatory(bindingAnnotation.mandatory())
+                .timestamp(bindingAnnotation.timestamp())
+                .ack(bindingAnnotation.ack())
+                .build();
+
+        return new ProcessedOperationBinding(bindingAnnotation.type(), kafkaOperationBinding);
+    }
+}

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AmqpAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AmqpAsyncOperationBinding.java
@@ -5,6 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * {@code @AmqpAsyncOperationBinding} is a method-level annotation used in combination with {@link AsyncPublisher} or {@link AsyncSubscriber}.
+ * It configures the operation binding for the AMQP protocol.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})
 public @interface AmqpAsyncOperationBinding {

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AmqpAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AmqpAsyncOperationBinding.java
@@ -1,0 +1,27 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.METHOD})
+public @interface AmqpAsyncOperationBinding {
+
+    String type() default "amqp";
+
+    int expiration() default 0;
+
+    String[] cc() default {};
+
+    int priority() default 0;
+
+    int deliveryMode() default 0;
+
+    boolean mandatory() default false;
+
+    boolean timestamp() default false;
+
+    boolean ack() default false;
+}

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScannerTest.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScannerTest.java
@@ -1,7 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.cloudstream;
 
-import com.asyncapi.v2.binding.ChannelBinding;
-import com.asyncapi.v2.binding.OperationBinding;
 import com.asyncapi.v2.model.channel.ChannelItem;
 import com.asyncapi.v2.model.channel.operation.Operation;
 import com.asyncapi.v2.model.info.Info;
@@ -10,6 +8,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.github.stavshamir.springwolf.asyncapi.scanners.beans.DefaultBeanMethodsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ConfigurationClassScanner;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.bindings.EmptyChannelBinding;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.bindings.EmptyOperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
@@ -83,14 +83,14 @@ public class CloudStreamFunctionChannelsScannerTest {
                 .build();
 
         Operation operation = Operation.builder()
-                .bindings(ImmutableMap.of("kafka", new OperationBinding()))
+                .bindings(ImmutableMap.of("kafka", new EmptyOperationBinding()))
                 .description("Auto-generated description")
                 .operationId("test-consumer-input-topic_publish_testConsumer")
                 .message(message)
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new ChannelBinding()))
+                .bindings(ImmutableMap.of("kafka", new EmptyChannelBinding()))
                 .publish(operation)
                 .build();
 
@@ -121,14 +121,14 @@ public class CloudStreamFunctionChannelsScannerTest {
                 .build();
 
         Operation operation = Operation.builder()
-                .bindings(ImmutableMap.of("kafka", new OperationBinding()))
+                .bindings(ImmutableMap.of("kafka", new EmptyOperationBinding()))
                 .description("Auto-generated description")
                 .operationId("test-supplier-output-topic_subscribe_testSupplier")
                 .message(message)
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new ChannelBinding()))
+                .bindings(ImmutableMap.of("kafka", new EmptyChannelBinding()))
                 .subscribe(operation)
                 .build();
 
@@ -165,14 +165,14 @@ public class CloudStreamFunctionChannelsScannerTest {
                 .build();
 
         Operation subscribeOperation = Operation.builder()
-                .bindings(ImmutableMap.of("kafka", new OperationBinding()))
+                .bindings(ImmutableMap.of("kafka", new EmptyOperationBinding()))
                 .description("Auto-generated description")
                 .operationId("test-out-topic_subscribe_testFunction")
                 .message(subscribeMessage)
                 .build();
 
         ChannelItem subscribeChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new ChannelBinding()))
+                .bindings(ImmutableMap.of("kafka", new EmptyChannelBinding()))
                 .subscribe(subscribeOperation)
                 .build();
 
@@ -185,14 +185,14 @@ public class CloudStreamFunctionChannelsScannerTest {
                 .build();
 
         Operation publishOperation = Operation.builder()
-                .bindings(ImmutableMap.of("kafka", new OperationBinding()))
+                .bindings(ImmutableMap.of("kafka", new EmptyOperationBinding()))
                 .description("Auto-generated description")
                 .operationId("test-in-topic_publish_testFunction")
                 .message(publishMessage)
                 .build();
 
         ChannelItem publishChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new ChannelBinding()))
+                .bindings(ImmutableMap.of("kafka", new EmptyChannelBinding()))
                 .publish(publishOperation)
                 .build();
 
@@ -231,14 +231,14 @@ public class CloudStreamFunctionChannelsScannerTest {
                 .build();
 
         Operation subscribeOperation = Operation.builder()
-                .bindings(ImmutableMap.of("kafka", new OperationBinding()))
+                .bindings(ImmutableMap.of("kafka", new EmptyOperationBinding()))
                 .description("Auto-generated description")
                 .operationId("test-out-topic_subscribe_kStreamTestFunction")
                 .message(subscribeMessage)
                 .build();
 
         ChannelItem subscribeChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new ChannelBinding()))
+                .bindings(ImmutableMap.of("kafka", new EmptyChannelBinding()))
                 .subscribe(subscribeOperation)
                 .build();
 
@@ -251,14 +251,14 @@ public class CloudStreamFunctionChannelsScannerTest {
                 .build();
 
         Operation publishOperation = Operation.builder()
-                .bindings(ImmutableMap.of("kafka", new OperationBinding()))
+                .bindings(ImmutableMap.of("kafka", new EmptyOperationBinding()))
                 .description("Auto-generated description")
                 .operationId("test-in-topic_publish_kStreamTestFunction")
                 .message(publishMessage)
                 .build();
 
         ChannelItem publishChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new ChannelBinding()))
+                .bindings(ImmutableMap.of("kafka", new EmptyChannelBinding()))
                 .publish(publishOperation)
                 .build();
 

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScanner.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScanner.java
@@ -2,12 +2,14 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import com.asyncapi.v2.binding.ChannelBinding;
 import com.asyncapi.v2.binding.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeadersForSpringKafkaBuilder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.core.annotation.Order;
 import org.springframework.kafka.annotation.KafkaHandler;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
@@ -21,6 +23,7 @@ import static io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotat
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Order(value = ChannelPriority.AUTO_DISCOVERED)
 public class ClassLevelKafkaListenerScanner extends AbstractClassLevelListenerScanner<KafkaListener, KafkaHandler>
         implements ChannelsScanner, EmbeddedValueResolverAware {
 

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelKafkaListenerScanner.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelKafkaListenerScanner.java
@@ -2,10 +2,12 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import com.asyncapi.v2.binding.ChannelBinding;
 import com.asyncapi.v2.binding.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.core.annotation.Order;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringValueResolver;
@@ -16,6 +18,7 @@ import java.util.Map;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Order(value = ChannelPriority.AUTO_DISCOVERED)
 public class MethodLevelKafkaListenerScanner extends AbstractMethodLevelListenerScanner<KafkaListener>
         implements ChannelsScanner, EmbeddedValueResolverAware {
 

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/KafkaOperationBindingProcessor.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/KafkaOperationBindingProcessor.java
@@ -1,0 +1,38 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata;
+
+import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.OperationBindingProcessor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class KafkaOperationBindingProcessor implements OperationBindingProcessor {
+
+    @Override
+    public Optional<ProcessedOperationBinding> process(Method method) {
+        return Arrays.stream(method.getAnnotations())
+                .filter(annotation -> annotation instanceof KafkaAsyncOperationBinding)
+                .map(annotation -> (KafkaAsyncOperationBinding) annotation)
+                .findAny()
+                .map(this::mapToOperationBinding);
+    }
+
+    private ProcessedOperationBinding mapToOperationBinding(KafkaAsyncOperationBinding bindingAnnotation) {
+        KafkaOperationBinding kafkaOperationBinding = KafkaOperationBinding.builder()
+                .bindingVersion(nullIfEmpty(bindingAnnotation.bindingVersion()))
+                .clientId(nullIfEmpty(bindingAnnotation.clientId()))
+                .groupId(nullIfEmpty(bindingAnnotation.groupId()))
+                .build();
+
+        return new ProcessedOperationBinding(bindingAnnotation.type(), kafkaOperationBinding);
+    }
+
+    private static String nullIfEmpty(String stringValue) {
+        return StringUtils.isEmpty(stringValue) ? null : stringValue;
+    }
+}

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/KafkaAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/KafkaAsyncOperationBinding.java
@@ -5,6 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * {@code @KafkaAsyncOperationBinding} is a method-level annotation used in combination with {@link AsyncPublisher} or @{@link AsyncSubscriber}.
+ * It configures the operation binding for the Kafka protocol.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value={ElementType.METHOD})
 public @interface KafkaAsyncOperationBinding {

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/KafkaAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/KafkaAsyncOperationBinding.java
@@ -1,0 +1,19 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value={ElementType.METHOD})
+public @interface KafkaAsyncOperationBinding {
+
+    String type() default "kafka";
+
+    String groupId() default "";
+
+    String clientId() default "";
+    String bindingVersion() default "";
+
+}


### PR DESCRIPTION
In order to simplify documenting producers, we added annotations to document producers where the actual send methods are being called.
This is an additional way to define `ProducerData` and `ConsumerData`.

The following example is provided in the code as well (kafka + amqp):
```
@AsyncPublisher(operation = @AsyncOperation(
            channelName = PRODUCER_TOPIC,
            description = "Custom, optional description defined in the AsyncPublisher annotation",
            headers = @AsyncOperation.Headers(
                    schemaName = "SpringKafkaDefaultHeaders",
                    values = {
                            @AsyncOperation.Headers.Header(
                                    name = DEFAULT_CLASSID_FIELD_NAME,
                                    description = "Spring Type Id Header",
                                    value = "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto"
                            ),
                            @AsyncOperation.Headers.Header(
                                    name = DEFAULT_CLASSID_FIELD_NAME,
                                    description = "Spring Type Id Header",
                                    value = "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
                            ),
                    }
            )
    ))
    @KafkaAsyncOperationBinding(
            bindingVersion = "1",
            clientId = "foo-clientId",
            groupId = "foo-groupId"
    )
```

The `KafkaAsyncOperationBinding` annotation is optional, as are most fields that are not required (like the description and headers).

Review the changes in the example project for more details.

In terms of implementation, additional scanners have been defined, as well as the annotations themselves. As multiple ChannelItem might be found for a channel now (spring listener annotation + AsyncConsumer + ConsumerData in the Docket), the Merger builds the final channel item. By specifying priorities, custom annotations beat auto discovered definitions.