### PR TITLE
Feature/add support for message binding

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
@@ -4,10 +4,11 @@ import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -32,7 +33,7 @@ public class MessageHelper {
             case 1:
                 return messages.toArray()[0];
             default:
-                return ImmutableMap.of(ONE_OF, new HashSet<>(messages.stream().collect(Collectors.toCollection(messageSupplier))));
+                return ImmutableMap.of(ONE_OF, new ArrayList<>(messages.stream().collect(Collectors.toCollection(messageSupplier))));
         }
     }
 
@@ -43,12 +44,11 @@ public class MessageHelper {
         }
 
         if (messageObject instanceof Map) {
-            Set<Message> messages = ((Map<String, Set<Message>>) messageObject).get(ONE_OF);
+            List<Message> messages = ((Map<String, List<Message>>) messageObject).get(ONE_OF);
             return new HashSet<>(messages);
         }
 
         log.warn("Message object must contain either a Message or a Map<String, Set<Message>, but contained: {}", messageObject.getClass());
         return new HashSet<>();
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
@@ -21,9 +21,6 @@ public class MessageHelper {
 
     private static final Comparator<Message> byMessageName = Comparator.comparing(Message::getName);
 
-    // TODO Why do we need a SortedSet here? Using a comparator with only the message name will break deep equals on the Set
-    // Unfortunately there are Tests relying on deep equals
-    // see https://docs.oracle.com/javase/7/docs/api/java/util/TreeSet.html
     private static final Supplier<Set<Message>> messageSupplier = () -> new TreeSet<>(byMessageName);
 
     public static Object toMessageObjectOrComposition(Set<Message> messages) {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/controller/dtos/MessageDto.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/controller/dtos/MessageDto.java
@@ -1,4 +1,4 @@
-package io.github.stavshamir.springwolf.asyncapi.dtos;
+package io.github.stavshamir.springwolf.asyncapi.controller.dtos;
 
 import lombok.Builder;
 import lombok.Data;
@@ -6,14 +6,14 @@ import lombok.extern.jackson.Jacksonized;
 
 import java.util.Map;
 
-
 @Data
 @Builder
 @Jacksonized
-public class KafkaMessageDto {
+public class MessageDto {
+
+    private final Map<String, String> bindings;
 
     private final Map<String, String> headers;
 
     private final Map<String, ?> payload;
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AbstractClassLevelListenerScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AbstractClassLevelListenerScanner.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import com.asyncapi.v2.binding.ChannelBinding;
+import com.asyncapi.v2.binding.MessageBinding;
 import com.asyncapi.v2.binding.OperationBinding;
 import com.asyncapi.v2.model.channel.ChannelItem;
 import com.asyncapi.v2.model.channel.operation.Operation;
@@ -18,7 +19,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -66,12 +73,18 @@ public abstract class AbstractClassLevelListenerScanner<ClassAnnotation extends 
 
     /**
      * @param annotation An instance of a listener annotation.
-     * @return A map containing an channel binding pointed to by the protocol binding name.
+     * @return A map containing a channel binding pointed to by the protocol binding name.
      */
     protected abstract Map<String, ? extends ChannelBinding> buildChannelBinding(ClassAnnotation annotation);
 
     /**
-     * Can be overriden by implementations
+     * @param method The specific method. Can be used to extract message binding from an annotation.
+     * @return A map containing a message binding pointed to by the protocol binding name.
+     */
+    protected abstract Map<String, ? extends MessageBinding> buildMessageBinding(Method method);
+
+    /**
+     * Can be overridden by implementations
      *
      * @param method The specific method. Can be used to extract the payload type
      * @return The AsyncHeaders
@@ -159,6 +172,7 @@ public abstract class AbstractClassLevelListenerScanner<ClassAnnotation extends 
                 .title(modelName)
                 .payload(PayloadReference.fromModelName(modelName))
                 .headers(HeaderReference.fromModelName(headerModelName))
+                .bindings(buildMessageBinding(method))
                 .build();
     }
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
@@ -99,6 +99,7 @@ public abstract class AbstractOperationDataScanner implements ChannelsScanner {
                 .description(operationData.getDescription())
                 .payload(PayloadReference.fromModelName(modelName))
                 .headers(HeaderReference.fromModelName(headerModelName))
+                .bindings(operationData.getMessageBinding())
                 .build();
     }
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProcessedMessageBinding.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProcessedMessageBinding.java
@@ -1,0 +1,10 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata;
+
+import com.asyncapi.v2.binding.MessageBinding;
+import lombok.Data;
+
+@Data
+public class ProcessedMessageBinding {
+    private final String type;
+    private final MessageBinding binding;
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtil.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtil.java
@@ -1,6 +1,8 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
 
+import com.asyncapi.v2.binding.MessageBinding;
 import com.asyncapi.v2.binding.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProcessedMessageBinding;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProcessedOperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaderSchema;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
@@ -59,11 +61,19 @@ class AsyncAnnotationScannerUtil {
                 .orElse(null);
     }
 
-    public static Map<String, OperationBinding> processBindingFromAnnotation(Method method, List<OperationBindingProcessor> operationBindingProcessors) {
+    public static Map<String, OperationBinding> processOperationBindingFromAnnotation(Method method, List<OperationBindingProcessor> operationBindingProcessors) {
         return operationBindingProcessors.stream()
                 .map(operationBindingProcessor -> operationBindingProcessor.process(method))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toMap(ProcessedOperationBinding::getType, ProcessedOperationBinding::getBinding));
+    }
+
+    public static Map<String, MessageBinding> processMessageBindingFromAnnotation(Method method, List<MessageBindingProcessor> messageBindingProcessors) {
+        return messageBindingProcessors.stream()
+                .map(messageBindingProcessor -> messageBindingProcessor.process(method))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toMap(ProcessedMessageBinding::getType, ProcessedMessageBinding::getBinding));
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
@@ -1,5 +1,6 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
 
+import com.asyncapi.v2.binding.MessageBinding;
 import com.asyncapi.v2.binding.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.SpringPayloadAnnotationTypeExtractor;
@@ -32,6 +33,8 @@ public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner
 
     private final List<OperationBindingProcessor> operationBindingProcessors;
 
+    private final List<MessageBindingProcessor> messageBindingProcessors;
+
     @Override
     public void setEmbeddedValueResolver(StringValueResolver resolver) {
         this.resolver = resolver;
@@ -63,7 +66,8 @@ public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner
     private OperationData mapMethodToOperationData(Method method) {
         log.debug("Mapping method \"{}\" to channels", method.getName());
 
-        Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processBindingFromAnnotation(method, operationBindingProcessors);
+        Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processOperationBindingFromAnnotation(method, operationBindingProcessors);
+        Map<String, MessageBinding> messageBindings = AsyncAnnotationScannerUtil.processMessageBindingFromAnnotation(method, messageBindingProcessors);
 
         Class<AsyncListener> annotationClass = AsyncListener.class;
         AsyncListener annotation = Optional.of(method.getAnnotation(annotationClass))
@@ -78,6 +82,7 @@ public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner
                 .headers(AsyncAnnotationScannerUtil.getAsyncHeaders(op))
                 .payloadType(payloadType)
                 .operationBinding(operationBindings)
+                .messageBinding(messageBindings)
                 .build();
     }
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
@@ -1,5 +1,6 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
 
+import com.asyncapi.v2.binding.MessageBinding;
 import com.asyncapi.v2.binding.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.SpringPayloadAnnotationTypeExtractor;
@@ -32,6 +33,8 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
 
     private final List<OperationBindingProcessor> operationBindingProcessors;
 
+    private final List<MessageBindingProcessor> messageBindingProcessors;
+
     @Override
     public void setEmbeddedValueResolver(StringValueResolver resolver) {
         this.resolver = resolver;
@@ -63,7 +66,8 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
     private OperationData mapMethodToOperationData(Method method) {
         log.debug("Mapping method \"{}\" to channels", method.getName());
 
-        Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processBindingFromAnnotation(method, operationBindingProcessors);
+        Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processOperationBindingFromAnnotation(method, operationBindingProcessors);
+        Map<String, MessageBinding> messageBindings = AsyncAnnotationScannerUtil.processMessageBindingFromAnnotation(method, messageBindingProcessors);
 
         Class<AsyncPublisher> annotationClass = AsyncPublisher.class;
         AsyncPublisher annotation = Optional.of(method.getAnnotation(annotationClass))
@@ -78,6 +82,7 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
                 .headers(AsyncAnnotationScannerUtil.getAsyncHeaders(op))
                 .payloadType(payloadType)
                 .operationBinding(operationBindings)
+                .messageBinding(messageBindings)
                 .build();
     }
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/MessageBindingProcessor.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/MessageBindingProcessor.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 public interface MessageBindingProcessor {
 
     /**
-     * Process the methods annotated with {@link AsyncPublisher} and {@link AsyncSubscriber}
+     * Process the methods annotated with {@link AsyncPublisher} and {@link AsyncListener}
      * for protocol specific messageBinding annotations, method parameters, etc
      *
      * @param method The method being annotated

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/MessageBindingProcessor.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/MessageBindingProcessor.java
@@ -1,0 +1,18 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProcessedMessageBinding;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public interface MessageBindingProcessor {
+
+    /**
+     * Process the methods annotated with {@link AsyncPublisher} and {@link AsyncSubscriber}
+     * for protocol specific messageBinding annotations, method parameters, etc
+     *
+     * @param method The method being annotated
+     * @return A message binding, if found
+     */
+    Optional<ProcessedMessageBinding> process(Method method);
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ConsumerData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ConsumerData.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.types;
 
 import com.asyncapi.v2.binding.ChannelBinding;
+import com.asyncapi.v2.binding.MessageBinding;
 import com.asyncapi.v2.binding.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import lombok.AllArgsConstructor;
@@ -61,4 +62,13 @@ public class ConsumerData implements OperationData {
      */
     protected Map<String, ? extends OperationBinding> operationBinding;
 
+    /**
+     * The message binding of the consumer.
+     * <br>
+     * For example:
+     * <code>
+     *     ImmutableMap.of("kafka", new KafkaMessageBinding())
+     * </code>
+     */
+    protected Map<String, ? extends MessageBinding> messageBinding;
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/OperationData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/OperationData.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.types;
 
 import com.asyncapi.v2.binding.ChannelBinding;
+import com.asyncapi.v2.binding.MessageBinding;
 import com.asyncapi.v2.binding.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 
@@ -40,10 +41,16 @@ public interface OperationData {
      */
     Map<String, ? extends OperationBinding> getOperationBinding();
 
+    /**
+     * The message binding.
+     */
+    Map<String, ? extends MessageBinding> getMessageBinding();
+
     enum OperationType {
         PUBLISH("publish"), SUBSCRIBE("subscribe");
 
         public final String operationName;
+
         OperationType(String operationName) {
             this.operationName = operationName;
         }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ProducerData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ProducerData.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.types;
 
 import com.asyncapi.v2.binding.ChannelBinding;
+import com.asyncapi.v2.binding.MessageBinding;
 import com.asyncapi.v2.binding.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import lombok.AllArgsConstructor;
@@ -60,5 +61,15 @@ public class ProducerData implements OperationData {
      * </code>
      */
     protected Map<String, ? extends OperationBinding> operationBinding;
+
+    /**
+     * The message binding of the producer.
+     * <br>
+     * For example:
+     * <code>
+     *     ImmutableMap.of("kafka", new KafkaMessageBinding())
+     * </code>
+     */
+    protected Map<String, ? extends MessageBinding> messageBinding;
 
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
@@ -1,7 +1,10 @@
 package io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message;
 
+import com.asyncapi.v2.binding.MessageBinding;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.HeaderReference;
 import lombok.*;
+
+import java.util.Map;
 
 /**
  * Describes a message received on a given channel and operation.
@@ -34,4 +37,6 @@ public class Message {
     private PayloadReference payload;
 
     private HeaderReference headers;
+
+    private Map<String, ? extends MessageBinding> bindings;
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
@@ -10,7 +10,8 @@ import lombok.*;
  */
 @Data
 @Builder
-@EqualsAndHashCode(of = {"name"})
+// TODO Why ignore other fields?
+//@EqualsAndHashCode(of = {"name"})
 @NoArgsConstructor
 @AllArgsConstructor
 public class Message {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
@@ -13,8 +13,6 @@ import java.util.Map;
  */
 @Data
 @Builder
-// TODO Why ignore other fields?
-//@EqualsAndHashCode(of = {"name"})
 @NoArgsConstructor
 @AllArgsConstructor
 public class Message {

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerServiceTest.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
 import com.asyncapi.v2.binding.OperationBinding;
+import com.asyncapi.v2.binding.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
 import com.asyncapi.v2.model.channel.ChannelItem;
 import com.asyncapi.v2.model.channel.operation.Operation;
@@ -15,6 +16,7 @@ import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import lombok.Data;
 import org.apache.commons.io.IOUtils;
 import org.json.JSONException;
@@ -67,6 +69,7 @@ public class DefaultAsyncApiSerializerServiceTest {
                 .name("io.github.stavshamir.springwolf.ExamplePayload")
                 .title("Example Payload")
                 .payload(PayloadReference.fromModelName("ExamplePayload"))
+                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding(new StringSchema(), "binding-version-1")))
                 .build();
 
         OperationBinding operationBinding = KafkaOperationBinding.builder().groupId("myGroupId").build();

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
@@ -1,5 +1,6 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
+import com.asyncapi.v2.binding.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
 import com.asyncapi.v2.model.channel.ChannelItem;
 import com.asyncapi.v2.model.info.Info;
@@ -53,13 +54,16 @@ public class DefaultAsyncApiServiceTest {
                     .description("producer-topic-description")
                     .payloadType(String.class)
                     .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                    .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                     .build();
 
             ConsumerData kafkaConsumerData = ConsumerData.builder()
                     .channelName("consumer-topic")
                     .description("consumer-topic-description")
                     .payloadType(String.class)
-                    .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding())).build();
+                    .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                    .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                    .build();
 
             return AsyncApiDocket.builder()
                     .info(info)
@@ -106,6 +110,7 @@ public class DefaultAsyncApiServiceTest {
         assertThat(channel.getSubscribe()).isNotNull();
         final Message message = (Message) channel.getSubscribe().getMessage();
         assertThat(message.getDescription()).isEqualTo("producer-topic-description");
+        assertThat(message.getBindings()).isEqualTo(ImmutableMap.of("kafka", new KafkaMessageBinding()));
     }
 
     @Test
@@ -120,6 +125,7 @@ public class DefaultAsyncApiServiceTest {
         assertThat(channel.getPublish()).isNotNull();
         final Message message = (Message) channel.getPublish().getMessage();
         assertThat(message.getDescription()).isEqualTo("consumer-topic-description");
+        assertThat(message.getBindings()).isEqualTo(ImmutableMap.of("kafka", new KafkaMessageBinding()));
     }
 
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
@@ -54,6 +54,60 @@ public class MessageHelperTest {
     }
 
     @Test
+    public void toMessageObjectOrComposition_multipleMessages_remove_duplicates() {
+        Message message1 = Message.builder()
+                .name("foo")
+                .description("This is message 1")
+                .build();
+
+        Message message2 = Message.builder()
+                .name("bar")
+                .description("This is message 2")
+                .build();
+
+        Message message3 = Message.builder()
+                .name("bar")
+                .description("This is message 3, but in essence the same payload type as message 2")
+                .build();
+
+        Object asObject = toMessageObjectOrComposition(ImmutableSet.of(message1, message2, message3));
+
+        // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
+        assertThat(asObject)
+                .isInstanceOf(Map.class)
+                .isEqualTo(ImmutableMap.of("oneOf", ImmutableSet.of(message1, message2)));
+    }
+
+    @Test
+    public void toMessageObjectOrComposition_multipleMessages_should_not_break_deep_equals() {
+        Message actualMessage1 = Message.builder()
+                .name("foo")
+                .description("This is actual message 1")
+                .build();
+
+        Message actualMessage2 = Message.builder()
+                .name("bar")
+                .description("This is actual message 2")
+                .build();
+
+        Object actualObject = toMessageObjectOrComposition(ImmutableSet.of(actualMessage1, actualMessage2));
+
+        Message expectedMessage1 = Message.builder()
+                .name("foo")
+                .description("This is expected message 1")
+                .build();
+
+        Message expectedMessage2 = Message.builder()
+                .name("bar")
+                .description("This is expected message 2")
+                .build();
+
+        Object expectedObject = toMessageObjectOrComposition(ImmutableSet.of(expectedMessage1, expectedMessage2));
+
+        assertThat(actualObject).isNotEqualTo(expectedObject);
+    }
+
+    @Test
     public void messageObjectToSet_notAMessageOrAMap() {
         Object string = "foo";
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
@@ -1,5 +1,6 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
@@ -50,7 +51,7 @@ public class MessageHelperTest {
 
         assertThat(asObject)
                 .isInstanceOf(Map.class)
-                .isEqualTo(ImmutableMap.of("oneOf", ImmutableSet.of(message1, message2)));
+                .isEqualTo(ImmutableMap.of("oneOf", ImmutableList.of(message2, message1)));
     }
 
     @Test
@@ -75,7 +76,7 @@ public class MessageHelperTest {
         // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
         assertThat(asObject)
                 .isInstanceOf(Map.class)
-                .isEqualTo(ImmutableMap.of("oneOf", ImmutableSet.of(message1, message2)));
+                .isEqualTo(ImmutableMap.of("oneOf", ImmutableList.of(message2, message1)));
     }
 
     @Test

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/dtos/MessageDtoDeserializationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/dtos/MessageDtoDeserializationTest.java
@@ -1,4 +1,4 @@
-package io.github.stavshamir.springwolf.asyncapi.dtos;
+package io.github.stavshamir.springwolf.asyncapi.controller.dtos;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -8,13 +8,13 @@ import java.io.IOException;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class KafkaMessageDtoDeserializationTest {
+public class MessageDtoDeserializationTest {
 
     @Test
     public void testCanBeSerialized() throws IOException {
         String content = "{\"headers\": { \"some-header-key\" : \"some-header-value\" }, \"payload\": { \"some-payload-key\" : \"some-payload-value\" }}";
 
-        KafkaMessageDto value = new ObjectMapper().readValue(content, KafkaMessageDto.class);
+        MessageDto value = new ObjectMapper().readValue(content, MessageDto.class);
 
         assertThat(value).isNotNull();
         assertThat(value.getHeaders()).isEqualTo(singletonMap("some-header-key", "some-header-value"));

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
@@ -16,7 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ChannelMergerTest {
 
-
     @Test
     public void shouldNotMergeDifferentChannelNames() {
         // given
@@ -110,8 +109,7 @@ public class ChannelMergerTest {
 
         // then expectedMessage only includes message1 and message2.
         // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
-        // TODO Is it really expected that the first occurrence is used? (no test in Message Helper...)
-        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message3));
+        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message2));
         assertThat(mergedChannels).hasSize(1)
                 .hasEntrySatisfying(channelName, it -> {
                     assertThat(it.getPublish()).isEqualTo(Operation.builder().operationId("publisher1").message(expectedMessages).build());

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
@@ -110,7 +110,8 @@ public class ChannelMergerTest {
 
         // then expectedMessage only includes message1 and message2.
         // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
-        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message2));
+        // TODO Is it really expected that the first occurrence is used? (no test in Message Helper...)
+        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message3));
         assertThat(mergedChannels).hasSize(1)
                 .hasEntrySatisfying(channelName, it -> {
                     assertThat(it.getPublish()).isEqualTo(Operation.builder().operationId("publisher1").message(expectedMessages).build());

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/TestMethodLevelListenerScanner.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/TestMethodLevelListenerScanner.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import com.asyncapi.v2.binding.ChannelBinding;
+import com.asyncapi.v2.binding.MessageBinding;
 import com.asyncapi.v2.binding.OperationBinding;
 import com.google.common.collect.ImmutableMap;
 import lombok.EqualsAndHashCode;
@@ -31,6 +32,11 @@ public class TestMethodLevelListenerScanner extends AbstractMethodLevelListenerS
     }
 
     @Override
+    protected Map<String, ? extends MessageBinding> buildMessageBinding(TestMethodLevelListenerScannerTest.TestChannelListener annotation) {
+        return ImmutableMap.of("test-message-binding", new TestMessageBinding());
+    }
+
+    @Override
     protected Class<?> getPayloadType(Method method) {
         Class<?>[] parameterTypes = method.getParameterTypes();
         if (parameterTypes.length != 1) {
@@ -47,6 +53,10 @@ public class TestMethodLevelListenerScanner extends AbstractMethodLevelListenerS
 
     @EqualsAndHashCode(callSuper = true)
     public static class TestOperationBinding extends OperationBinding {
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    public static class TestMessageBinding extends MessageBinding {
     }
 
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/TestMethodLevelListenerScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/TestMethodLevelListenerScannerTest.java
@@ -72,6 +72,7 @@ public class TestMethodLevelListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(ImmutableMap.of("test-message-binding", new TestMethodLevelListenerScanner.TestMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerTest.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata;
 
 import com.asyncapi.v2.binding.kafka.KafkaChannelBinding;
+import com.asyncapi.v2.binding.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
 import com.asyncapi.v2.model.channel.ChannelItem;
 import com.asyncapi.v2.model.channel.operation.Operation;
@@ -51,6 +52,7 @@ public class ConsumerOperationDataScannerTest {
                 .description(description)
                 .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
                 .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .payloadType(ExamplePayloadDto.class)
                 .build();
 
@@ -73,6 +75,7 @@ public class ConsumerOperationDataScannerTest {
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                        .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                         .build())
                 .build();
 
@@ -114,6 +117,7 @@ public class ConsumerOperationDataScannerTest {
                 .description(description1)
                 .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
                 .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .payloadType(ExamplePayloadDto.class)
                 .build();
 
@@ -122,6 +126,7 @@ public class ConsumerOperationDataScannerTest {
                 .description(description2)
                 .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
                 .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .payloadType(AnotherExamplePayloadDto.class)
                 .headers(AsyncHeaders.NOT_USED)
                 .build();
@@ -143,6 +148,7 @@ public class ConsumerOperationDataScannerTest {
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                        .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                         .build(),
                 Message.builder()
                         .name(AnotherExamplePayloadDto.class.getName())
@@ -150,6 +156,7 @@ public class ConsumerOperationDataScannerTest {
                         .title(AnotherExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(AnotherExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_USED.getSchemaName()))
+                        .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                         .build()
         );
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerTest.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata;
 
 import com.asyncapi.v2.binding.kafka.KafkaChannelBinding;
+import com.asyncapi.v2.binding.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
 import com.asyncapi.v2.model.channel.ChannelItem;
 import com.asyncapi.v2.model.channel.operation.Operation;
@@ -51,6 +52,7 @@ public class ProducerOperationDataScannerTest {
                 .description(description)
                 .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
                 .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .payloadType(ExamplePayloadDto.class)
                 .build();
 
@@ -73,6 +75,7 @@ public class ProducerOperationDataScannerTest {
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                        .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                         .build())
                 .build();
 
@@ -114,6 +117,7 @@ public class ProducerOperationDataScannerTest {
                 .description(description1)
                 .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
                 .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .payloadType(ExamplePayloadDto.class)
                 .build();
 
@@ -122,6 +126,7 @@ public class ProducerOperationDataScannerTest {
                 .description(description2)
                 .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
                 .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .payloadType(AnotherExamplePayloadDto.class)
                 .headers(AsyncHeaders.NOT_USED)
                 .build();
@@ -143,6 +148,7 @@ public class ProducerOperationDataScannerTest {
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                        .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                         .build(),
                 Message.builder()
                         .name(AnotherExamplePayloadDto.class.getName())
@@ -150,6 +156,7 @@ public class ProducerOperationDataScannerTest {
                         .title(AnotherExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(AnotherExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_USED.getSchemaName()))
+                        .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                         .build()
         );
 
@@ -165,8 +172,7 @@ public class ProducerOperationDataScannerTest {
                 .subscribe(operation)
                 .build();
 
-        assertThat(producerChannels.get(channelName))
-                .isEqualTo(expectedChannel);
+        assertThat(producerChannels.get(channelName)).isEqualTo(expectedChannel);
     }
 
     private void mockProducers(Collection<ProducerData> producers) {

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
@@ -66,7 +66,7 @@ public class AsyncListenerAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                .description(null)
+                .description("")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
                 .build();

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
@@ -69,6 +69,7 @@ public class AsyncListenerAnnotationScannerTest {
                 .description("")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(EMPTY_MAP)
                 .build();
 
         Operation operation = Operation.builder()
@@ -102,6 +103,7 @@ public class AsyncListenerAnnotationScannerTest {
                 .description("description")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("TestSchema"))
+                .bindings(EMPTY_MAP)
                 .build();
 
         Operation operation = Operation.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
@@ -69,6 +69,7 @@ public class AsyncPublisherAnnotationScannerTest {
                 .description("")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(EMPTY_MAP)
                 .build();
 
         Operation operation = Operation.builder()
@@ -102,6 +103,7 @@ public class AsyncPublisherAnnotationScannerTest {
                 .description("description")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("TestSchema"))
+                .bindings(EMPTY_MAP)
                 .build();
 
         Operation operation = Operation.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
@@ -66,7 +66,7 @@ public class AsyncPublisherAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                .description(null)
+                .description("")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
                 .build();

--- a/springwolf-core/src/test/resources/asyncapi/asyncapi.json
+++ b/springwolf-core/src/test/resources/asyncapi/asyncapi.json
@@ -43,6 +43,18 @@
           "title" : "Example Payload",
           "payload" : {
             "$ref" : "#/components/schemas/ExamplePayload"
+          },
+          "bindings" : {
+            "kafka": {
+              "key": {
+                "type": "string",
+                "exampleSetFlag": false,
+                "types": [
+                  "string"
+                ]
+              },
+              "bindingVersion": "binding-version-1"
+            }
           }
         }
       }

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/consumers/ExampleClassLevelKafkaListener.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/consumers/ExampleClassLevelKafkaListener.java
@@ -3,6 +3,7 @@ package io.github.stavshamir.springwolf.example.consumers;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncListener;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding.KafkaAsyncMessageBinding;
 import io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto;
 import io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import javax.money.MonetaryAmount;
 
+import static io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding.KafkaAsyncMessageBinding.KafkaKeyTypes.STRING_KEY;
 import static org.springframework.kafka.support.mapping.AbstractJavaTypeMapper.DEFAULT_CLASSID_FIELD_NAME;
 
 
@@ -48,7 +50,12 @@ public class ExampleClassLevelKafkaListener {
     @KafkaAsyncOperationBinding(
             bindingVersion = "1",
             clientId = "foo-clientId",
-            groupId = "#{'foo-groupId'}"
+            groupId = "#{'foo-groupId'}",
+            messageBinding = @KafkaAsyncMessageBinding(
+                    keyType = STRING_KEY,
+                    bindingVersion = "1",
+                    description = "Kafka Consumer Message Key"
+            )
     )
     public void receiveMonetaryAmount(MonetaryAmount payload) {
         log.info("Received new message in multi-payload-topic: {}", payload.toString());

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/consumers/ExampleClassLevelKafkaListener.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/consumers/ExampleClassLevelKafkaListener.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 
 import javax.money.MonetaryAmount;
 
-import static io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding.KafkaAsyncMessageBinding.KafkaKeyTypes.STRING_KEY;
 import static org.springframework.kafka.support.mapping.AbstractJavaTypeMapper.DEFAULT_CLASSID_FIELD_NAME;
 
 
@@ -52,9 +51,11 @@ public class ExampleClassLevelKafkaListener {
             clientId = "foo-clientId",
             groupId = "#{'foo-groupId'}",
             messageBinding = @KafkaAsyncMessageBinding(
-                    keyType = STRING_KEY,
-                    bindingVersion = "1",
-                    description = "Kafka Consumer Message Key"
+                    key = @KafkaAsyncOperationBinding.KafkaAsyncKey(
+                            description = "Kafka Consumer Message Key",
+                            example = "example-key"
+                    ),
+                    bindingVersion = "1"
             )
     )
     public void receiveMonetaryAmount(MonetaryAmount payload) {

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/producers/ExampleProducer.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/producers/ExampleProducer.java
@@ -3,13 +3,13 @@ package io.github.stavshamir.springwolf.example.producers;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding.KafkaAsyncKey;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding.KafkaAsyncMessageBinding;
 import io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
-import static io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding.KafkaAsyncMessageBinding.KafkaKeyTypes.STRING_KEY;
 import static io.github.stavshamir.springwolf.example.configuration.KafkaConfiguration.PRODUCER_TOPIC;
 import static org.springframework.kafka.support.mapping.AbstractJavaTypeMapper.DEFAULT_CLASSID_FIELD_NAME;
 
@@ -42,9 +42,11 @@ public class ExampleProducer {
             bindingVersion = "1",
             clientId = "foo-clientId",
             messageBinding = @KafkaAsyncMessageBinding(
-                    keyType = STRING_KEY,
-                    bindingVersion = "1",
-                    description = "Kafka Producer Message Key"
+                    key = @KafkaAsyncKey(
+                            description = "Kafka Producer Message Key",
+                            example = "example-key"
+                    ),
+                    bindingVersion = "1"
             )
     )
     public void sendMessage(ExamplePayloadDto msg) {

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/producers/ExampleProducer.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/producers/ExampleProducer.java
@@ -3,11 +3,13 @@ package io.github.stavshamir.springwolf.example.producers;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding.KafkaAsyncMessageBinding;
 import io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+import static io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding.KafkaAsyncMessageBinding.KafkaKeyTypes.STRING_KEY;
 import static io.github.stavshamir.springwolf.example.configuration.KafkaConfiguration.PRODUCER_TOPIC;
 import static org.springframework.kafka.support.mapping.AbstractJavaTypeMapper.DEFAULT_CLASSID_FIELD_NAME;
 
@@ -38,7 +40,12 @@ public class ExampleProducer {
     ))
     @KafkaAsyncOperationBinding(
             bindingVersion = "1",
-            clientId = "foo-clientId"
+            clientId = "foo-clientId",
+            messageBinding = @KafkaAsyncMessageBinding(
+                    keyType = STRING_KEY,
+                    bindingVersion = "1",
+                    description = "Kafka Producer Message Key"
+            )
     )
     public void sendMessage(ExamplePayloadDto msg) {
         kafkaTemplate.send(PRODUCER_TOPIC, msg);

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -167,6 +167,17 @@
             },
             "headers" : {
               "$ref" : "#/components/schemas/SpringKafkaDefaultHeaders-MonetaryAmount"
+            },
+            "bindings" : {
+              "kafka" : {
+                "key" : {
+                  "type" : "string",
+                  "description" : "Kafka Consumer Message Key",
+                  "exampleSetFlag" : false,
+                  "types" : [ "string" ]
+                },
+                "bindingVersion" : "1"
+              }
             }
           } ]
         }

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -63,6 +63,9 @@
           },
           "headers" : {
             "$ref" : "#/components/schemas/HeadersNotDocumented"
+          },
+          "bindings" : {
+            "kafka" : { }
           }
         }
       },
@@ -87,6 +90,9 @@
             },
             "headers" : {
               "$ref" : "#/components/schemas/CloudEventHeadersForAnotherPayloadDtoEndpoint"
+            },
+            "bindings" : {
+              "kafka" : { }
             }
           }, {
             "name" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
@@ -97,6 +103,17 @@
             },
             "headers" : {
               "$ref" : "#/components/schemas/SpringKafkaDefaultHeaders"
+            },
+            "bindings" : {
+              "kafka" : {
+                "key" : {
+                  "type" : "string",
+                  "description" : "Kafka Producer Message Key",
+                  "example" : "example-key",
+                  "exampleSetFlag" : true,
+                  "types" : [ "string" ]
+                }
+              }
             }
           } ]
         }
@@ -120,6 +137,9 @@
           },
           "headers" : {
             "$ref" : "#/components/schemas/HeadersNotDocumented"
+          },
+          "bindings" : {
+            "kafka" : { }
           }
         }
       },
@@ -148,6 +168,9 @@
             },
             "headers" : {
               "$ref" : "#/components/schemas/SpringKafkaDefaultHeaders-AnotherPayloadDto"
+            },
+            "bindings" : {
+              "kafka" : { }
             }
           }, {
             "name" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
@@ -157,6 +180,9 @@
             },
             "headers" : {
               "$ref" : "#/components/schemas/SpringKafkaDefaultHeaders-ExamplePayloadDto"
+            },
+            "bindings" : {
+              "kafka" : { }
             }
           }, {
             "name" : "javax.money.MonetaryAmount",
@@ -173,7 +199,8 @@
                 "key" : {
                   "type" : "string",
                   "description" : "Kafka Consumer Message Key",
-                  "exampleSetFlag" : false,
+                  "example" : "example-key",
+                  "exampleSetFlag" : true,
                   "types" : [ "string" ]
                 },
                 "bindingVersion" : "1"

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/SpringwolfAmqpController.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/SpringwolfAmqpController.java
@@ -1,14 +1,17 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
+import io.github.stavshamir.springwolf.asyncapi.controller.dtos.MessageDto;
 import io.github.stavshamir.springwolf.producer.SpringwolfAmqpProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.Map;
 
 import static io.github.stavshamir.springwolf.SpringWolfAmqpConfigConstants.SPRINGWOLF_AMQP_CONFIG_PREFIX;
 import static io.github.stavshamir.springwolf.SpringWolfAmqpConfigConstants.SPRINGWOLF_AMQP_PLUGIN_PUBLISHING_ENABLED;
@@ -23,14 +26,14 @@ public class SpringwolfAmqpController {
     private final SpringwolfAmqpProducer amqpProducer;
 
     @PostMapping("/publish")
-    public void publish(@RequestParam String topic, @RequestBody Map<String, Object> payload) {
+    public void publish(@RequestParam String topic, @RequestBody MessageDto message) {
         if (amqpProducer.isEnabled()) {
             log.warn("AMQP producer is not enabled - message will not be published");
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "AMQP producer is not enabled");
         }
 
-        log.info("Publishing to amqp queue {}: {}", topic, payload);
-        amqpProducer.send(topic, payload);
+        log.info("Publishing to amqp queue {}: {}", topic, message.getPayload());
+        amqpProducer.send(topic, message.getPayload());
     }
 
 }

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScanner.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScanner.java
@@ -1,8 +1,10 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import com.asyncapi.v2.binding.ChannelBinding;
+import com.asyncapi.v2.binding.MessageBinding;
 import com.asyncapi.v2.binding.OperationBinding;
 import com.asyncapi.v2.binding.amqp.AMQPChannelBinding;
+import com.asyncapi.v2.binding.amqp.AMQPMessageBinding;
 import com.asyncapi.v2.binding.amqp.AMQPOperationBinding;
 import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
@@ -105,6 +107,12 @@ public class MethodLevelRabbitListenerScanner extends AbstractMethodLevelListene
     @Override
     protected Map<String, ? extends OperationBinding> buildOperationBinding(RabbitListener annotation) {
         return ImmutableMap.of("amqp", AMQPOperationBinding.builder().cc(getRoutingKeys(annotation)).build());
+    }
+
+    @Override
+    protected Map<String, ? extends MessageBinding> buildMessageBinding(RabbitListener annotation) {
+        // currently the feature to define amqp message binding is not implemented.
+        return ImmutableMap.of("amqp", new AMQPMessageBinding());
     }
 
     private List<String> getRoutingKeys(RabbitListener annotation) {

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducer.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducer.java
@@ -33,7 +33,7 @@ public class SpringwolfAmqpProducer {
         this.rabbitTemplate = rabbitTemplates.isEmpty() ? Optional.empty() : Optional.of(rabbitTemplates.get(0));
     }
 
-    public void send(String channelName, Map<String, Object> payload) {
+    public void send(String channelName, Map<String, ?> payload) {
         ChannelItem channelItem = channelsService.getChannels().get(channelName);
 
         String exchange = getExchangeName(channelItem);

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScannerTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScannerTest.java
@@ -2,6 +2,7 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import com.asyncapi.v2.binding.ChannelBinding;
 import com.asyncapi.v2.binding.amqp.AMQPChannelBinding;
+import com.asyncapi.v2.binding.amqp.AMQPMessageBinding;
 import com.asyncapi.v2.binding.amqp.AMQPOperationBinding;
 import com.asyncapi.v2.model.channel.ChannelItem;
 import com.asyncapi.v2.model.channel.operation.Operation;
@@ -99,6 +100,7 @@ public class MethodLevelRabbitListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(ImmutableMap.of("amqp", new AMQPMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
@@ -140,6 +142,7 @@ public class MethodLevelRabbitListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(ImmutableMap.of("amqp", new AMQPMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
@@ -178,6 +181,7 @@ public class MethodLevelRabbitListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(ImmutableMap.of("amqp", new AMQPMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
@@ -216,6 +220,7 @@ public class MethodLevelRabbitListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(ImmutableMap.of("amqp", new AMQPMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
@@ -271,6 +276,7 @@ public class MethodLevelRabbitListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(ImmutableMap.of("amqp", new AMQPMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScanner.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScanner.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import com.asyncapi.v2.binding.ChannelBinding;
+import com.asyncapi.v2.binding.MessageBinding;
 import com.asyncapi.v2.binding.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
@@ -57,6 +58,13 @@ public class ClassLevelKafkaListenerScanner extends AbstractClassLevelListenerSc
     @Override
     protected Map<String, ? extends ChannelBinding> buildChannelBinding(KafkaListener annotation) {
         return KafkaListenerUtil.buildChannelBinding();
+    }
+
+    @Override
+    protected Map<String, ? extends MessageBinding> buildMessageBinding(Method method) {
+        // Currently there is no interesting data in the KafkaListener annotation, but we keep it for the sake of
+        // consistency in the code and in the serialized specification (always have at least an empty binding for kafka)
+        return KafkaListenerUtil.buildMessageBinding();
     }
 
     @Override

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/KafkaListenerUtil.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/KafkaListenerUtil.java
@@ -1,8 +1,10 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import com.asyncapi.v2.binding.ChannelBinding;
+import com.asyncapi.v2.binding.MessageBinding;
 import com.asyncapi.v2.binding.OperationBinding;
 import com.asyncapi.v2.binding.kafka.KafkaChannelBinding;
+import com.asyncapi.v2.binding.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
 import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
@@ -43,5 +45,9 @@ public class KafkaListenerUtil {
         KafkaOperationBinding binding = new KafkaOperationBinding();
         binding.setGroupId(groupId);
         return ImmutableMap.of("kafka", binding);
+    }
+
+    public static Map<String, ? extends MessageBinding> buildMessageBinding() {
+        return ImmutableMap.of("kafka", new KafkaMessageBinding());
     }
 }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelKafkaListenerScanner.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelKafkaListenerScanner.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import com.asyncapi.v2.binding.ChannelBinding;
+import com.asyncapi.v2.binding.MessageBinding;
 import com.asyncapi.v2.binding.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
@@ -47,6 +48,13 @@ public class MethodLevelKafkaListenerScanner extends AbstractMethodLevelListener
     @Override
     protected Map<String, ? extends OperationBinding> buildOperationBinding(KafkaListener annotation) {
         return KafkaListenerUtil.buildOperationBinding(annotation, resolver);
+    }
+
+    @Override
+    protected Map<String, ? extends MessageBinding> buildMessageBinding(KafkaListener annotation) {
+        // Currently there is no interesting data in the KafkaListener annotation, but we keep it for the sake of
+        // consistency in the code and in the serialized specification (always have at least an empty binding for kafka)
+        return KafkaListenerUtil.buildMessageBinding();
     }
 
     @Override

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/KafkaMessageBindingProcessor.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/KafkaMessageBindingProcessor.java
@@ -49,12 +49,13 @@ public class KafkaMessageBindingProcessor implements MessageBindingProcessor, Em
 
     private Schema<?> resolveSchemaOrNull(KafkaAsyncMessageBinding messageBinding) {
         Schema<?> schemaDefinition = null;
-        switch (messageBinding.keyType()) {
-            case NO_KEY:
+        switch (messageBinding.key().type()) {
+            case UNDEFINED_KEY:
                 break;
             case STRING_KEY:
                 schemaDefinition = new StringSchema()
-                        .description(resolveOrNull(messageBinding.description()));
+                        .example(messageBinding.key().example())
+                        .description(resolveOrNull(messageBinding.key().description()));
         }
 
         return schemaDefinition;

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/KafkaMessageBindingProcessor.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/KafkaMessageBindingProcessor.java
@@ -1,0 +1,62 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata;
+
+import com.asyncapi.v2.binding.kafka.KafkaMessageBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding.KafkaAsyncMessageBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.MessageBindingProcessor;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.util.StringValueResolver;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class KafkaMessageBindingProcessor implements MessageBindingProcessor, EmbeddedValueResolverAware {
+    private StringValueResolver resolver;
+
+    @Override
+    public void setEmbeddedValueResolver(StringValueResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public Optional<ProcessedMessageBinding> process(Method method) {
+        return Arrays.stream(method.getAnnotations())
+                .filter(annotation -> annotation instanceof KafkaAsyncOperationBinding)
+                .map(annotation -> (KafkaAsyncOperationBinding) annotation)
+                .findAny()
+                .map(this::mapToMessageBinding);
+    }
+
+    private ProcessedMessageBinding mapToMessageBinding(KafkaAsyncOperationBinding bindingAnnotation) {
+        KafkaAsyncMessageBinding messageBinding = bindingAnnotation.messageBinding();
+        KafkaMessageBinding kafkaMessageBinding = KafkaMessageBinding.builder()
+                .bindingVersion(resolveOrNull(messageBinding.bindingVersion()))
+                .key(resolveSchemaOrNull(messageBinding))
+                .build();
+
+        return new ProcessedMessageBinding(bindingAnnotation.type(), kafkaMessageBinding);
+    }
+
+    private String resolveOrNull(String stringValue) {
+        return StringUtils.isEmpty(stringValue) ? null : resolver.resolveStringValue(stringValue);
+    }
+
+    private Schema<?> resolveSchemaOrNull(KafkaAsyncMessageBinding messageBinding) {
+        Schema<?> schemaDefinition = null;
+        switch (messageBinding.keyType()) {
+            case NO_KEY:
+                break;
+            case STRING_KEY:
+                schemaDefinition = new StringSchema()
+                        .description(resolveOrNull(messageBinding.description()));
+        }
+
+        return schemaDefinition;
+    }
+}

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/KafkaAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/KafkaAsyncOperationBinding.java
@@ -26,14 +26,22 @@ public @interface KafkaAsyncOperationBinding {
     @Target({})
     @interface KafkaAsyncMessageBinding {
 
-        KafkaKeyTypes keyType() default KafkaKeyTypes.NO_KEY;
+        KafkaAsyncKey key() default @KafkaAsyncKey(type = KafkaAsyncKey.KafkaKeyTypes.UNDEFINED_KEY);
+
+        String bindingVersion() default "";
+    }
+    @Retention(RetentionPolicy.CLASS)
+    @Target({})
+    @interface KafkaAsyncKey {
+
+        KafkaKeyTypes type() default KafkaKeyTypes.STRING_KEY;
+
+        String example() default "";
 
         String description() default "";
 
-        String bindingVersion() default "";
-
         enum KafkaKeyTypes {
-            NO_KEY,
+            UNDEFINED_KEY,
             STRING_KEY
         }
     }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/KafkaAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/KafkaAsyncOperationBinding.java
@@ -20,4 +20,21 @@ public @interface KafkaAsyncOperationBinding {
     String clientId() default "";
     String bindingVersion() default "";
 
+    KafkaAsyncMessageBinding messageBinding() default @KafkaAsyncMessageBinding();
+
+    @Retention(RetentionPolicy.CLASS)
+    @Target({})
+    @interface KafkaAsyncMessageBinding {
+
+        KafkaKeyTypes keyType() default KafkaKeyTypes.NO_KEY;
+
+        String description() default "";
+
+        String bindingVersion() default "";
+
+        enum KafkaKeyTypes {
+            NO_KEY,
+            STRING_KEY
+        }
+    }
 }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/KafkaConsumerData.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/KafkaConsumerData.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.types;
 
 import com.asyncapi.v2.binding.kafka.KafkaChannelBinding;
+import com.asyncapi.v2.binding.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
 import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
@@ -15,5 +16,6 @@ public class KafkaConsumerData extends ConsumerData {
         this.payloadType = payloadType;
         this.headers = headers != null ? headers : this.headers;
         this.operationBinding = ImmutableMap.of("kafka", new KafkaOperationBinding());
+        this.messageBinding = ImmutableMap.of("kafka", new KafkaMessageBinding());
     }
 }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/KafkaProducerData.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/KafkaProducerData.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.types;
 
 import com.asyncapi.v2.binding.kafka.KafkaChannelBinding;
+import com.asyncapi.v2.binding.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
 import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
@@ -16,6 +17,7 @@ public class KafkaProducerData extends ProducerData {
         this.payloadType = payloadType;
         this.headers = headers != null ? headers : this.headers;
         this.operationBinding = ImmutableMap.of("kafka", new KafkaOperationBinding());
+        this.messageBinding = ImmutableMap.of("kafka", new KafkaMessageBinding());
     }
 
 }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/producer/SpringwolfKafkaProducer.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/producer/SpringwolfKafkaProducer.java
@@ -25,18 +25,18 @@ public class SpringwolfKafkaProducer {
         return kafkaTemplate.isPresent();
     }
 
-    public void send(String topic, Map<String, String> headers, Map<String, ?> payload) {
+    public void send(String topic, String key, Map<String, String> headers, Map<String, ?> payload) {
         if (kafkaTemplate.isPresent()) {
-            kafkaTemplate.get().send(buildProducerRecord(topic, headers, payload));
+            kafkaTemplate.get().send(buildProducerRecord(topic, key, headers, payload));
         } else {
             log.warn("Kafka producer is not configured");
         }
     }
 
-    private ProducerRecord<Object, Map<String, ?>> buildProducerRecord(String topic, Map<String, String> headers, Map<String, ?> payload) {
+    private ProducerRecord<Object, Map<String, ?>> buildProducerRecord(String topic, String key, Map<String, String> headers, Map<String, ?> payload) {
         List<Header> recordHeaders = headers != null ? buildHeaders(headers) : Collections.emptyList();
 
-        return new ProducerRecord<>(topic, null, null, null, payload, recordHeaders);
+        return new ProducerRecord<>(topic, null, null, key, payload, recordHeaders);
     }
 
     private List<Header> buildHeaders(Map<String, String> headers) {

--- a/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScannerTest.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScannerTest.java
@@ -76,12 +76,14 @@ public class ClassLevelKafkaListenerScannerTest {
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleFoo.class.getSimpleName()))
                 .build();
 
         Message barMessage = Message.builder()
                 .name(SimpleBar.class.getName())
                 .title(SimpleBar.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleBar.class.getSimpleName()))
+                .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleBar.class.getSimpleName()))
                 .build();
 
         Operation operation = Operation.builder()

--- a/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScannerTest.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScannerTest.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import com.asyncapi.v2.binding.kafka.KafkaChannelBinding;
+import com.asyncapi.v2.binding.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
 import com.asyncapi.v2.model.channel.ChannelItem;
 import com.asyncapi.v2.model.channel.operation.Operation;
@@ -77,6 +78,7 @@ public class ClassLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleFoo.class.getSimpleName()))
+                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Message barMessage = Message.builder()
@@ -84,6 +86,7 @@ public class ClassLevelKafkaListenerScannerTest {
                 .title(SimpleBar.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleBar.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleBar.class.getSimpleName()))
+                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
@@ -139,6 +142,7 @@ public class ClassLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleFoo.class.getSimpleName()))
+                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
@@ -171,6 +175,7 @@ public class ClassLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleFoo.class.getSimpleName()))
+                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Message barMessage = Message.builder()
@@ -178,6 +183,7 @@ public class ClassLevelKafkaListenerScannerTest {
                 .title(SimpleBar.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleBar.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleBar.class.getSimpleName()))
+                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
@@ -211,6 +217,7 @@ public class ClassLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleFoo.class.getSimpleName()))
+                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()

--- a/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelKafkaListenerScannerTest.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelKafkaListenerScannerTest.java
@@ -2,6 +2,7 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import com.asyncapi.v2.binding.OperationBinding;
 import com.asyncapi.v2.binding.kafka.KafkaChannelBinding;
+import com.asyncapi.v2.binding.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
 import com.asyncapi.v2.model.channel.ChannelItem;
 import com.asyncapi.v2.model.channel.operation.Operation;
@@ -80,6 +81,7 @@ public class MethodLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
@@ -112,6 +114,7 @@ public class MethodLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
@@ -179,6 +182,7 @@ public class MethodLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
@@ -211,6 +215,7 @@ public class MethodLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()

--- a/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/producer/SpringwolfKafkaProducerTest.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/producer/SpringwolfKafkaProducerTest.java
@@ -49,7 +49,7 @@ public class SpringwolfKafkaProducerTest {
     public void testSendingKafkaMessageWithoutHeaders() {
         Map<String, Object> payload = Collections.singletonMap("some", "field");
 
-        springwolfKafkaProducer.send("test-topic", null, payload);
+        springwolfKafkaProducer.send("test-topic", null, null, payload);
 
         verify(kafkaTemplate).send(recordArgumentCaptor.capture());
 
@@ -67,7 +67,7 @@ public class SpringwolfKafkaProducerTest {
         Map<String, Object> payload = Collections.singletonMap("some", "field");
         Map<String, String> headers = Collections.singletonMap("header-key", "header");
 
-        springwolfKafkaProducer.send("test-topic", headers, payload);
+        springwolfKafkaProducer.send("test-topic", null, headers, payload);
 
         verify(kafkaTemplate).send(recordArgumentCaptor.capture());
 


### PR DESCRIPTION
This intended as an attempt to fix issue https://github.com/springwolf/springwolf-core/issues/116 in a generic way. It adds the possibility to document of the message binding.

Docs: 
- https://www.asyncapi.com/docs/reference/specification/v2.4.0#messageObject
- https://www.asyncapi.com/docs/reference/specification/v2.4.0#messageBindingsObject

It is currently only implemented for the springwolf-kafka-plugin.

The API for producing messages has been extended to be able to pick up binding information. The controller in of the kafka plugin will use the key from the binding information when producing the message.   

This PR works together with https://github.com/springwolf/springwolf-ui/pull/35