### PR TITLE
Feat: Resolve annotation headers + Multiple AsyncListener/AsyncPublisher annotation

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListener.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListener.java
@@ -3,6 +3,7 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata
 import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -30,6 +31,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})
+@Repeatable(AsyncListeners.class)
 public @interface AsyncListener {
     /**
      * Mapped to {@link OperationData}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
@@ -79,7 +79,7 @@ public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner
         return ConsumerData.builder()
                 .channelName(resolver.resolveStringValue(op.channelName()))
                 .description(resolver.resolveStringValue(op.description()))
-                .headers(AsyncAnnotationScannerUtil.getAsyncHeaders(op))
+                .headers(AsyncAnnotationScannerUtil.getAsyncHeaders(op, resolver))
                 .payloadType(payloadType)
                 .operationBinding(operationBindings)
                 .messageBinding(messageBindings)

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
@@ -17,10 +17,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringValueResolver;
 
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.toSet;
+import java.util.stream.Stream;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -48,31 +49,33 @@ public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner
     @Override
     protected List<OperationData> getOperationData() {
         return componentClassScanner.scan().stream()
-                .map(this::getAnnotatedMethods)
-                .flatMap(Collection::stream)
-                .map(this::mapMethodToOperationData)
+                .flatMap(this::getAnnotatedMethods)
+                .flatMap(this::toOperationData)
                 .collect(Collectors.toList());
     }
 
-    private Set<Method> getAnnotatedMethods(Class<?> type) {
+    private Stream<Method> getAnnotatedMethods(Class<?> type) {
         Class<AsyncListener> annotationClass = AsyncListener.class;
+        Class<AsyncListeners> annotationClassRepeatable = AsyncListeners.class;
         log.debug("Scanning class \"{}\" for @\"{}\" annotated methods", type.getName(), annotationClass.getName());
 
         return Arrays.stream(type.getDeclaredMethods())
-                .filter(method -> method.isAnnotationPresent(annotationClass))
-                .collect(toSet());
+                .filter(method -> method.isAnnotationPresent(annotationClass) || method.isAnnotationPresent(annotationClassRepeatable));
     }
 
-    private OperationData mapMethodToOperationData(Method method) {
+    private Stream<OperationData> toOperationData(Method method) {
         log.debug("Mapping method \"{}\" to channels", method.getName());
 
         Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processOperationBindingFromAnnotation(method, operationBindingProcessors);
         Map<String, MessageBinding> messageBindings = AsyncAnnotationScannerUtil.processMessageBindingFromAnnotation(method, messageBindingProcessors);
 
         Class<AsyncListener> annotationClass = AsyncListener.class;
-        AsyncListener annotation = Optional.of(method.getAnnotation(annotationClass))
-                .orElseThrow(() -> new IllegalArgumentException("Method must be annotated with " + annotationClass.getName()));
+        return Arrays
+                .stream(method.getAnnotationsByType(annotationClass))
+                .map(annotation -> toConsumerData(method, operationBindings, messageBindings, annotation));
+    }
 
+    private ConsumerData toConsumerData(Method method, Map<String, OperationBinding> operationBindings, Map<String, MessageBinding> messageBindings, AsyncListener annotation) {
         AsyncOperation op = annotation.operation();
         Class<?> payloadType = op.payloadType() != Object.class ? op.payloadType() :
                 SpringPayloadAnnotationTypeExtractor.getPayloadType(method);

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListeners.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListeners.java
@@ -1,0 +1,12 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.METHOD})
+public @interface AsyncListeners {
+    AsyncListener[] value();
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListeners.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListeners.java
@@ -7,6 +7,6 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})
-public @interface AsyncListeners {
+@interface AsyncListeners {
     AsyncListener[] value();
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisher.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisher.java
@@ -3,6 +3,7 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata
 import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -29,6 +30,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})
+@Repeatable(AsyncPublishers.class)
 public @interface AsyncPublisher {
     /**
      * Mapped to {@link OperationData}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
@@ -17,10 +17,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringValueResolver;
 
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.toSet;
+import java.util.stream.Stream;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -48,31 +49,33 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
     @Override
     protected List<OperationData> getOperationData() {
         return componentClassScanner.scan().stream()
-                .map(this::getAnnotatedMethods)
-                .flatMap(Collection::stream)
-                .map(this::mapMethodToOperationData)
+                .flatMap(this::getAnnotatedMethods)
+                .flatMap(this::toOperationData)
                 .collect(Collectors.toList());
     }
 
-    private Set<Method> getAnnotatedMethods(Class<?> type) {
+    private Stream<Method> getAnnotatedMethods(Class<?> type) {
         Class<AsyncPublisher> annotationClass = AsyncPublisher.class;
+        Class<AsyncPublishers> annotationClassRepeatable = AsyncPublishers.class;
         log.debug("Scanning class \"{}\" for @\"{}\" annotated methods", type.getName(), annotationClass.getName());
 
         return Arrays.stream(type.getDeclaredMethods())
-                .filter(method -> method.isAnnotationPresent(annotationClass))
-                .collect(toSet());
+                .filter(method -> method.isAnnotationPresent(annotationClass) || method.isAnnotationPresent(annotationClassRepeatable));
     }
 
-    private OperationData mapMethodToOperationData(Method method) {
+    private Stream<OperationData> toOperationData(Method method) {
         log.debug("Mapping method \"{}\" to channels", method.getName());
 
         Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processOperationBindingFromAnnotation(method, operationBindingProcessors);
         Map<String, MessageBinding> messageBindings = AsyncAnnotationScannerUtil.processMessageBindingFromAnnotation(method, messageBindingProcessors);
 
         Class<AsyncPublisher> annotationClass = AsyncPublisher.class;
-        AsyncPublisher annotation = Optional.of(method.getAnnotation(annotationClass))
-                .orElseThrow(() -> new IllegalArgumentException("Method must be annotated with " + annotationClass.getName()));
+        return Arrays
+                .stream(method.getAnnotationsByType(annotationClass))
+                .map(annotation -> toConsumerData(method, operationBindings, messageBindings, annotation));
+    }
 
+    private ProducerData toConsumerData(Method method, Map<String, OperationBinding> operationBindings, Map<String, MessageBinding> messageBindings, AsyncPublisher annotation) {
         AsyncOperation op = annotation.operation();
         Class<?> payloadType = op.payloadType() != Object.class ? op.payloadType() :
                 SpringPayloadAnnotationTypeExtractor.getPayloadType(method);

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
@@ -79,7 +79,7 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
         return ProducerData.builder()
                 .channelName(resolver.resolveStringValue(op.channelName()))
                 .description(resolver.resolveStringValue(op.description()))
-                .headers(AsyncAnnotationScannerUtil.getAsyncHeaders(op))
+                .headers(AsyncAnnotationScannerUtil.getAsyncHeaders(op, resolver))
                 .payloadType(payloadType)
                 .operationBinding(operationBindings)
                 .messageBinding(messageBindings)

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublishers.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublishers.java
@@ -1,0 +1,12 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.METHOD})
+public @interface AsyncPublishers {
+    AsyncPublisher[] value();
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublishers.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublishers.java
@@ -7,6 +7,6 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})
-public @interface AsyncPublishers {
+@interface AsyncPublishers {
     AsyncPublisher[] value();
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtilTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtilTest.java
@@ -1,0 +1,66 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import com.asyncapi.v2.binding.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
+import org.assertj.core.util.Maps;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.StringValueResolver;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AsyncAnnotationScannerUtilTest {
+
+    @Test
+    void getAsyncHeaders() throws NoSuchMethodException {
+        // given
+        Method m = ClassWithOperationBindingProcessor.class.getDeclaredMethod("methodWithAnnotation", String.class);
+        AsyncOperation operation = m.getAnnotation(AsyncListener.class).operation();
+
+        StringValueResolver resolver = mock(StringValueResolver.class);
+
+        // when
+        when(resolver.resolveStringValue(any())).thenAnswer(invocation -> invocation.getArgument(0).toString()+"Resolved");
+
+        // then
+        AsyncHeaders headers = AsyncAnnotationScannerUtil.getAsyncHeaders(operation, resolver);
+        assertEquals(headers.getSchemaName(), "TestSchema");
+        assertTrue(headers.containsKey("headerResolved"));
+        assertEquals(headers.get("headerResolved").getType(), "string");
+        assertEquals(headers.get("headerResolved").getExample(), "valueResolved");
+        assertEquals(headers.get("headerResolved").getDescription(), "descriptionResolved");
+    }
+
+    @Test
+    void processBindingFromAnnotation() throws NoSuchMethodException {
+        // given
+        Method m = ClassWithOperationBindingProcessor.class.getDeclaredMethod("methodWithAnnotation", String.class);
+
+        // when
+        Map<String, OperationBinding> bindings = AsyncAnnotationScannerUtil.processBindingFromAnnotation(m, Collections.singletonList(new TestOperationBindingProcessor()));
+
+        // then
+        assertEquals(Maps.newHashMap(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING), bindings);
+    }
+
+    private static class ClassWithOperationBindingProcessor {
+        @AsyncListener(operation = @AsyncOperation(
+                channelName = "${test.property.test-channel}",
+                description = "${test.property.description}",
+                headers = @AsyncOperation.Headers(
+                        schemaName = "TestSchema",
+                        values = {@AsyncOperation.Headers.Header(name = "header", value = "value", description = "description")}
+                )
+        ))
+        @TestOperationBindingProcessor.TestOperationBinding()
+        private void methodWithAnnotation(String payload) {
+        }
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtilTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtilTest.java
@@ -44,7 +44,7 @@ class AsyncAnnotationScannerUtilTest {
         Method m = ClassWithOperationBindingProcessor.class.getDeclaredMethod("methodWithAnnotation", String.class);
 
         // when
-        Map<String, OperationBinding> bindings = AsyncAnnotationScannerUtil.processBindingFromAnnotation(m, Collections.singletonList(new TestOperationBindingProcessor()));
+        Map<String, OperationBinding> bindings = AsyncAnnotationScannerUtil.processOperationBindingFromAnnotation(m, Collections.singletonList(new TestOperationBindingProcessor()));
 
         // then
         assertEquals(Maps.newHashMap(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING), bindings);

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
@@ -122,6 +122,51 @@ public class AsyncListenerAnnotationScannerTest {
                 .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
     }
 
+    @Test
+    public void scan_componentHasMultipleListenerAnnotations() {
+        // Given a class with methods annotated with AsyncListener, where only the channel-name is set
+        setClassToScan(ClassWithMultipleListenerAnnotations.class);
+
+        // When scan is called
+        Map<String, ChannelItem> actualChannels = channelScanner.scan();
+
+        // Then the returned collection contains the channel
+        Message message = Message.builder()
+                .name(SimpleFoo.class.getName())
+                .title(SimpleFoo.class.getSimpleName())
+                .build();
+
+        Operation operation1 = Operation.builder()
+                .description("Auto-generated description")
+                .operationId("test-channel-1_publish")
+                .bindings(EMPTY_MAP)
+                .message(message)
+                .build();
+
+        ChannelItem expectedChannel1 = ChannelItem.builder()
+                .bindings(null)
+                .publish(operation1)
+                .build();
+
+        Operation operation2 = Operation.builder()
+                .description("Auto-generated description")
+                .operationId("test-channel-2_publish")
+                .bindings(EMPTY_MAP)
+                .message(message)
+                .build();
+
+        ChannelItem expectedChannel2 = ChannelItem.builder()
+                .bindings(null)
+                .publish(operation2)
+                .build();
+
+        assertThat(actualChannels)
+                .containsExactlyEntriesOf(
+                        ImmutableMap.of(
+                                "test-channel-1", expectedChannel1,
+                                "test-channel-2", expectedChannel2));
+    }
+
 
     private static class ClassWithoutListenerAnnotation {
 
@@ -157,6 +202,18 @@ public class AsyncListenerAnnotationScannerTest {
         }
 
         private void methodWithoutAnnotation() {
+        }
+    }
+
+    private static class ClassWithMultipleListenerAnnotations {
+
+        @AsyncListener(operation = @AsyncOperation(
+                channelName = "test-channel-1"
+        ))
+        @AsyncListener(operation = @AsyncOperation(
+                channelName = "test-channel-2"
+        ))
+        private void methodWithMultipleAnnotation(SimpleFoo payload) {
         }
     }
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
@@ -134,6 +134,10 @@ public class AsyncListenerAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
+                .description("")
+                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(EMPTY_MAP)
                 .build();
 
         Operation operation1 = Operation.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
@@ -134,6 +134,10 @@ public class AsyncPublisherAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
+                .description("")
+                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                .bindings(EMPTY_MAP)
                 .build();
 
         Operation operation1 = Operation.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
@@ -122,6 +122,50 @@ public class AsyncPublisherAnnotationScannerTest {
                 .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
     }
 
+    @Test
+    public void scan_componentHasMultiplePublisherAnnotations() {
+        // Given a class with methods annotated with AsyncListener, where only the channel-name is set
+        setClassToScan(ClassWithMultipleListenerAnnotations.class);
+
+        // When scan is called
+        Map<String, ChannelItem> actualChannels = channelScanner.scan();
+
+        // Then the returned collection contains the channel
+        Message message = Message.builder()
+                .name(SimpleFoo.class.getName())
+                .title(SimpleFoo.class.getSimpleName())
+                .build();
+
+        Operation operation1 = Operation.builder()
+                .description("Auto-generated description")
+                .operationId("test-channel-1_subscribe")
+                .bindings(EMPTY_MAP)
+                .message(message)
+                .build();
+
+        ChannelItem expectedChannel1 = ChannelItem.builder()
+                .bindings(null)
+                .subscribe(operation1)
+                .build();
+
+        Operation operation2 = Operation.builder()
+                .description("Auto-generated description")
+                .operationId("test-channel-2_subscribe")
+                .bindings(EMPTY_MAP)
+                .message(message)
+                .build();
+
+        ChannelItem expectedChannel2 = ChannelItem.builder()
+                .bindings(null)
+                .subscribe(operation2)
+                .build();
+
+        assertThat(actualChannels)
+                .containsExactlyEntriesOf(
+                        ImmutableMap.of(
+                                "test-channel-1", expectedChannel1,
+                                "test-channel-2", expectedChannel2));
+    }
 
     private static class ClassWithoutPublisherAnnotation {
 
@@ -157,6 +201,18 @@ public class AsyncPublisherAnnotationScannerTest {
         }
 
         private void methodWithoutAnnotation() {
+        }
+    }
+
+    private static class ClassWithMultipleListenerAnnotations {
+
+        @AsyncPublisher(operation = @AsyncOperation(
+                channelName = "test-channel-1"
+        ))
+        @AsyncPublisher(operation = @AsyncOperation(
+                channelName = "test-channel-2"
+        ))
+        private void methodWithMultipleAnnotation(SimpleFoo payload) {
         }
     }
 


### PR DESCRIPTION
Resolving values in the annotation is helpful when spring variables are used, like `${spring.application-name}`

Also, if a listener method is able to consume multiple topics/payload types, multiple AsyncListener annotations are necessary on a single method.