### PR TITLE
bugfix: Message is not comparable (ClassCastException)

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMerger.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMerger.java
@@ -58,6 +58,6 @@ public class ChannelMerger {
                 .ofNullable(operation)
                 .map(Operation::getMessage)
                 .map(MessageHelper::messageObjectToSet)
-                .orElseGet(TreeSet::new);
+                .orElseGet(HashSet::new);
     }
 }


### PR DESCRIPTION
Exception: Caused by: java.lang.ClassCastException: class io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message cannot be cast to class java.lang.Comparable (io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message is in unnamed module of loader 'app'; java.lang.Comparable is in module java.base of loader 'bootstrap')