### PR TITLE
chore: Run spectral from docker container directly

### DIFF
--- a/.github/workflows/springwolf-amqp.yml
+++ b/.github/workflows/springwolf-amqp.yml
@@ -24,9 +24,11 @@ jobs:
         run: |
           echo 'extends: ["spectral:asyncapi"]' > .spectral.yaml
       - name: Lint asyncapi.json with spectral
-        uses: stoplightio/spectral-action@v0.8.8
+        uses: addnab/docker-run-action@v3
         with:
-          file_glob: 'springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json'
+          image: stoplight/spectral:latest
+          options: -v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }}
+          run: spectral lint --ruleset ./.spectral.yaml --fail-on-unmatched-globs ./springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1

--- a/.github/workflows/springwolf-cloud-stream.yml
+++ b/.github/workflows/springwolf-cloud-stream.yml
@@ -24,9 +24,11 @@ jobs:
         run: |
           echo 'extends: ["spectral:asyncapi"]' > .spectral.yaml
       - name: Lint asyncapi.json with spectral
-        uses: stoplightio/spectral-action@v0.8.8
+        uses: addnab/docker-run-action@v3
         with:
-          file_glob: 'springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json'
+          image: stoplight/spectral:latest
+          options: -v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }}
+          run: spectral lint --ruleset ./.spectral.yaml --fail-on-unmatched-globs ./springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1

--- a/.github/workflows/springwolf-kafka.yml
+++ b/.github/workflows/springwolf-kafka.yml
@@ -24,9 +24,11 @@ jobs:
         run: |
           echo 'extends: ["spectral:asyncapi"]' > .spectral.yaml
       - name: Lint asyncapi.json with spectral
-        uses: stoplightio/spectral-action@v0.8.8
+        uses: addnab/docker-run-action@v3
         with:
-          file_glob: 'springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json'
+          image: stoplight/spectral:latest
+          options: -v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }}
+          run: spectral lint --ruleset ./.spectral.yaml --fail-on-unmatched-globs ./springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1


### PR DESCRIPTION
Avoid gh action that builds the spectral docker container first

Relates to https://github.com/stoplightio/spectral-action/issues/452#issuecomment-1285886971