### PR TITLE
chore: Rename AsyncSubscriber to AsyncListener

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelPriority.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelPriority.java
@@ -1,7 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
 
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
-import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncSubscriber;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncListener;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
 
 public class ChannelPriority {
@@ -15,7 +15,7 @@ public class ChannelPriority {
     /**
      * Definition via custom annotations
      * <p>
-     * Example: {@link AsyncPublisher}, {@link AsyncSubscriber}
+     * Example: {@link AsyncPublisher}, {@link AsyncListener}
      */
     public static final int ASYNC_ANNOTATION = 2;
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListener.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListener.java
@@ -8,7 +8,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * {@code @AsyncSubscriber} is a method-level annotation to document springwolf listeners.
+ * {@code @AsyncListener} is a method-level annotation to document springwolf listeners.
+ * Listeners in this context are methods that receive and process incoming data from a message broker.
  * To document producers, use {@link AsyncPublisher}.
  * <p>
  * The fields channel, description, payload and headers are part of {@link AsyncOperation}
@@ -19,7 +20,7 @@ import java.lang.annotation.Target;
  * Add an operation binding with one of the protocol specific operation binding annotation ({@code AmqpAsyncOperationBinding}, {@code KafkaAsyncOperationBinding}) on the same method.
  * <pre class="code">
  *     &#064;KafkaListener
- *     &#064;AsyncSubscriber(operation = &#064;AsyncOperation(
+ *     &#064;AsyncListener(operation = &#064;AsyncOperation(
  *             channelName = "topic-name",
  *             ...
  *     ))
