### PR TITLE
Fix: Remove that EqualsAndHashCode of Message only uses the name, Cha…

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
@@ -4,10 +4,11 @@ import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -32,7 +33,7 @@ public class MessageHelper {
             case 1:
                 return messages.toArray()[0];
             default:
-                return ImmutableMap.of(ONE_OF, new HashSet<>(messages.stream().collect(Collectors.toCollection(messageSupplier))));
+                return ImmutableMap.of(ONE_OF, new ArrayList<>(messages.stream().collect(Collectors.toCollection(messageSupplier))));
         }
     }
 
@@ -43,12 +44,11 @@ public class MessageHelper {
         }
 
         if (messageObject instanceof Map) {
-            Set<Message> messages = ((Map<String, Set<Message>>) messageObject).get(ONE_OF);
+            List<Message> messages = ((Map<String, List<Message>>) messageObject).get(ONE_OF);
             return new HashSet<>(messages);
         }
 
         log.warn("Message object must contain either a Message or a Map<String, Set<Message>, but contained: {}", messageObject.getClass());
         return new HashSet<>();
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
@@ -10,7 +10,8 @@ import lombok.*;
  */
 @Data
 @Builder
-@EqualsAndHashCode(of = {"name"})
+// TODO Why ignore other fields?
+//@EqualsAndHashCode(of = {"name"})
 @NoArgsConstructor
 @AllArgsConstructor
 public class Message {

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
@@ -54,6 +54,60 @@ public class MessageHelperTest {
     }
 
     @Test
+    public void toMessageObjectOrComposition_multipleMessages_remove_duplicates() {
+        Message message1 = Message.builder()
+                .name("foo")
+                .description("This is message 1")
+                .build();
+
+        Message message2 = Message.builder()
+                .name("bar")
+                .description("This is message 2")
+                .build();
+
+        Message message3 = Message.builder()
+                .name("bar")
+                .description("This is message 3, but in essence the same payload type as message 2")
+                .build();
+
+        Object asObject = toMessageObjectOrComposition(ImmutableSet.of(message1, message2, message3));
+
+        // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
+        assertThat(asObject)
+                .isInstanceOf(Map.class)
+                .isEqualTo(ImmutableMap.of("oneOf", ImmutableSet.of(message1, message2)));
+    }
+
+    @Test
+    public void toMessageObjectOrComposition_multipleMessages_should_not_break_deep_equals() {
+        Message actualMessage1 = Message.builder()
+                .name("foo")
+                .description("This is actual message 1")
+                .build();
+
+        Message actualMessage2 = Message.builder()
+                .name("bar")
+                .description("This is actual message 2")
+                .build();
+
+        Object actualObject = toMessageObjectOrComposition(ImmutableSet.of(actualMessage1, actualMessage2));
+
+        Message expectedMessage1 = Message.builder()
+                .name("foo")
+                .description("This is expected message 1")
+                .build();
+
+        Message expectedMessage2 = Message.builder()
+                .name("bar")
+                .description("This is expected message 2")
+                .build();
+
+        Object expectedObject = toMessageObjectOrComposition(ImmutableSet.of(expectedMessage1, expectedMessage2));
+
+        assertThat(actualObject).isNotEqualTo(expectedObject);
+    }
+
+    @Test
     public void messageObjectToSet_notAMessageOrAMap() {
         Object string = "foo";
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
@@ -1,5 +1,6 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
@@ -50,7 +51,7 @@ public class MessageHelperTest {
 
         assertThat(asObject)
                 .isInstanceOf(Map.class)
-                .isEqualTo(ImmutableMap.of("oneOf", ImmutableSet.of(message1, message2)));
+                .isEqualTo(ImmutableMap.of("oneOf", ImmutableList.of(message2, message1)));
     }
 
     @Test
@@ -75,7 +76,7 @@ public class MessageHelperTest {
         // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
         assertThat(asObject)
                 .isInstanceOf(Map.class)
-                .isEqualTo(ImmutableMap.of("oneOf", ImmutableSet.of(message1, message2)));
+                .isEqualTo(ImmutableMap.of("oneOf", ImmutableList.of(message2, message1)));
     }
 
     @Test

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
@@ -16,7 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ChannelMergerTest {
 
-
     @Test
     public void shouldNotMergeDifferentChannelNames() {
         // given
@@ -110,8 +109,7 @@ public class ChannelMergerTest {
 
         // then expectedMessage only includes message1 and message2.
         // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
-        // TODO Is it really expected that the first occurrence is used? (no test in Message Helper...)
-        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message3));
+        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message2));
         assertThat(mergedChannels).hasSize(1)
                 .hasEntrySatisfying(channelName, it -> {
                     assertThat(it.getPublish()).isEqualTo(Operation.builder().operationId("publisher1").message(expectedMessages).build());

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
@@ -110,7 +110,8 @@ public class ChannelMergerTest {
 
         // then expectedMessage only includes message1 and message2.
         // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
-        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message2));
+        // TODO Is it really expected that the first occurrence is used? (no test in Message Helper...)
+        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message3));
         assertThat(mergedChannels).hasSize(1)
                 .hasEntrySatisfying(channelName, it -> {
                     assertThat(it.getPublish()).isEqualTo(Operation.builder().operationId("publisher1").message(expectedMessages).build());

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
@@ -66,7 +66,7 @@ public class AsyncPublisherAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                .description(null)
+                .description("")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
                 .build();

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncSubscriberAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncSubscriberAnnotationScannerTest.java
@@ -66,7 +66,7 @@ public class AsyncSubscriberAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                .description(null)
+                .description("")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
                 .build();

--- a/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScannerTest.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScannerTest.java
@@ -77,12 +77,14 @@ public class ClassLevelKafkaListenerScannerTest extends TestCase {
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleFoo.class.getSimpleName()))
                 .build();
 
         Message barMessage = Message.builder()
                 .name(SimpleBar.class.getName())
                 .title(SimpleBar.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleBar.class.getSimpleName()))
+                .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleBar.class.getSimpleName()))
                 .build();
 
         Operation operation = Operation.builder()


### PR DESCRIPTION
…nge MessageHelper to not expose the TreeSet that is used for deduplication because a TreeSet breaks equals