### PR TITLE
Add example configuration for springdoc-openapi-gradle-plugin

### DIFF
--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.0'
 
     id 'com.bmuschko.docker-spring-boot-application' version '6.7.0'
+    id 'org.springdoc.openapi-gradle-plugin' version '1.6.0'
 }
 
 sourceCompatibility = '1.8'
@@ -67,3 +68,13 @@ test {
         exceptionFormat = 'full'
     }
 }
+
+openApi {
+    apiDocsUrl = "http://localhost:8080/springwolf/docs"
+    // For testing purposes we put the generated json into the test resources, but it could be any other directory
+    outputDir = file("$buildDir/resources/test")
+    outputFileName = "openapi-generated.json"
+}
+
+// generate the open api docs before tests are executed so that if it works, the json is already there
+test.dependsOn("generateOpenApiDocs")

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/OpenApiGeneratorTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/OpenApiGeneratorTest.java
@@ -1,0 +1,36 @@
+package io.github.stavshamir.springwolf.example;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * This test is strongly coupled with the configuration of the springdoc openapi plugin in build.gradle
+ * <p>
+ * The gradle project is configured to run the generateOpenApiDocs task before the test task.
+ * The generateOpenApiDocs task will generate the openapi-generated.json into the test-resources so that
+ * this test can pick up the openapi-generated.json afterwards and compare it to the reference asyncapi.json
+ */
+public class OpenApiGeneratorTest {
+
+    @Test
+    public void asyncApiResourceArtifactTest() throws JSONException, IOException {
+
+        InputStream expectedStream  = this.getClass().getResourceAsStream("/asyncapi.json");
+
+        // When running with EmbeddedKafka, localhost is used as hostname
+        String expectedWithoutServersKafkaUrlPatch = IOUtils.toString(expectedStream, StandardCharsets.UTF_8);
+        String expected = expectedWithoutServersKafkaUrlPatch.replace("kafka:29092", "localhost:29092");
+
+        InputStream actualStream = this.getClass().getResourceAsStream("/openapi-generated.json");
+        String actual = IOUtils.toString(actualStream, StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
+    }
+}


### PR DESCRIPTION
Added an example configuration for springdoc-openapi-gradle-plugin to the springwolf-kafka-example to demonstrate how it can be used. 
To test and ensure that the plugin still works for springwolf, I also added:
* The plugin is executed before the test step
* A unit test compares the generated file with expected spec that is also used in the other test.

I'm not super happy with the testing part, because there is no way to ignore exception from springdoc-openapi-gradle-plugin. That means that if there is a problem with the application start and the plugin can not get the spec, the build will fail before the tests are executed. If that is not acceptable we can discuss more complex options ie moving this test into its own gradle task that is executed after the tests.