@@ -29,7 +30,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})
-public @interface AsyncSubscriber {
+public @interface AsyncListener {
     /**
      * Mapped to {@link OperationData}
      */

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
@@ -25,7 +25,7 @@ import static java.util.stream.Collectors.toSet;
 @RequiredArgsConstructor
 @Component
 @Order(value = ChannelPriority.ASYNC_ANNOTATION)
-public class AsyncSubscriberAnnotationScanner extends AbstractOperationDataScanner implements EmbeddedValueResolverAware {
+public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner implements EmbeddedValueResolverAware {
     private StringValueResolver resolver;
     private final ComponentClassScanner componentClassScanner;
     private final SchemasService schemasService;
@@ -52,7 +52,7 @@ public class AsyncSubscriberAnnotationScanner extends AbstractOperationDataScann
     }
 
     private Set<Method> getAnnotatedMethods(Class<?> type) {
-        Class<AsyncSubscriber> annotationClass = AsyncSubscriber.class;
+        Class<AsyncListener> annotationClass = AsyncListener.class;
         log.debug("Scanning class \"{}\" for @\"{}\" annotated methods", type.getName(), annotationClass.getName());
 
         return Arrays.stream(type.getDeclaredMethods())
@@ -65,8 +65,8 @@ public class AsyncSubscriberAnnotationScanner extends AbstractOperationDataScann
 
         Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processBindingFromAnnotation(method, operationBindingProcessors);
 
-        Class<AsyncSubscriber> annotationClass = AsyncSubscriber.class;
-        AsyncSubscriber annotation = Optional.of(method.getAnnotation(annotationClass))
+        Class<AsyncListener> annotationClass = AsyncListener.class;
+        AsyncListener annotation = Optional.of(method.getAnnotation(annotationClass))
                 .orElseThrow(() -> new IllegalArgumentException("Method must be annotated with " + annotationClass.getName()));
 
         AsyncOperation op = annotation.operation();

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisher.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisher.java
@@ -9,7 +9,8 @@ import java.lang.annotation.Target;
 
 /**
  * {@code @AsyncPublisher} is a method-level annotation to document springwolf publishers.
- * To document listeners, use {@link AsyncSubscriber}.
+ * Publishers in this context are methods that send a message to a message broker.
+ * To document listeners, use {@link AsyncListener}.
  * <p>
  * The fields channel, description, payload and headers are part of {@link AsyncOperation}
  * and behaves identical to {@link io.github.stavshamir.springwolf.asyncapi.types.ProducerData}.

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/OperationBindingProcessor.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/OperationBindingProcessor.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 public interface OperationBindingProcessor {
 
     /**
-     * Process the methods annotated with {@link AsyncPublisher} and {@link AsyncSubscriber}
+     * Process the methods annotated with {@link AsyncPublisher} and {@link AsyncListener}
      * for protocol specific operationBinding annotations, method parameters, etc
      *
      * @param method The method being annotated

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
@@ -29,12 +29,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes = {AsyncSubscriberAnnotationScanner.class, DefaultSchemasService.class, TestOperationBindingProcessor.class})
+@ContextConfiguration(classes = {AsyncListenerAnnotationScanner.class, DefaultSchemasService.class, TestOperationBindingProcessor.class})
 @TestPropertySource(properties = {"test.property.test-channel=test-channel", "test.property.description=description"})
-public class AsyncSubscriberAnnotationScannerTest {
+public class AsyncListenerAnnotationScannerTest {
 
     @Autowired
-    private AsyncSubscriberAnnotationScanner channelScanner;
+    private AsyncListenerAnnotationScanner channelScanner;
 
     @MockBean
     private ComponentClassScanner componentClassScanner;
@@ -46,7 +46,7 @@ public class AsyncSubscriberAnnotationScannerTest {
 
     @Test
     public void scan_componentHasNoListenerMethods() {
-        setClassToScan(ClassWithoutSubscriberAnnotation.class);
+        setClassToScan(ClassWithoutListenerAnnotation.class);
 
         Map<String, ChannelItem> channels = channelScanner.scan();
 
@@ -56,7 +56,7 @@ public class AsyncSubscriberAnnotationScannerTest {
 
     @Test
     public void scan_componentHasListenerMethod() {
-        // Given a class with methods annotated with AsyncSubscriber, where only the channel-name is set
+        // Given a class with methods annotated with AsyncListener, where only the channel-name is set
         setClassToScan(ClassWithListenerAnnotation.class);
 
         // When scan is called
@@ -89,7 +89,7 @@ public class AsyncSubscriberAnnotationScannerTest {
 
     @Test
     public void scan_componentHasListenerMethodWithAllAttributes() {
-        // Given a class with method annotated with AsyncSubscriber, where all attributes are set
+        // Given a class with method annotated with AsyncListener, where all attributes are set
         setClassToScan(ClassWithListenerAnnotationWithAllAttributes.class);
 
         // When scan is called
@@ -121,7 +121,7 @@ public class AsyncSubscriberAnnotationScannerTest {
     }
 
 
-    private static class ClassWithoutSubscriberAnnotation {
+    private static class ClassWithoutListenerAnnotation {
 
         private void methodWithoutAnnotation() {
         }
@@ -129,7 +129,7 @@ public class AsyncSubscriberAnnotationScannerTest {
 
     private static class ClassWithListenerAnnotation {
 
-        @AsyncSubscriber(operation = @AsyncOperation(
+        @AsyncListener(operation = @AsyncOperation(
                 channelName = "test-channel"
         ))
         private void methodWithAnnotation(SimpleFoo payload) {
@@ -142,7 +142,7 @@ public class AsyncSubscriberAnnotationScannerTest {
 
     private static class ClassWithListenerAnnotationWithAllAttributes {
 
-        @AsyncSubscriber(operation = @AsyncOperation(
+        @AsyncListener(operation = @AsyncOperation(
                 channelName = "${test.property.test-channel}",
                 description = "${test.property.description}",
                 headers = @AsyncOperation.Headers(

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
@@ -4,6 +4,8 @@ import com.asyncapi.v2.model.info.Contact;
 import com.asyncapi.v2.model.info.Info;
 import com.asyncapi.v2.model.info.License;
 import com.asyncapi.v2.model.server.Server;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncListener;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
 import io.github.stavshamir.springwolf.asyncapi.types.AmqpConsumerData;
 import io.github.stavshamir.springwolf.asyncapi.types.AmqpProducerData;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
@@ -32,8 +34,8 @@ public class AsyncApiConfiguration {
      * This bean is only required if full control on the {@link AsyncApiDocket} is needed
      * <p>
      * By default, Springwolf uses the {@see Info} provided in the application.properties
-     * Consumers are detected when the @RabbitListener or @AsyncSubscriber annotation is used
-     * Producers are detected when the springwolf @AsyncPublisher annotation is used
+     * Consumers are detected when the @RabbitListener or {@link AsyncListener} annotation is used
+     * Producers are detected when the springwolf {@link AsyncPublisher} annotation is used
      */
     @Bean
     @ConditionalOnProperty(value = "customAsyncApiDocketBean", havingValue = "true", matchIfMissing = true)

--- a/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
@@ -4,6 +4,8 @@ import com.asyncapi.v2.model.info.Contact;
 import com.asyncapi.v2.model.info.Info;
 import com.asyncapi.v2.model.info.License;
 import com.asyncapi.v2.model.server.Server;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncListener;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
 import io.github.stavshamir.springwolf.configuration.EnableAsyncApi;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,8 +27,8 @@ public class AsyncApiConfiguration {
      * This bean is only required if full control on the {@link AsyncApiDocket} is needed
      * <p>
      * By default, Springwolf uses the {@see Info} provided in the application.properties
-     * Consumers are detected when the @KafkaListener or @AsyncSubscriber annotation is used
-     * Producers are detected when the springwolf @AsyncPublisher annotation is used
+     * Consumers are detected when the @KafkaListener or {@link AsyncListener} annotation is used
+     * Producers are detected when the springwolf {@link AsyncPublisher} annotation is used
      */
     @Bean
     @ConditionalOnProperty(value = "customAsyncApiDocketBean", havingValue = "true", matchIfMissing = true)

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
@@ -4,6 +4,8 @@ import com.asyncapi.v2.model.info.Contact;
 import com.asyncapi.v2.model.info.Info;
 import com.asyncapi.v2.model.info.License;
 import com.asyncapi.v2.model.server.Server;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncListener;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
 import io.github.stavshamir.springwolf.asyncapi.types.KafkaConsumerData;
 import io.github.stavshamir.springwolf.asyncapi.types.KafkaProducerData;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
@@ -35,8 +37,8 @@ public class AsyncApiConfiguration {
      * This bean is only required if full control on the {@link AsyncApiDocket} is needed
      * <p>
      * By default, Springwolf uses the {@see Info} provided in the application.properties
-     * Consumers are detected when the @KafkaListener or @AsyncSubscriber annotation is used
-     * Producers are detected when the springwolf @AsyncPublisher annotation is used
+     * Consumers are detected when the @KafkaListener or {@link AsyncListener} annotation is used
+     * Producers are detected when the springwolf {@link AsyncPublisher} annotation is used
      */
     @Bean
     @ConditionalOnProperty(value = "customAsyncApiDocketBean", havingValue = "true", matchIfMissing = true)

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/consumers/ExampleClassLevelKafkaListener.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/consumers/ExampleClassLevelKafkaListener.java
@@ -1,7 +1,7 @@
 package io.github.stavshamir.springwolf.example.consumers;
 
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
-import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncSubscriber;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncListener;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding;
 import io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto;
 import io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto;
@@ -33,9 +33,9 @@ public class ExampleClassLevelKafkaListener {
     }
 
     @KafkaHandler
-    @AsyncSubscriber(operation = @AsyncOperation(
+    @AsyncListener(operation = @AsyncOperation(
             channelName = "multi-payload-topic",
-            description = "Override description in the AsyncSubscriber annotation with servers at ${kafka.bootstrap.servers}",
+            description = "Override description in the AsyncListener annotation with servers at ${kafka.bootstrap.servers}",
             headers = @AsyncOperation.Headers(
                     schemaName = "SpringKafkaDefaultHeaders-MonetaryAmount",
                     values = {

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -161,7 +161,7 @@
           }, {
             "name" : "javax.money.MonetaryAmount",
             "title" : "MonetaryAmount",
-            "description" : "Override description in the AsyncSubscriber annotation with servers at kafka:29092",
+            "description" : "Override description in the AsyncListener annotation with servers at kafka:29092",
             "payload" : {
               "$ref" : "#/components/schemas/MonetaryAmount"
             },

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AmqpAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AmqpAsyncOperationBinding.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * {@code @AmqpAsyncOperationBinding} is a method-level annotation used in combination with {@link AsyncPublisher} or {@link AsyncSubscriber}.
+ * {@code @AmqpAsyncOperationBinding} is a method-level annotation used in combination with {@link AsyncPublisher} or {@link AsyncListener}.
  * It configures the operation binding for the AMQP protocol.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/KafkaAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/KafkaAsyncOperationBinding.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * {@code @KafkaAsyncOperationBinding} is a method-level annotation used in combination with {@link AsyncPublisher} or @{@link AsyncSubscriber}.
+ * {@code @KafkaAsyncOperationBinding} is a method-level annotation used in combination with {@link AsyncPublisher} or @{@link AsyncListener}.
  * It configures the operation binding for the Kafka protocol.
  */
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
Follows the naming of spring (listeners and publisher) Intention is to avoid confusion with the reversed naming in asyncApi, where
- AsyncApi Publisher = Spring Listener
- AsyncApi Subscriber = Spring Publisher