### PR TITLE
spotless code formatting

### DIFF
--- a/.github/workflows/springwolf-core.yml
+++ b/.github/workflows/springwolf-core.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Check code formatting
+        run: ./gradlew -p springwolf-core spotlessCheck
+
       - name: Build with Gradle
         run: ./gradlew -p springwolf-core build
 

--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -6,6 +6,7 @@ plugins {
 
     id 'org.springframework.boot' version '2.7.6'
     id 'io.spring.dependency-management' version '1.1.0'
+    id 'com.diffplug.spotless' version '6.11.0'
 }
 
 def isSnapshot = Boolean.valueOf(project.findProperty('SNAPSHOT'))
@@ -56,8 +57,31 @@ java {
 }
 
 test {
+    dependsOn spotlessCheck
+
     useJUnitPlatform()
 }
+
+spotless {
+    encoding 'UTF-8'
+
+    java {
+
+//        googleJavaFormat()
+        googleJavaFormat().aosp()
+//        eclipse()
+//        clangFormat()
+//        formatAnnotations()
+
+
+        importOrder('', 'javax', 'java', '\\#')
+        removeUnusedImports()
+
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
 
 publishing {
     publications {

--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -57,7 +57,8 @@ java {
 }
 
 test {
-    dependsOn spotlessCheck
+    // Automatically fix code formatting if possible
+    dependsOn spotlessApply
 
     useJUnitPlatform()
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigConstants.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigConstants.java
@@ -5,5 +5,6 @@ public class SpringWolfConfigConstants {
     public static final String SPRINGWOLF_CONFIG_PREFIX = "springwolf";
 
     public static final String SPRINGWOLF_ENABLED = SPRINGWOLF_CONFIG_PREFIX + ".enabled";
-    public static final String SPRINGWOLF_PLUGIN_CONFIG_PREFIX = SPRINGWOLF_CONFIG_PREFIX + ".plugin";
+    public static final String SPRINGWOLF_PLUGIN_CONFIG_PREFIX =
+            SPRINGWOLF_CONFIG_PREFIX + ".plugin";
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigProperties.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigProperties.java
@@ -12,6 +12,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.annotation.Configuration;
 
 import javax.annotation.Nullable;
+
 import java.util.Map;
 
 @Configuration
@@ -23,31 +24,29 @@ public class SpringWolfConfigProperties {
 
     private boolean enabled = true;
 
-    @Nullable
-    private ConfigDocket docket;
+    @Nullable private ConfigDocket docket;
 
     @Getter
     @Setter
     public static class ConfigDocket {
 
         /**
-         * The base package to scan for listeners which are declared inside a class annotated with @Component or @Service.
+         * The base package to scan for listeners which are declared inside a class annotated
+         * with @Component or @Service.
          *
          * @see AsyncApiDocket.AsyncApiDocketBuilder#basePackage(String)
          */
-        @Nullable
-        private String basePackage;
+        @Nullable private String basePackage;
 
-        @Nullable
-        private Map<String, Server> servers;
+        @Nullable private Map<String, Server> servers;
 
         /**
-         * The object provides metadata about the API. The metadata can be used by the clients if needed.
+         * The object provides metadata about the API. The metadata can be used by the clients if
+         * needed.
          *
          * @see com.asyncapi.v2.model.info.Info
          */
-        @Nullable
-        private Info info;
+        @Nullable private Info info;
 
         @Getter
         @Setter
@@ -58,42 +57,33 @@ public class SpringWolfConfigProperties {
              *
              * @see com.asyncapi.v2.model.info.Info#getTitle()
              */
-            @Nullable
-            private String title;
+            @Nullable private String title;
 
             /**
-             * Required. Provides the version of the application API (not to be confused with the specification version).
+             * Required. Provides the version of the application API (not to be confused with the
+             * specification version).
              *
              * @see com.asyncapi.v2.model.info.Info#getVersion()
              */
-            @Nullable
-            private String version;
+            @Nullable private String version;
 
             /**
-             * A short description of the application. CommonMark syntax can be used for rich text representation.
+             * A short description of the application. CommonMark syntax can be used for rich text
+             * representation.
              *
              * @see com.asyncapi.v2.model.info.Info#getDescription()
              */
-            @Nullable
-            private String description;
+            @Nullable private String description;
 
             /**
-             * A URL to the Terms of Service for the API. MUST be in the format of a URL.
-             * {@link com.asyncapi.v2.model.info.Info#getTermsOfService()}
+             * A URL to the Terms of Service for the API. MUST be in the format of a URL. {@link
+             * com.asyncapi.v2.model.info.Info#getTermsOfService()}
              */
-            @Nullable
-            private String termsOfService;
+            @Nullable private String termsOfService;
 
-            @NestedConfigurationProperty
-            @Nullable
-            private Contact contact;
+            @NestedConfigurationProperty @Nullable private Contact contact;
 
-            @NestedConfigurationProperty
-            @Nullable
-            private License license;
+            @NestedConfigurationProperty @Nullable private License license;
         }
-
     }
-
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/AsyncApiSerializerService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/AsyncApiSerializerService.java
@@ -6,5 +6,4 @@ import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
 public interface AsyncApiSerializerService {
 
     String toJsonString(AsyncAPI asyncAPI) throws JsonProcessingException;
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/AsyncApiService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/AsyncApiService.java
@@ -5,5 +5,4 @@ import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
 public interface AsyncApiService {
 
     AsyncAPI getAsyncAPI();
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/ChannelsService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/ChannelsService.java
@@ -7,5 +7,4 @@ import java.util.Map;
 public interface ChannelsService {
 
     Map<String, ChannelItem> getChannels();
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
@@ -10,9 +10,9 @@ import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.github.stavshamir.springwolf.asyncapi.serializers.AmqpOperationBindingSerializer;
 import io.github.stavshamir.springwolf.asyncapi.serializers.EmptyChannelBindingSerializer;
 import io.github.stavshamir.springwolf.asyncapi.serializers.EmptyOperationBindingSerializer;
-import io.github.stavshamir.springwolf.asyncapi.serializers.AmqpOperationBindingSerializer;
 import io.github.stavshamir.springwolf.asyncapi.serializers.KafkaChannelBindingSerializer;
 import io.github.stavshamir.springwolf.asyncapi.serializers.KafkaOperationBindingSerializer;
 import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
@@ -26,7 +26,9 @@ import javax.annotation.PostConstruct;
 public class DefaultAsyncApiSerializerService implements AsyncApiSerializerService {
 
     private ObjectMapper jsonMapper = new ObjectMapper();
-    private PrettyPrinter printer = new DefaultPrettyPrinter().withObjectIndenter(new DefaultIndenter("  ", DefaultIndenter.SYS_LF));
+    private PrettyPrinter printer =
+            new DefaultPrettyPrinter()
+                    .withObjectIndenter(new DefaultIndenter("  ", DefaultIndenter.SYS_LF));
 
     @PostConstruct
     void postConstruct() {
@@ -49,27 +51,22 @@ public class DefaultAsyncApiSerializerService implements AsyncApiSerializerServi
         return jsonMapper.writer(printer).writeValueAsString(asyncAPI);
     }
 
-    /**
-     * Get the current object mapper configuration.
-     */
+    /** Get the current object mapper configuration. */
     public ObjectMapper getObjectMapper() {
         return jsonMapper;
     }
-    
+
     /**
      * Allows to customize the used objectMapper
-     * <p>
-     * Use {@link #getObjectMapper()} as a starting point
+     *
+     * <p>Use {@link #getObjectMapper()} as a starting point
      */
     public void setObjectMapper(ObjectMapper mapper) {
         jsonMapper = mapper;
     }
 
-    /**
-     * Allows to override the used PrettyPrinter
-     */
+    /** Allows to override the used PrettyPrinter */
     public void setPrettyPrinter(PrettyPrinter prettyPrinter) {
         printer = prettyPrinter;
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.java
@@ -28,21 +28,20 @@ public class DefaultAsyncApiService implements AsyncApiService {
 
         AsyncApiDocket docket = asyncApiDocketService.getAsyncApiDocket();
 
-        Components components = Components.builder()
-                .schemas(schemasService.getDefinitions())
-                .build();
+        Components components =
+                Components.builder().schemas(schemasService.getDefinitions()).build();
 
-        asyncAPI = AsyncAPI.builder()
-                .info(docket.getInfo())
-                .servers(docket.getServers())
-                .channels(channelsService.getChannels())
-                .components(components)
-                .build();
+        asyncAPI =
+                AsyncAPI.builder()
+                        .info(docket.getInfo())
+                        .servers(docket.getServers())
+                        .channels(channelsService.getChannels())
+                        .components(components)
+                        .build();
     }
 
     @Override
     public AsyncAPI getAsyncAPI() {
         return asyncAPI;
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsService.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +31,10 @@ public class DefaultChannelsService implements ChannelsService {
                 Map<String, ChannelItem> channels = scanner.scan();
                 foundChannelItems.addAll(channels.entrySet());
             } catch (Exception e) {
-                log.error("An error was encountered during channel scanning with {}: {}", scanner, e.getMessage());
+                log.error(
+                        "An error was encountered during channel scanning with {}: {}",
+                        scanner,
+                        e.getMessage());
             }
         }
 
@@ -41,5 +45,4 @@ public class DefaultChannelsService implements ChannelsService {
     public Map<String, ChannelItem> getChannels() {
         return channels;
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
@@ -13,7 +13,8 @@ public class MessageHelper {
     private static final String ONE_OF = "oneOf";
 
     private static final Comparator<Message> byMessageName = Comparator.comparing(Message::getName);
-    private static final Supplier<Set<Message>> messageSupplier = () -> new TreeSet<>(byMessageName);
+    private static final Supplier<Set<Message>> messageSupplier =
+            () -> new TreeSet<>(byMessageName);
 
     public static Object toMessageObjectOrComposition(Set<Message> messages) {
         switch (messages.size()) {
@@ -22,7 +23,9 @@ public class MessageHelper {
             case 1:
                 return messages.toArray()[0];
             default:
-                return ImmutableMap.of(ONE_OF, messages.stream().collect(Collectors.toCollection(messageSupplier)));
+                return ImmutableMap.of(
+                        ONE_OF,
+                        messages.stream().collect(Collectors.toCollection(messageSupplier)));
         }
     }
 
@@ -37,8 +40,9 @@ public class MessageHelper {
             return new HashSet<>(messages);
         }
 
-        log.warn("Message object must contain either a Message or a Map<String, Set<Message>, but contained: {}", messageObject.getClass());
+        log.warn(
+                "Message object must contain either a Message or a Map<String, Set<Message>, but contained: {}",
+                messageObject.getClass());
         return new HashSet<>();
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/controller/AsyncApiController.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/controller/AsyncApiController.java
@@ -25,5 +25,4 @@ public class AsyncApiController {
         AsyncAPI asyncAPI = asyncApiService.getAsyncAPI();
         return serializer.toJsonString(asyncAPI);
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/beans/BeanMethodsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/beans/BeanMethodsScanner.java
@@ -6,8 +6,8 @@ import java.util.Set;
 public interface BeanMethodsScanner {
 
     /**
-     * @return Methods annotated with @Bean which are declared in @Configuration classes from the base package.
+     * @return Methods annotated with @Bean which are declared in @Configuration classes from the
+     *     base package.
      */
     Set<Method> getBeanMethods();
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/beans/DefaultBeanMethodsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/beans/DefaultBeanMethodsScanner.java
@@ -23,14 +23,12 @@ public class DefaultBeanMethodsScanner implements BeanMethodsScanner {
     public Set<Method> getBeanMethods() {
         Set<Class<?>> configurationClasses = configurationClassScanner.scan();
 
-        Stream<Method> methods = configurationClasses.stream()
-                .map(Class::getDeclaredMethods)
-                .map(Arrays::asList)
-                .flatMap(List::stream);
+        Stream<Method> methods =
+                configurationClasses.stream()
+                        .map(Class::getDeclaredMethods)
+                        .map(Arrays::asList)
+                        .flatMap(List::stream);
 
-        return methods
-                .filter(method -> method.isAnnotationPresent(Bean.class))
-                .collect(toSet());
+        return methods.filter(method -> method.isAnnotationPresent(Bean.class)).collect(toSet());
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMerger.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMerger.java
@@ -9,23 +9,20 @@ import java.util.*;
 
 import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.toMessageObjectOrComposition;
 
-
-/**
- * Util to merge multiple {@link ChannelItem}s
- */
+/** Util to merge multiple {@link ChannelItem}s */
 public class ChannelMerger {
 
     /**
      * Merges multiple channelItems by channel name
-     * <p>
-     * Given two channelItems for the same channel name, the first seen ChannelItem is used
-     * If an operation is null, the next non-null operation is used
-     * Messages within operations are merged
+     *
+     * <p>Given two channelItems for the same channel name, the first seen ChannelItem is used If an
+     * operation is null, the next non-null operation is used Messages within operations are merged
      *
      * @param channelEntries Ordered pairs of channel name to ChannelItem
      * @return A map of channelName to a single ChannelItem
      */
-    public static Map<String, ChannelItem> merge(List<Map.Entry<String, ChannelItem>> channelEntries) {
+    public static Map<String, ChannelItem> merge(
+            List<Map.Entry<String, ChannelItem>> channelEntries) {
         Map<String, ChannelItem> mergedChannels = new TreeMap<>();
 
         for (Map.Entry<String, ChannelItem> entry : channelEntries) {
@@ -33,8 +30,11 @@ public class ChannelMerger {
                 mergedChannels.put(entry.getKey(), entry.getValue());
             } else {
                 ChannelItem channelItem = mergedChannels.get(entry.getKey());
-                channelItem.setPublish(mergeOperation(channelItem.getPublish(), entry.getValue().getPublish()));
-                channelItem.setSubscribe(mergeOperation(channelItem.getSubscribe(), entry.getValue().getSubscribe()));
+                channelItem.setPublish(
+                        mergeOperation(channelItem.getPublish(), entry.getValue().getPublish()));
+                channelItem.setSubscribe(
+                        mergeOperation(
+                                channelItem.getSubscribe(), entry.getValue().getSubscribe()));
             }
         }
 
@@ -54,8 +54,7 @@ public class ChannelMerger {
     }
 
     private static Set<Message> getMessages(Operation operation) {
-        return Optional
-                .ofNullable(operation)
+        return Optional.ofNullable(operation)
                 .map(Operation::getMessage)
                 .map(MessageHelper::messageObjectToSet)
                 .orElseGet(TreeSet::new);

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelPriority.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelPriority.java
@@ -1,28 +1,28 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
 
-import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncListener;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
 
 public class ChannelPriority {
     /**
      * Manual defined channels have the highest priority
-     * <p>
-     * Example: Definition via {@link AsyncApiDocket}
+     *
+     * <p>Example: Definition via {@link AsyncApiDocket}
      */
     public static final int MANUAL_DEFINED = 1;
 
     /**
      * Definition via custom annotations
-     * <p>
-     * Example: {@link AsyncPublisher}, {@link AsyncListener}
+     *
+     * <p>Example: {@link AsyncPublisher}, {@link AsyncListener}
      */
     public static final int ASYNC_ANNOTATION = 2;
 
     /**
      * Definitions found via spring listener annotations are used last.
-     * <p>
-     * Examples: Plugins like KafkaListener, etc
+     *
+     * <p>Examples: Plugins like KafkaListener, etc
      */
     public static final int AUTO_DISCOVERED = 3;
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/SpringPayloadAnnotationTypeExtractor.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/SpringPayloadAnnotationTypeExtractor.java
@@ -12,31 +12,39 @@ import java.util.List;
 
 @Slf4j
 public class SpringPayloadAnnotationTypeExtractor {
-    public SpringPayloadAnnotationTypeExtractor() {
-    }
+    public SpringPayloadAnnotationTypeExtractor() {}
 
     public static Class<?> getPayloadType(Method method) {
-        String methodName = String.format("%s::%s", method.getDeclaringClass().getSimpleName(), method.getName());
+        String methodName =
+                String.format(
+                        "%s::%s", method.getDeclaringClass().getSimpleName(), method.getName());
         log.debug("Finding payload type for {}", methodName);
 
         Class<?>[] parameterTypes = method.getParameterTypes();
-        int parameterPayloadIndex = getPayloadParameterIndex(parameterTypes, method.getParameterAnnotations(), methodName);
+        int parameterPayloadIndex =
+                getPayloadParameterIndex(
+                        parameterTypes, method.getParameterAnnotations(), methodName);
 
         return getPayloadParameterClass(method, parameterTypes, parameterPayloadIndex);
     }
 
-    static Class<?> getPayloadParameterClass(Method method, Class<?>[] parameterTypes, int parameterPayloadIndex) {
+    static Class<?> getPayloadParameterClass(
+            Method method, Class<?>[] parameterTypes, int parameterPayloadIndex) {
         Class<?> parameterClass = parameterTypes[parameterPayloadIndex];
 
         try {
             // Resolve generic type for batch listeners
             if (parameterClass == List.class) {
-                Type type = ((ParameterizedType) method.getGenericParameterTypes()[parameterPayloadIndex]).getActualTypeArguments()[0];
+                Type type =
+                        ((ParameterizedType)
+                                        method.getGenericParameterTypes()[parameterPayloadIndex])
+                                .getActualTypeArguments()[0];
                 try {
                     return Class.forName(type.getTypeName());
                 } catch (IllegalAccessError error) {
                     // remove, when the used java version has been upgraded to support java modules
-                    log.info("Springwolf was not compiled for the Java version you are using. More info: https://github.com/springwolf/springwolf-core/issues/132");
+                    log.info(
+                            "Springwolf was not compiled for the Java version you are using. More info: https://github.com/springwolf/springwolf-core/issues/132");
                 }
             }
         } catch (Exception ex) {
@@ -46,19 +54,23 @@ public class SpringPayloadAnnotationTypeExtractor {
         return parameterClass;
     }
 
-    static int getPayloadParameterIndex(Class<?>[] parameterTypes, Annotation[][] parameterAnnotations, String methodName) {
+    static int getPayloadParameterIndex(
+            Class<?>[] parameterTypes, Annotation[][] parameterAnnotations, String methodName) {
         switch (parameterTypes.length) {
             case 0:
-                throw new IllegalArgumentException("Listener methods must not have 0 parameters: " + methodName);
+                throw new IllegalArgumentException(
+                        "Listener methods must not have 0 parameters: " + methodName);
             case 1:
                 return 0;
             default:
-                int payloadAnnotatedParameterIndex = getPayloadAnnotatedParameterIndex(parameterAnnotations);
+                int payloadAnnotatedParameterIndex =
+                        getPayloadAnnotatedParameterIndex(parameterAnnotations);
 
                 if (payloadAnnotatedParameterIndex == -1) {
-                    String msg = "Multi-parameter KafkaListener methods must have one parameter annotated with @Payload, "
-                            + "but none was found: "
-                            + methodName;
+                    String msg =
+                            "Multi-parameter KafkaListener methods must have one parameter annotated with @Payload, "
+                                    + "but none was found: "
+                                    + methodName;
 
                     throw new IllegalArgumentException(msg);
                 }
@@ -70,8 +82,9 @@ public class SpringPayloadAnnotationTypeExtractor {
     static int getPayloadAnnotatedParameterIndex(Annotation[][] parameterAnnotations) {
         for (int i = 0, length = parameterAnnotations.length; i < length; i++) {
             Annotation[] annotations = parameterAnnotations[i];
-            boolean hasPayloadAnnotation = Arrays.stream(annotations)
-                    .anyMatch(annotation -> annotation instanceof Payload);
+            boolean hasPayloadAnnotation =
+                    Arrays.stream(annotations)
+                            .anyMatch(annotation -> annotation instanceof Payload);
 
             if (hasPayloadAnnotation) {
                 return i;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
@@ -33,21 +33,25 @@ public abstract class AbstractOperationDataScanner implements ChannelsScanner {
 
     @Override
     public Map<String, ChannelItem> scan() {
-        Map<String, List<OperationData>> operationDataGroupedByChannelName = this.getOperationData().stream()
-                .filter(this::allFieldsAreNonNull)
-                .collect(groupingBy(OperationData::getChannelName));
+        Map<String, List<OperationData>> operationDataGroupedByChannelName =
+                this.getOperationData().stream()
+                        .filter(this::allFieldsAreNonNull)
+                        .collect(groupingBy(OperationData::getChannelName));
 
         return operationDataGroupedByChannelName.entrySet().stream()
                 .collect(toMap(Map.Entry::getKey, entry -> buildChannel(entry.getValue())));
     }
 
     private boolean allFieldsAreNonNull(OperationData operationData) {
-        boolean allNonNull = operationData.getChannelName() != null
-                && operationData.getPayloadType() != null
-                && operationData.getOperationBinding() != null;
+        boolean allNonNull =
+                operationData.getChannelName() != null
+                        && operationData.getPayloadType() != null
+                        && operationData.getOperationBinding() != null;
 
         if (!allNonNull) {
-            log.warn("Some data fields are null - this producer will not be documented: {}", operationData);
+            log.warn(
+                    "Some data fields are null - this producer will not be documented: {}",
+                    operationData);
         }
 
         return allNonNull;
@@ -56,19 +60,25 @@ public abstract class AbstractOperationDataScanner implements ChannelsScanner {
     private ChannelItem buildChannel(List<OperationData> operationDataList) {
         // All bindings in the group are assumed to be the same
         // AsyncApi does not support multiple bindings on a single channel
-        Map<String, ? extends ChannelBinding> channelBinding = operationDataList.get(0).getChannelBinding();
-        Map<String, ? extends OperationBinding> operationBinding = operationDataList.get(0).getOperationBinding();
-        String operationId = operationDataList.get(0).getChannelName() + "_" + this.getOperationType().operationName;
+        Map<String, ? extends ChannelBinding> channelBinding =
+                operationDataList.get(0).getChannelBinding();
+        Map<String, ? extends OperationBinding> operationBinding =
+                operationDataList.get(0).getOperationBinding();
+        String operationId =
+                operationDataList.get(0).getChannelName()
+                        + "_"
+                        + this.getOperationType().operationName;
 
-        Operation operation = Operation.builder()
-                .description("Auto-generated description")
-                .operationId(operationId)
-                .message(getMessageObject(operationDataList))
-                .bindings(operationBinding)
-                .build();
+        Operation operation =
+                Operation.builder()
+                        .description("Auto-generated description")
+                        .operationId(operationId)
+                        .message(getMessageObject(operationDataList))
+                        .bindings(operationBinding)
+                        .build();
 
-        ChannelItem.ChannelItemBuilder channelBuilder = ChannelItem.builder()
-                .bindings(channelBinding);
+        ChannelItem.ChannelItemBuilder channelBuilder =
+                ChannelItem.builder().bindings(channelBinding);
         switch (getOperationType()) {
             case PUBLISH:
                 channelBuilder = channelBuilder.publish(operation);
@@ -81,9 +91,7 @@ public abstract class AbstractOperationDataScanner implements ChannelsScanner {
     }
 
     private Object getMessageObject(List<OperationData> operationDataList) {
-        Set<Message> messages = operationDataList.stream()
-                .map(this::buildMessage)
-                .collect(toSet());
+        Set<Message> messages = operationDataList.stream().map(this::buildMessage).collect(toSet());
 
         return toMessageObjectOrComposition(messages);
     }
@@ -101,5 +109,4 @@ public abstract class AbstractOperationDataScanner implements ChannelsScanner {
                 .headers(HeaderReference.fromModelName(headerModelName))
                 .build();
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProcessedOperationBinding.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProcessedOperationBinding.java
@@ -5,6 +5,6 @@ import lombok.Data;
 
 @Data
 public class ProcessedOperationBinding {
-     private final String type;
-     private final OperationBinding binding;
+    private final String type;
+    private final OperationBinding binding;
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtil.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtil.java
@@ -24,34 +24,31 @@ class AsyncAnnotationScannerUtil {
         AsyncHeaders asyncHeaders = new AsyncHeaders(op.headers().schemaName());
         Arrays.stream(op.headers().values())
                 .collect(groupingBy(AsyncOperation.Headers.Header::name))
-                .forEach((headerName, headers) -> {
-                    List<String> values = getHeaderValues(headers);
-                    String exampleValue = values.stream().findFirst().orElse(null);
-                    asyncHeaders.addHeader(
-                            AsyncHeaderSchema
-                                    .headerBuilder()
-                                    .headerName(headerName)
-                                    .description(getDescription(headers))
-                                    .enumValue(values)
-                                    .example(exampleValue)
-                                    .build()
-                    );
-                });
+                .forEach(
+                        (headerName, headers) -> {
+                            List<String> values = getHeaderValues(headers);
+                            String exampleValue = values.stream().findFirst().orElse(null);
+                            asyncHeaders.addHeader(
+                                    AsyncHeaderSchema.headerBuilder()
+                                            .headerName(headerName)
+                                            .description(getDescription(headers))
+                                            .enumValue(values)
+                                            .example(exampleValue)
+                                            .build());
+                        });
 
         return asyncHeaders;
     }
 
     private static List<String> getHeaderValues(List<AsyncOperation.Headers.Header> value) {
-        return value
-                .stream()
+        return value.stream()
                 .map(AsyncOperation.Headers.Header::value)
                 .sorted()
                 .collect(Collectors.toList());
     }
 
     private static String getDescription(List<AsyncOperation.Headers.Header> value) {
-        return value
-                .stream()
+        return value.stream()
                 .map(AsyncOperation.Headers.Header::description)
                 .filter(StringUtils::isNotBlank)
                 .sorted()
@@ -59,11 +56,15 @@ class AsyncAnnotationScannerUtil {
                 .orElse(null);
     }
 
-    public static Map<String, OperationBinding> processBindingFromAnnotation(Method method, List<OperationBindingProcessor> operationBindingProcessors) {
+    public static Map<String, OperationBinding> processBindingFromAnnotation(
+            Method method, List<OperationBindingProcessor> operationBindingProcessors) {
         return operationBindingProcessors.stream()
                 .map(operationBindingProcessor -> operationBindingProcessor.process(method))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .collect(Collectors.toMap(ProcessedOperationBinding::getType, ProcessedOperationBinding::getBinding));
+                .collect(
+                        Collectors.toMap(
+                                ProcessedOperationBinding::getType,
+                                ProcessedOperationBinding::getBinding));
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListener.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListener.java
@@ -8,16 +8,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * {@code @AsyncListener} is a method-level annotation to document springwolf listeners.
- * Listeners in this context are methods that receive and process incoming data from a message broker.
- * To document producers, use {@link AsyncPublisher}.
- * <p>
- * The fields channel, description, payload and headers are part of {@link AsyncOperation}
- * and behaves identical to {@link io.github.stavshamir.springwolf.asyncapi.types.ConsumerData}.
- * If no {@link AsyncOperation#payloadType()} is passed, the payload type is extracted from the signature of the method.
- * Add {@link org.springframework.messaging.handler.annotation.Payload} to the payload argument, if the method has more than one argument.
- * <p>
- * Add an operation binding with one of the protocol specific operation binding annotation ({@code AmqpAsyncOperationBinding}, {@code KafkaAsyncOperationBinding}) on the same method.
+ * {@code @AsyncListener} is a method-level annotation to document springwolf listeners. Listeners
+ * in this context are methods that receive and process incoming data from a message broker. To
+ * document producers, use {@link AsyncPublisher}.
+ *
+ * <p>The fields channel, description, payload and headers are part of {@link AsyncOperation} and
+ * behaves identical to {@link io.github.stavshamir.springwolf.asyncapi.types.ConsumerData}. If no
+ * {@link AsyncOperation#payloadType()} is passed, the payload type is extracted from the signature
+ * of the method. Add {@link org.springframework.messaging.handler.annotation.Payload} to the
+ * payload argument, if the method has more than one argument.
+ *
+ * <p>Add an operation binding with one of the protocol specific operation binding annotation
+ * ({@code AmqpAsyncOperationBinding}, {@code KafkaAsyncOperationBinding}) on the same method.
+ *
  * <pre class="code">
  *     &#064;KafkaListener
  *     &#064;AsyncListener(operation = &#064;AsyncOperation(
@@ -31,8 +34,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})
 public @interface AsyncListener {
-    /**
-     * Mapped to {@link OperationData}
-     */
+    /** Mapped to {@link OperationData} */
     AsyncOperation operation();
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
@@ -25,7 +25,8 @@ import static java.util.stream.Collectors.toSet;
 @RequiredArgsConstructor
 @Component
 @Order(value = ChannelPriority.ASYNC_ANNOTATION)
-public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner implements EmbeddedValueResolverAware {
+public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner
+        implements EmbeddedValueResolverAware {
     private StringValueResolver resolver;
     private final ComponentClassScanner componentClassScanner;
     private final SchemasService schemasService;
@@ -53,7 +54,10 @@ public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner
 
     private Set<Method> getAnnotatedMethods(Class<?> type) {
         Class<AsyncListener> annotationClass = AsyncListener.class;
-        log.debug("Scanning class \"{}\" for @\"{}\" annotated methods", type.getName(), annotationClass.getName());
+        log.debug(
+                "Scanning class \"{}\" for @\"{}\" annotated methods",
+                type.getName(),
+                annotationClass.getName());
 
         return Arrays.stream(type.getDeclaredMethods())
                 .filter(method -> method.isAnnotationPresent(annotationClass))
@@ -63,15 +67,24 @@ public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner
     private OperationData mapMethodToOperationData(Method method) {
         log.debug("Mapping method \"{}\" to channels", method.getName());
 
-        Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processBindingFromAnnotation(method, operationBindingProcessors);
+        Map<String, OperationBinding> operationBindings =
+                AsyncAnnotationScannerUtil.processBindingFromAnnotation(
+                        method, operationBindingProcessors);
 
         Class<AsyncListener> annotationClass = AsyncListener.class;
-        AsyncListener annotation = Optional.of(method.getAnnotation(annotationClass))
-                .orElseThrow(() -> new IllegalArgumentException("Method must be annotated with " + annotationClass.getName()));
+        AsyncListener annotation =
+                Optional.of(method.getAnnotation(annotationClass))
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "Method must be annotated with "
+                                                        + annotationClass.getName()));
 
         AsyncOperation op = annotation.operation();
-        Class<?> payloadType = op.payloadType() != Object.class ? op.payloadType() :
-                SpringPayloadAnnotationTypeExtractor.getPayloadType(method);
+        Class<?> payloadType =
+                op.payloadType() != Object.class
+                        ? op.payloadType()
+                        : SpringPayloadAnnotationTypeExtractor.getPayloadType(method);
         return ConsumerData.builder()
                 .channelName(resolver.resolveStringValue(op.channelName()))
                 .description(resolver.resolveStringValue(op.description()))

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncOperation.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncOperation.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
 
-
 import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaderSchema;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
@@ -9,38 +8,26 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Annotation is mapped to {@link OperationData}
- */
+/** Annotation is mapped to {@link OperationData} */
 @Retention(RetentionPolicy.CLASS)
 @Target({})
 public @interface AsyncOperation {
-    /**
-     * Mapped to {@link OperationData#getChannelName()}
-     */
+    /** Mapped to {@link OperationData#getChannelName()} */
     String channelName();
 
-    /**
-     * Mapped to {@link OperationData#getDescription()}
-     */
+    /** Mapped to {@link OperationData#getDescription()} */
     String description() default "";
 
-    /**
-     * Mapped to {@link OperationData#getPayloadType()}
-     */
+    /** Mapped to {@link OperationData#getPayloadType()} */
     Class<?> payloadType() default Object.class;
 
-    /**
-     * Mapped to {@link OperationData#getHeaders()}
-     */
+    /** Mapped to {@link OperationData#getHeaders()} */
     Headers headers() default @Headers();
 
     @Retention(RetentionPolicy.CLASS)
     @Target({})
     @interface Headers {
-        /**
-         * Mapped to {@link AsyncHeaders#getSchemaName()}
-         */
+        /** Mapped to {@link AsyncHeaders#getSchemaName()} */
         String schemaName() default "";
 
         Header[] values() default {};
@@ -48,19 +35,13 @@ public @interface AsyncOperation {
         @Retention(RetentionPolicy.CLASS)
         @Target({})
         @interface Header {
-            /**
-             * Mapped to {@link AsyncHeaderSchema#getHeaderName()}
-             */
+            /** Mapped to {@link AsyncHeaderSchema#getHeaderName()} */
             String name();
 
-            /**
-             * Mapped to {@link AsyncHeaderSchema#getDescription()} ()}
-             */
+            /** Mapped to {@link AsyncHeaderSchema#getDescription()} ()} */
             String description() default "";
 
-            /**
-             * Mapped to {@link AsyncHeaderSchema#getDefault()}
-             */
+            /** Mapped to {@link AsyncHeaderSchema#getDefault()} */
             String value();
         }
     }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisher.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisher.java
@@ -9,15 +9,18 @@ import java.lang.annotation.Target;
 
 /**
  * {@code @AsyncPublisher} is a method-level annotation to document springwolf publishers.
- * Publishers in this context are methods that send a message to a message broker.
- * To document listeners, use {@link AsyncListener}.
- * <p>
- * The fields channel, description, payload and headers are part of {@link AsyncOperation}
- * and behaves identical to {@link io.github.stavshamir.springwolf.asyncapi.types.ProducerData}.
- * If no {@link AsyncOperation#payloadType()} is passed, the payload type is extracted from the signature of the method.
- * Add {@link org.springframework.messaging.handler.annotation.Payload} to the payload argument, if the method has more than one argument.
- * <p>
- * Add an operation binding with one of the protocol specific operation binding annotation ({@code AmqpAsyncOperationBinding}, {@code KafkaAsyncOperationBinding}) on the same method.
+ * Publishers in this context are methods that send a message to a message broker. To document
+ * listeners, use {@link AsyncListener}.
+ *
+ * <p>The fields channel, description, payload and headers are part of {@link AsyncOperation} and
+ * behaves identical to {@link io.github.stavshamir.springwolf.asyncapi.types.ProducerData}. If no
+ * {@link AsyncOperation#payloadType()} is passed, the payload type is extracted from the signature
+ * of the method. Add {@link org.springframework.messaging.handler.annotation.Payload} to the
+ * payload argument, if the method has more than one argument.
+ *
+ * <p>Add an operation binding with one of the protocol specific operation binding annotation
+ * ({@code AmqpAsyncOperationBinding}, {@code KafkaAsyncOperationBinding}) on the same method.
+ *
  * <pre class="code">
  *     &#064;AsyncPublisher(operation = &#064;AsyncOperation(
  *             channelName = "topic-name",
@@ -30,8 +33,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})
 public @interface AsyncPublisher {
-    /**
-     * Mapped to {@link OperationData}
-     */
+    /** Mapped to {@link OperationData} */
     AsyncOperation operation();
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
@@ -25,7 +25,8 @@ import static java.util.stream.Collectors.toSet;
 @RequiredArgsConstructor
 @Component
 @Order(value = ChannelPriority.ASYNC_ANNOTATION)
-public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanner implements EmbeddedValueResolverAware {
+public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanner
+        implements EmbeddedValueResolverAware {
     private StringValueResolver resolver;
     private final ComponentClassScanner componentClassScanner;
     private final SchemasService schemasService;
@@ -53,7 +54,10 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
 
     private Set<Method> getAnnotatedMethods(Class<?> type) {
         Class<AsyncPublisher> annotationClass = AsyncPublisher.class;
-        log.debug("Scanning class \"{}\" for @\"{}\" annotated methods", type.getName(), annotationClass.getName());
+        log.debug(
+                "Scanning class \"{}\" for @\"{}\" annotated methods",
+                type.getName(),
+                annotationClass.getName());
 
         return Arrays.stream(type.getDeclaredMethods())
                 .filter(method -> method.isAnnotationPresent(annotationClass))
@@ -63,15 +67,24 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
     private OperationData mapMethodToOperationData(Method method) {
         log.debug("Mapping method \"{}\" to channels", method.getName());
 
-        Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processBindingFromAnnotation(method, operationBindingProcessors);
+        Map<String, OperationBinding> operationBindings =
+                AsyncAnnotationScannerUtil.processBindingFromAnnotation(
+                        method, operationBindingProcessors);
 
         Class<AsyncPublisher> annotationClass = AsyncPublisher.class;
-        AsyncPublisher annotation = Optional.of(method.getAnnotation(annotationClass))
-                .orElseThrow(() -> new IllegalArgumentException("Method must be annotated with " + annotationClass.getName()));
+        AsyncPublisher annotation =
+                Optional.of(method.getAnnotation(annotationClass))
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "Method must be annotated with "
+                                                        + annotationClass.getName()));
 
         AsyncOperation op = annotation.operation();
-        Class<?> payloadType = op.payloadType() != Object.class ? op.payloadType() :
-                SpringPayloadAnnotationTypeExtractor.getPayloadType(method);
+        Class<?> payloadType =
+                op.payloadType() != Object.class
+                        ? op.payloadType()
+                        : SpringPayloadAnnotationTypeExtractor.getPayloadType(method);
         return ProducerData.builder()
                 .channelName(resolver.resolveStringValue(op.channelName()))
                 .description(resolver.resolveStringValue(op.description()))

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/OperationBindingProcessor.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/OperationBindingProcessor.java
@@ -8,8 +8,8 @@ import java.util.Optional;
 public interface OperationBindingProcessor {
 
     /**
-     * Process the methods annotated with {@link AsyncPublisher} and {@link AsyncListener}
-     * for protocol specific operationBinding annotations, method parameters, etc
+     * Process the methods annotated with {@link AsyncPublisher} and {@link AsyncListener} for
+     * protocol specific operationBinding annotations, method parameters, etc
      *
      * @param method The method being annotated
      * @return An operation binding, if found

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/AbstractAnnotatedClassScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/AbstractAnnotatedClassScanner.java
@@ -17,12 +17,9 @@ import static java.util.stream.Collectors.toSet;
 @Slf4j
 public abstract class AbstractAnnotatedClassScanner<T extends Annotation> implements ClassScanner {
 
-    @Autowired
-    private AsyncApiDocketService asyncApiDocketService;
+    @Autowired private AsyncApiDocketService asyncApiDocketService;
 
-    /**
-     * @return The class object of the annotation to scan.
-     */
+    /** @return The class object of the annotation to scan. */
     protected abstract Class<T> getAnnotationClass();
 
     @Override
@@ -32,10 +29,12 @@ public abstract class AbstractAnnotatedClassScanner<T extends Annotation> implem
             throw new IllegalArgumentException("Base package must not be blank");
         }
 
-        ClassPathScanningCandidateComponentProvider provider = new ClassPathScanningCandidateComponentProvider(false);
+        ClassPathScanningCandidateComponentProvider provider =
+                new ClassPathScanningCandidateComponentProvider(false);
         provider.addIncludeFilter(new AnnotationTypeFilter(getAnnotationClass()));
 
-        log.debug("Scanning for {} classes in {}", getAnnotationClass().getSimpleName(), basePackage);
+        log.debug(
+                "Scanning for {} classes in {}", getAnnotationClass().getSimpleName(), basePackage);
         return provider.findCandidateComponents(basePackage).stream()
                 .map(BeanDefinition::getBeanClassName)
                 .map(this::getClass)
@@ -53,5 +52,4 @@ public abstract class AbstractAnnotatedClassScanner<T extends Annotation> implem
             return Optional.empty();
         }
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/ClassScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/ClassScanner.java
@@ -1,13 +1,14 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.classes;
 
-import java.util.Set;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
+
+import java.util.Set;
 
 public interface ClassScanner {
 
     /**
-     * Scan your project for components potentially containing asynchronous listeners,
-     * based on the configuration of your registered {@link AsyncApiDocket}.
+     * Scan your project for components potentially containing asynchronous listeners, based on the
+     * configuration of your registered {@link AsyncApiDocket}.
      *
      * @return A set of found classes.
      */

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/ComponentClassScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/ComponentClassScanner.java
@@ -4,11 +4,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 @Service
-public class ComponentClassScanner extends AbstractAnnotatedClassScanner<Component> implements ClassScanner {
+public class ComponentClassScanner extends AbstractAnnotatedClassScanner<Component>
+        implements ClassScanner {
 
     @Override
     protected Class<Component> getAnnotationClass() {
         return Component.class;
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/ConfigurationClassScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/ConfigurationClassScanner.java
@@ -4,11 +4,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Service;
 
 @Service
-public class ConfigurationClassScanner extends AbstractAnnotatedClassScanner<Configuration> implements ClassScanner {
+public class ConfigurationClassScanner extends AbstractAnnotatedClassScanner<Configuration>
+        implements ClassScanner {
 
     @Override
     protected Class<Configuration> getAnnotationClass() {
         return Configuration.class;
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/AmqpOperationBindingSerializer.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/AmqpOperationBindingSerializer.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi.serializers;
 
-
 import com.asyncapi.v2.binding.amqp.AMQPOperationBinding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -19,7 +18,9 @@ public class AmqpOperationBindingSerializer extends StdSerializer<AMQPOperationB
     }
 
     @Override
-    public void serialize(AMQPOperationBinding value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    public void serialize(
+            AMQPOperationBinding value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
         gen.writeStartObject();
 
         gen.writeNumberField("expiration", value.getExpiration());

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/EmptyChannelBindingSerializer.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/EmptyChannelBindingSerializer.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi.serializers;
 
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
@@ -19,9 +18,9 @@ public class EmptyChannelBindingSerializer extends StdSerializer<EmptyChannelBin
     }
 
     @Override
-    public void serialize(EmptyChannelBinding value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    public void serialize(EmptyChannelBinding value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
         gen.writeStartObject();
         gen.writeEndObject();
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/EmptyOperationBindingSerializer.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/EmptyOperationBindingSerializer.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi.serializers;
 
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
@@ -19,9 +18,10 @@ public class EmptyOperationBindingSerializer extends StdSerializer<EmptyOperatio
     }
 
     @Override
-    public void serialize(EmptyOperationBinding value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    public void serialize(
+            EmptyOperationBinding value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
         gen.writeStartObject();
         gen.writeEndObject();
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/KafkaChannelBindingSerializer.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/KafkaChannelBindingSerializer.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi.serializers;
 
-
 import com.asyncapi.v2.binding.kafka.KafkaChannelBinding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -19,9 +18,9 @@ public class KafkaChannelBindingSerializer extends StdSerializer<KafkaChannelBin
     }
 
     @Override
-    public void serialize(KafkaChannelBinding value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    public void serialize(KafkaChannelBinding value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
         gen.writeStartObject();
         gen.writeEndObject();
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/KafkaOperationBindingSerializer.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/serializers/KafkaOperationBindingSerializer.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi.serializers;
 
-
 import com.asyncapi.v2.binding.kafka.KafkaOperationBinding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -19,7 +18,9 @@ public class KafkaOperationBindingSerializer extends StdSerializer<KafkaOperatio
     }
 
     @Override
-    public void serialize(KafkaOperationBinding value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    public void serialize(
+            KafkaOperationBinding value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
         gen.writeStartObject();
 
         if (value.getGroupId() != null) {
@@ -38,5 +39,4 @@ public class KafkaOperationBindingSerializer extends StdSerializer<KafkaOperatio
         gen.writeEndArray();
         gen.writeEndObject();
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AsyncAPI.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AsyncAPI.java
@@ -7,14 +7,18 @@ import com.asyncapi.v2.model.server.Server;
 import lombok.*;
 
 import javax.validation.constraints.NotNull;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * This is the root document object for the API specification. It combines resource listing and API declaration together into one document.
+ * This is the root document object for the API specification. It combines resource listing and API
+ * declaration together into one document.
  *
- * @see <a href="https://www.asyncapi.com/docs/specifications/2.0.0/#a-name-a2sobject-a-asyncapi-object">AsyncAPI specification</a>
+ * @see <a
+ *     href="https://www.asyncapi.com/docs/specifications/2.0.0/#a-name-a2sobject-a-asyncapi-object">AsyncAPI
+ *     specification</a>
  */
 @Data
 @Builder
@@ -22,60 +26,48 @@ import java.util.Set;
 @AllArgsConstructor
 public class AsyncAPI {
     /**
-     * <b>Required.</b>
-     * Specifies the AsyncAPI Specification version being used.
-     * It can be used by tooling Specifications and clients to interpret the version.
-     * The structure shall be major.minor.patch, where patch versions must be compatible
-     * with the existing major.minor tooling.
-     * Typically patch versions will be introduced to address errors in the documentation,
-     * and tooling should typically be compatible with the corresponding major.minor (1.0.*).
-     * Patch versions will correspond to patches of this document.
+     * <b>Required.</b> Specifies the AsyncAPI Specification version being used. It can be used by
+     * tooling Specifications and clients to interpret the version. The structure shall be
+     * major.minor.patch, where patch versions must be compatible with the existing major.minor
+     * tooling. Typically patch versions will be introduced to address errors in the documentation,
+     * and tooling should typically be compatible with the corresponding major.minor (1.0.*). Patch
+     * versions will correspond to patches of this document.
      */
-    @NonNull
-    @Builder.Default
-    private String asyncapi = "2.0.0";
+    @NonNull @Builder.Default private String asyncapi = "2.0.0";
 
     /**
-     * <b>Required.</b>
-     * Provides metadata about the API. The metadata can be used by the clients if needed.
+     * <b>Required.</b> Provides metadata about the API. The metadata can be used by the clients if
+     * needed.
      */
-    @NonNull
-    private Info info;
+    @NonNull private Info info;
 
     /**
-     * A string representing the default content type to use when encoding/decoding a message's payload.
-     * The value MUST be a specific media type (e.g. application/json).
-     * This value MUST be used by schema parsers when the contentType property is omitted.
-     * In case a message can't be encoded/decoded using this value, schema parsers MUST use their default content type.
+     * A string representing the default content type to use when encoding/decoding a message's
+     * payload. The value MUST be a specific media type (e.g. application/json). This value MUST be
+     * used by schema parsers when the contentType property is omitted. In case a message can't be
+     * encoded/decoded using this value, schema parsers MUST use their default content type.
      */
     private String defaultContentType;
 
-    /**
-     * Provides connection details of servers.
-     */
+    /** Provides connection details of servers. */
     private Map<String, Server> servers;
 
     /**
-     * <b>Required.</b>
-     * The available channels and messages for the API.
-     * Channels are also known as "topics", "routing keys", "event types" or "paths".
+     * <b>Required.</b> The available channels and messages for the API. Channels are also known as
+     * "topics", "routing keys", "event types" or "paths".
      */
-    @NonNull
-    private Map<String, ChannelItem> channels;
+    @NonNull private Map<String, ChannelItem> channels;
 
     /**
-     * Holds a set of reusable objects for different aspects of the AsyncAPI specification.
-     * All objects defined within the components object will have no effect on the API unless they are explicitly
-     * referenced from properties outside the components object.
+     * Holds a set of reusable objects for different aspects of the AsyncAPI specification. All
+     * objects defined within the components object will have no effect on the API unless they are
+     * explicitly referenced from properties outside the components object.
      */
     private Components components;
 
     /**
-     * <b>Required.</b>
-     * A set of tags used by the specification with additional metadata. Each tag name in the set MUST be unique.
+     * <b>Required.</b> A set of tags used by the specification with additional metadata. Each tag
+     * name in the set MUST be unique.
      */
-    @NotNull
-    @Builder.Default
-    private Set<Tag> tags = Collections.emptySet();
-
+    @NotNull @Builder.Default private Set<Tag> tags = Collections.emptySet();
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/Components.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/Components.java
@@ -9,11 +9,12 @@ import lombok.NoArgsConstructor;
 import java.util.Map;
 
 /**
- * Holds a set of reusable objects for different aspects of the AsyncAPI specification.
- * All objects defined within the components object will have no effect on the API unless they are explicitly
+ * Holds a set of reusable objects for different aspects of the AsyncAPI specification. All objects
+ * defined within the components object will have no effect on the API unless they are explicitly
  * referenced from properties outside the components object.
  *
- * @see <a href="https://www.asyncapi.com/docs/specifications/2.0.0/#componentsObject">Components specification</a>
+ * @see <a href="https://www.asyncapi.com/docs/specifications/2.0.0/#componentsObject">Components
+ *     specification</a>
  */
 @Data
 @Builder
@@ -22,5 +23,4 @@ import java.util.Map;
 public class Components {
 
     private Map<String, Schema> schemas;
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ConsumerData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ConsumerData.java
@@ -10,55 +10,38 @@ import lombok.NoArgsConstructor;
 
 import java.util.Map;
 
-/**
- * Holds information about a producer channel.
- * All fields must be set and not null.
- */
+/** Holds information about a producer channel. All fields must be set and not null. */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ConsumerData implements OperationData {
 
-    /**
-     * The name of the channel (topic, queue etc.).
-     */
+    /** The name of the channel (topic, queue etc.). */
     protected String channelName;
 
-    /**
-     * Optional, additional information about the channel and/or its message
-     */
+    /** Optional, additional information about the channel and/or its message */
     protected String description;
 
     /**
-     * The channel binding of the producer.
-     * <br>
-     * For example:
-     * <code>
+     * The channel binding of the producer. <br>
+     * For example: <code>
      *     ImmutableMap.of("kafka", new KafkaChannelBinding())
      * </code>
      */
     protected Map<String, ? extends ChannelBinding> channelBinding;
 
-    /**
-     * The class object of the payload published by this consumer.
-     */
+    /** The class object of the payload published by this consumer. */
     protected Class<?> payloadType;
 
-    /**
-     * The message headers, usually describing the payload.
-     */
-    @Builder.Default
-    protected AsyncHeaders headers = AsyncHeaders.NOT_DOCUMENTED;
+    /** The message headers, usually describing the payload. */
+    @Builder.Default protected AsyncHeaders headers = AsyncHeaders.NOT_DOCUMENTED;
 
     /**
-     * The operation binding of the consumer.
-     * <br>
-     * For example:
-     * <code>
+     * The operation binding of the consumer. <br>
+     * For example: <code>
      *     ImmutableMap.of("kafka", new KafkaOperationBinding())
      * </code>
      */
     protected Map<String, ? extends OperationBinding> operationBinding;
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/OperationData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/OperationData.java
@@ -10,40 +10,30 @@ import java.util.Map;
  * Generic, internal interface used by springwolf scanners to process listener and producer data.
  */
 public interface OperationData {
-    /**
-     * The name of the channel (topic, queue etc.).
-     */
+    /** The name of the channel (topic, queue etc.). */
     String getChannelName();
 
-    /**
-     * Optional, additional information about the channel and/or its message
-     */
+    /** Optional, additional information about the channel and/or its message */
     String getDescription();
 
-    /**
-     * The channel binding.
-     */
+    /** The channel binding. */
     Map<String, ? extends ChannelBinding> getChannelBinding();
 
-    /**
-     * The class object of the payload.
-     */
+    /** The class object of the payload. */
     Class<?> getPayloadType();
 
-    /**
-     * The message headers, usually describing the payload.
-     */
+    /** The message headers, usually describing the payload. */
     AsyncHeaders getHeaders();
 
-    /**
-     * The operation binding.
-     */
+    /** The operation binding. */
     Map<String, ? extends OperationBinding> getOperationBinding();
 
     enum OperationType {
-        PUBLISH("publish"), SUBSCRIBE("subscribe");
+        PUBLISH("publish"),
+        SUBSCRIBE("subscribe");
 
         public final String operationName;
+
         OperationType(String operationName) {
             this.operationName = operationName;
         }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ProducerData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ProducerData.java
@@ -10,55 +10,38 @@ import lombok.NoArgsConstructor;
 
 import java.util.Map;
 
-/**
- * Holds information about a producer channel.
- * All fields must be set and not null.
- */
+/** Holds information about a producer channel. All fields must be set and not null. */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProducerData implements OperationData {
 
-    /**
-     * The name of the channel (topic, queue etc.).
-     */
+    /** The name of the channel (topic, queue etc.). */
     protected String channelName;
 
-    /**
-     * Optional, additional information about the channel and its message
-     */
+    /** Optional, additional information about the channel and its message */
     protected String description;
 
     /**
-     * The channel binding of the producer.
-     * <br>
-     * For example:
-     * <code>
+     * The channel binding of the producer. <br>
+     * For example: <code>
      *     ImmutableMap.of("kafka", new KafkaChannelBinding())
      * </code>
      */
     protected Map<String, ? extends ChannelBinding> channelBinding;
 
-    /**
-     * The class object of the payload published by this producer.
-     */
+    /** The class object of the payload published by this producer. */
     protected Class<?> payloadType;
 
-    /**
-     * The class object of the headers published by this producer.
-     */
-    @Builder.Default
-    protected AsyncHeaders headers = AsyncHeaders.NOT_DOCUMENTED;
+    /** The class object of the headers published by this producer. */
+    @Builder.Default protected AsyncHeaders headers = AsyncHeaders.NOT_DOCUMENTED;
 
     /**
-     * The operation binding of the producer.
-     * <br>
-     * For example:
-     * <code>
+     * The operation binding of the producer. <br>
+     * For example: <code>
      *     ImmutableMap.of("kafka", new KafkaOperationBinding())
      * </code>
      */
     protected Map<String, ? extends OperationBinding> operationBinding;
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/bindings/EmptyChannelBinding.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/bindings/EmptyChannelBinding.java
@@ -2,5 +2,4 @@ package io.github.stavshamir.springwolf.asyncapi.types.channel.bindings;
 
 import com.asyncapi.v2.binding.ChannelBinding;
 
-public class EmptyChannelBinding extends ChannelBinding {
-}
+public class EmptyChannelBinding extends ChannelBinding {}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/bindings/EmptyOperationBinding.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/bindings/EmptyOperationBinding.java
@@ -2,6 +2,4 @@ package io.github.stavshamir.springwolf.asyncapi.types.channel.operation.binding
 
 import com.asyncapi.v2.binding.OperationBinding;
 
-public class EmptyOperationBinding extends OperationBinding {
-
-}
+public class EmptyOperationBinding extends OperationBinding {}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
@@ -6,7 +6,8 @@ import lombok.*;
 /**
  * Describes a message received on a given channel and operation.
  *
- * @see <a href="https://www.asyncapi.com/docs/specifications/2.0.0/#messageObject">Message specification</a>
+ * @see <a href="https://www.asyncapi.com/docs/specifications/2.0.0/#messageObject">Message
+ *     specification</a>
  */
 @Data
 @Builder
@@ -15,19 +16,13 @@ import lombok.*;
 @AllArgsConstructor
 public class Message {
 
-    /**
-     * A machine-friendly name for the message.
-     */
+    /** A machine-friendly name for the message. */
     private String name;
 
-    /**
-     * A human-friendly title for the message.
-     */
+    /** A human-friendly title for the message. */
     private String title;
 
-    /**
-     * A human-friendly description for the message.
-     */
+    /** A human-friendly description for the message. */
     private String description;
 
     private PayloadReference payload;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/PayloadReference.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/PayloadReference.java
@@ -10,10 +10,7 @@ import lombok.ToString;
 @ToString
 public class PayloadReference {
 
-    @Getter
-    @EqualsAndHashCode.Include
-    @ToString.Include
-    private String $ref;
+    @Getter @EqualsAndHashCode.Include @ToString.Include private String $ref;
 
     private PayloadReference(String $ref) {
         this.$ref = $ref;
@@ -22,5 +19,4 @@ public class PayloadReference {
     public static PayloadReference fromModelName(String modelName) {
         return new PayloadReference("#/components/schemas/" + modelName);
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeaderSchema.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeaderSchema.java
@@ -7,10 +7,9 @@ import lombok.Builder;
 import java.util.List;
 
 public class AsyncHeaderSchema extends StringSchema {
-    @JsonIgnore
-    private final String headerName;
-    
-    public AsyncHeaderSchema(String headerName){
+    @JsonIgnore private final String headerName;
+
+    public AsyncHeaderSchema(String headerName) {
         super();
         this.headerName = headerName;
     }
@@ -20,7 +19,8 @@ public class AsyncHeaderSchema extends StringSchema {
     }
 
     @Builder(builderMethodName = "headerBuilder")
-    private static AsyncHeaderSchema createHeader(String headerName, String description, String example, List<String> enumValue) {
+    private static AsyncHeaderSchema createHeader(
+            String headerName, String description, String example, List<String> enumValue) {
         AsyncHeaderSchema header = new AsyncHeaderSchema(headerName);
         header.setDescription(description);
         header.setExample(example);

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeaders.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeaders.java
@@ -6,14 +6,12 @@ import java.util.TreeMap;
 
 public class AsyncHeaders extends TreeMap<String, Schema> {
     /**
-     * Per default, if no headers are explicitly defined, NOT_DOCUMENTED is used.
-     * There can be headers, but don't have to be.
+     * Per default, if no headers are explicitly defined, NOT_DOCUMENTED is used. There can be
+     * headers, but don't have to be.
      */
-    public final static AsyncHeaders NOT_DOCUMENTED = new AsyncHeaders("HeadersNotDocumented");
-    /**
-     * Explicitly document that no headers are used.
-     */
-    public final static AsyncHeaders NOT_USED = new AsyncHeaders("HeadersNotUsed");
+    public static final AsyncHeaders NOT_DOCUMENTED = new AsyncHeaders("HeadersNotDocumented");
+    /** Explicitly document that no headers are used. */
+    public static final AsyncHeaders NOT_USED = new AsyncHeaders("HeadersNotUsed");
 
     private final String schemaName;
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeadersForCloudEventsBuilder.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeadersForCloudEventsBuilder.java
@@ -28,27 +28,25 @@ public class AsyncHeadersForCloudEventsBuilder {
         return withContentTypeHeader(contentType, of(contentType));
     }
 
-    public AsyncHeadersForCloudEventsBuilder withContentTypeHeader(MediaType exampleContentType, List<MediaType> contentTypeValues) {
-        List<String> contentTypeStringValues = contentTypeValues.stream().map(MimeType::toString).collect(toList());
+    public AsyncHeadersForCloudEventsBuilder withContentTypeHeader(
+            MediaType exampleContentType, List<MediaType> contentTypeValues) {
+        List<String> contentTypeStringValues =
+                contentTypeValues.stream().map(MimeType::toString).collect(toList());
         return withHeader(
                 "content-type",
                 contentTypeStringValues,
                 exampleContentType.toString(),
-                "CloudEvent Content-Type Header"
-        );
+                "CloudEvent Content-Type Header");
     }
 
     public AsyncHeadersForCloudEventsBuilder withSpecVersionHeader(String specVersion) {
         return withSpecVersionHeader(specVersion, of(specVersion));
     }
 
-    public AsyncHeadersForCloudEventsBuilder withSpecVersionHeader(String specVersion, List<String> specValues) {
+    public AsyncHeadersForCloudEventsBuilder withSpecVersionHeader(
+            String specVersion, List<String> specValues) {
         return withHeader(
-                "ce_specversion",
-                specValues,
-                specVersion,
-                "CloudEvent Spec Version Header"
-        );
+                "ce_specversion", specValues, specVersion, "CloudEvent Spec Version Header");
     }
 
     public AsyncHeadersForCloudEventsBuilder withIdHeader(String idExample) {
@@ -56,77 +54,59 @@ public class AsyncHeadersForCloudEventsBuilder {
     }
 
     public AsyncHeadersForCloudEventsBuilder withIdHeader(String idExample, List<String> idValues) {
-        return withHeader(
-                "ce_id",
-                idValues,
-                idExample,
-                "CloudEvent Id Header"
-        );
+        return withHeader("ce_id", idValues, idExample, "CloudEvent Id Header");
     }
 
     public AsyncHeadersForCloudEventsBuilder withTimeHeader(String timeExample) {
         return withTimeHeader(timeExample, of(timeExample));
     }
 
-    public AsyncHeadersForCloudEventsBuilder withTimeHeader(String timeExample, List<String> timeValues) {
-        return withHeader(
-                "ce_time",
-                timeValues,
-                timeExample,
-                "CloudEvent Time Header"
-        );
+    public AsyncHeadersForCloudEventsBuilder withTimeHeader(
+            String timeExample, List<String> timeValues) {
+        return withHeader("ce_time", timeValues, timeExample, "CloudEvent Time Header");
     }
 
     public AsyncHeadersForCloudEventsBuilder withTypeHeader(String typeExample) {
         return withTypeHeader(typeExample, of(typeExample));
     }
 
-    public AsyncHeadersForCloudEventsBuilder withTypeHeader(String typeExample, List<String> typeValues) {
-        return withHeader(
-                "ce_type",
-                typeValues,
-                typeExample,
-                "CloudEvent Payload Type Header"
-        );
+    public AsyncHeadersForCloudEventsBuilder withTypeHeader(
+            String typeExample, List<String> typeValues) {
+        return withHeader("ce_type", typeValues, typeExample, "CloudEvent Payload Type Header");
     }
 
     public AsyncHeadersForCloudEventsBuilder withSourceHeader(String sourceExample) {
         return withSourceHeader(sourceExample, of(sourceExample));
     }
 
-    public AsyncHeadersForCloudEventsBuilder withSourceHeader(String sourceExample, List<String> sourceValues) {
-        return withHeader(
-                "ce_source",
-                sourceValues,
-                sourceExample,
-                "CloudEvent Source Header"
-        );
+    public AsyncHeadersForCloudEventsBuilder withSourceHeader(
+            String sourceExample, List<String> sourceValues) {
+        return withHeader("ce_source", sourceValues, sourceExample, "CloudEvent Source Header");
     }
 
     public AsyncHeadersForCloudEventsBuilder withSubjectHeader(String subjectExample) {
         return withSubjectHeader(subjectExample, of(subjectExample));
     }
 
-    public AsyncHeadersForCloudEventsBuilder withSubjectHeader(String subjectExample, List<String> subjectValues) {
-        return withHeader(
-                "ce_subject",
-                subjectValues,
-                subjectExample,
-                "CloudEvent Subject Header"
-        );
+    public AsyncHeadersForCloudEventsBuilder withSubjectHeader(
+            String subjectExample, List<String> subjectValues) {
+        return withHeader("ce_subject", subjectValues, subjectExample, "CloudEvent Subject Header");
     }
 
-    public AsyncHeadersForCloudEventsBuilder withExtension(String headerName, List<String> values, String exampleValue, String description) {
+    public AsyncHeadersForCloudEventsBuilder withExtension(
+            String headerName, List<String> values, String exampleValue, String description) {
         return withHeader(headerName, values, exampleValue, description);
     }
 
-    private AsyncHeadersForCloudEventsBuilder withHeader(String headerName, List<String> values, String exampleValue, String description) {
-        AsyncHeaderSchema header = AsyncHeaderSchema.headerBuilder()
-                .headerName(headerName)
-                .description(description)
-                .example(exampleValue)
-                .enumValue(values)
-                .build();
+    private AsyncHeadersForCloudEventsBuilder withHeader(
+            String headerName, List<String> values, String exampleValue, String description) {
+        AsyncHeaderSchema header =
+                AsyncHeaderSchema.headerBuilder()
+                        .headerName(headerName)
+                        .description(description)
+                        .example(exampleValue)
+                        .enumValue(values)
+                        .build();
         headers.addHeader(header);
         return this;
     }
@@ -134,5 +114,4 @@ public class AsyncHeadersForCloudEventsBuilder {
     public AsyncHeaders build() {
         return AsyncHeaders.from(this.headers, this.headers.getSchemaName());
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/HeaderReference.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/HeaderReference.java
@@ -10,10 +10,7 @@ import lombok.ToString;
 @ToString
 public class HeaderReference {
 
-    @Getter
-    @EqualsAndHashCode.Include
-    @ToString.Include
-    private String $ref;
+    @Getter @EqualsAndHashCode.Include @ToString.Include private String $ref;
 
     private HeaderReference(String $ref) {
         this.$ref = $ref;
@@ -22,5 +19,4 @@ public class HeaderReference {
     public static HeaderReference fromModelName(String modelName) {
         return new HeaderReference("#/components/schemas/" + modelName);
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/AsyncApiDocket.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/AsyncApiDocket.java
@@ -14,41 +14,32 @@ import java.util.Map;
 
 /**
  * Use to (manually) configure springwolf
- * <p>
- * This will not be the final AsyncApiDocket, use {@link AsyncApiDocketService#getAsyncApiDocket()} to get it.
- * This will not be the final api definition, use {@link io.github.stavshamir.springwolf.asyncapi.AsyncApiService} to get it.
+ *
+ * <p>This will not be the final AsyncApiDocket, use {@link
+ * AsyncApiDocketService#getAsyncApiDocket()} to get it. This will not be the final api definition,
+ * use {@link io.github.stavshamir.springwolf.asyncapi.AsyncApiService} to get it.
  */
 @Data
 @Builder
 public class AsyncApiDocket {
 
-    /**
-     * The base package containing the declarations of consumers and producer beans.
-     */
+    /** The base package containing the declarations of consumers and producer beans. */
     private final String basePackage;
 
     /**
-     * <b>Required.</b>
-     * Provide metadata about the API. The metadata can be used by the clients if needed.
+     * <b>Required.</b> Provide metadata about the API. The metadata can be used by the clients if
+     * needed.
      *
-     * @see <a href="https://www.asyncapi.com/docs/specifications/2.0.0/#infoObject">Info specification</a>
+     * @see <a href="https://www.asyncapi.com/docs/specifications/2.0.0/#infoObject">Info
+     *     specification</a>
      */
-    @NonNull
-    private final Info info;
+    @NonNull private final Info info;
 
-    /**
-     * Provides connection details of servers.
-     */
-    @Singular
-    private final Map<String, Server> servers;
+    /** Provides connection details of servers. */
+    @Singular private final Map<String, Server> servers;
 
-    /**
-     * Provides information about the producers.
-     */
-    @Singular
-    private final List<ProducerData> producers;
+    /** Provides information about the producers. */
+    @Singular private final List<ProducerData> producers;
 
-    @Singular
-    private final List<ConsumerData> consumers;
-
+    @Singular private final List<ConsumerData> consumers;
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketService.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
+
 import java.util.Optional;
 
 @Slf4j
@@ -15,14 +16,10 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class DefaultAsyncApiDocketService implements AsyncApiDocketService {
 
-    /**
-     * Docket defined by the user as a @Bean
-     */
+    /** Docket defined by the user as a @Bean */
     private final Optional<AsyncApiDocket> customDocket;
 
-    /**
-     * Docket definition in application.properties
-     */
+    /** Docket definition in application.properties */
     private final Optional<SpringWolfConfigProperties> configProperties;
 
     @Override
@@ -34,16 +31,23 @@ public class DefaultAsyncApiDocketService implements AsyncApiDocketService {
             log.debug("Reading springwolf configuration from application.properties files");
             return parseApplicationConfigProperties(configProperties.get());
         }
-        throw new IllegalArgumentException("No springwolf configuration found. " +
-                "Either define the properties in the application.properties under the " + SpringWolfConfigConstants.SPRINGWOLF_CONFIG_PREFIX + " prefix " +
-                "or add a @Bean AsyncApiDocket to the spring context");
+        throw new IllegalArgumentException(
+                "No springwolf configuration found. "
+                        + "Either define the properties in the application.properties under the "
+                        + SpringWolfConfigConstants.SPRINGWOLF_CONFIG_PREFIX
+                        + " prefix "
+                        + "or add a @Bean AsyncApiDocket to the spring context");
     }
 
-    private AsyncApiDocket parseApplicationConfigProperties(SpringWolfConfigProperties configProperties) {
-        if (configProperties.getDocket() == null ||
-                configProperties.getDocket().getBasePackage() == null) {
-            throw new IllegalArgumentException("One or more required fields (docket, basePackage) " +
-                    "in application.properties with path prefix " + SpringWolfConfigConstants.SPRINGWOLF_CONFIG_PREFIX + " is not set.");
+    private AsyncApiDocket parseApplicationConfigProperties(
+            SpringWolfConfigProperties configProperties) {
+        if (configProperties.getDocket() == null
+                || configProperties.getDocket().getBasePackage() == null) {
+            throw new IllegalArgumentException(
+                    "One or more required fields (docket, basePackage) "
+                            + "in application.properties with path prefix "
+                            + SpringWolfConfigConstants.SPRINGWOLF_CONFIG_PREFIX
+                            + " is not set.");
         }
 
         Info info = buildInfo(configProperties.getDocket().getInfo());
@@ -56,11 +60,12 @@ public class DefaultAsyncApiDocketService implements AsyncApiDocketService {
     }
 
     private static Info buildInfo(@Nullable SpringWolfConfigProperties.ConfigDocket.Info info) {
-        if (info == null ||
-                info.getVersion() == null ||
-                info.getTitle() == null) {
-            throw new IllegalArgumentException("One or more required fields of the info object (title, version) " +
-                    "in application.properties with path prefix " + SpringWolfConfigConstants.SPRINGWOLF_CONFIG_PREFIX + " is not set.");
+        if (info == null || info.getVersion() == null || info.getTitle() == null) {
+            throw new IllegalArgumentException(
+                    "One or more required fields of the info object (title, version) "
+                            + "in application.properties with path prefix "
+                            + SpringWolfConfigConstants.SPRINGWOLF_CONFIG_PREFIX
+                            + " is not set.");
         }
 
         return Info.builder()
@@ -71,6 +76,4 @@ public class DefaultAsyncApiDocketService implements AsyncApiDocketService {
                 .license(info.getLicense())
                 .build();
     }
-
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/EnableAsyncApi.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/EnableAsyncApi.java
@@ -13,13 +13,15 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Enable the documentation of asynchronous consumer endpoints (methods annotated by @KafkaListener in a class annotated with @{@link Component}).
- * <br>
- * This annotation should be applied to a Spring java config and should have an accompanying '@{@link Configuration}' annotation.
+ * Enable the documentation of asynchronous consumer endpoints (methods annotated by @KafkaListener
+ * in a class annotated with @{@link Component}). <br>
+ * This annotation should be applied to a Spring java config and should have an accompanying
+ * '@{@link Configuration}' annotation.
+ *
  * @author Stav Shamir
  */
-@Retention(value=RUNTIME)
-@Target(value=TYPE)
-@ComponentScan(basePackages={"io/github/stavshamir/springwolf"})
+@Retention(value = RUNTIME)
+@Target(value = TYPE)
+@ComponentScan(basePackages = {"io/github/stavshamir/springwolf"})
 @ConditionalOnProperty(name = SpringWolfConfigConstants.SPRINGWOLF_ENABLED, matchIfMissing = true)
-public @interface EnableAsyncApi { }
+public @interface EnableAsyncApi {}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasService.java
@@ -29,9 +29,11 @@ public class DefaultSchemasService implements SchemasService {
     private final Map<String, Schema> definitions = new TreeMap<>();
 
     public DefaultSchemasService(Optional<List<ModelConverter>> externalModelConverters) {
-        externalModelConverters.ifPresent(converters -> converters.forEach(converter::addConverter));
+        externalModelConverters.ifPresent(
+                converters -> converters.forEach(converter::addConverter));
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        SimpleModule simpleModule = new SimpleModule().addSerializer(new JsonNodeExampleSerializer());
+        SimpleModule simpleModule =
+                new SimpleModule().addSerializer(new JsonNodeExampleSerializer());
         objectMapper.registerModule(simpleModule);
     }
 
@@ -40,7 +42,8 @@ public class DefaultSchemasService implements SchemasService {
         // The examples must first be set as JSON strings (the inflector does not work otherwise)
         definitions.forEach(this::buildExampleAsString);
 
-        // Then they must be deserialized to map, or they will be serialized as reguler string and not json by the
+        // Then they must be deserialized to map, or they will be serialized as reguler string and
+        // not json by the
         // object mapper
         definitions.forEach(this::deserializeExampleToMap);
         return definitions;
@@ -101,5 +104,4 @@ public class DefaultSchemasService implements SchemasService {
             log.error("Failed to convert example object of {} to map", schema.getName());
         }
     }
-
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/SchemasService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/SchemasService.java
@@ -10,6 +10,6 @@ public interface SchemasService {
     Map<String, Schema> getDefinitions();
 
     String register(AsyncHeaders headers);
-    String register(Class<?> type);
 
+    String register(Class<?> type);
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/CustomBeanAsyncApiDocketConfiguration.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/CustomBeanAsyncApiDocketConfiguration.java
@@ -10,10 +10,11 @@ class CustomBeanAsyncApiDocketConfiguration {
     @Bean
     public AsyncApiDocket docket() {
         return AsyncApiDocket.builder()
-                .info(Info.builder()
-                        .title("AsyncApiDocketConfiguration-title")
-                        .version("AsyncApiDocketConfiguration-version")
-                        .build())
+                .info(
+                        Info.builder()
+                                .title("AsyncApiDocketConfiguration-title")
+                                .version("AsyncApiDocketConfiguration-version")
+                                .build())
                 .build();
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/SpringContextTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/SpringContextTest.java
@@ -18,25 +18,24 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-
 public class SpringContextTest {
 
     @ExtendWith(SpringExtension.class)
-    @ContextConfiguration(classes = {
-            CustomBeanAsyncApiDocketConfiguration.class, // user has defined an own AsyncApiDocket bean
-            DefaultAsyncApiDocketService.class,
-            DefaultAsyncApiService.class,
-            DefaultChannelsService.class,
-            DefaultSchemasService.class,
-            DefaultAsyncApiService.class,
-            DefaultAsyncApiSerializerService.class,
-    })
+    @ContextConfiguration(
+            classes = {
+                CustomBeanAsyncApiDocketConfiguration
+                        .class, // user has defined an own AsyncApiDocket bean
+                DefaultAsyncApiDocketService.class,
+                DefaultAsyncApiService.class,
+                DefaultChannelsService.class,
+                DefaultSchemasService.class,
+                DefaultAsyncApiService.class,
+                DefaultAsyncApiSerializerService.class,
+            })
     public static class AsyncApiDocketTest {
 
-        @Autowired
-        private ApplicationContext context;
-        @Autowired
-        private AsyncApiService asyncApiService;
+        @Autowired private ApplicationContext context;
+        @Autowired private AsyncApiService asyncApiService;
 
         @Test
         public void testContextWithAsyncApiDocketBean() {
@@ -47,31 +46,32 @@ public class SpringContextTest {
     }
 
     @ExtendWith(SpringExtension.class)
-    @ContextConfiguration(classes = {
-            DefaultAsyncApiDocketService.class,
-            DefaultAsyncApiService.class,
-            DefaultChannelsService.class,
-            DefaultSchemasService.class,
-            DefaultAsyncApiService.class,
-            DefaultAsyncApiSerializerService.class,
-    })
-    @EnableConfigurationProperties(value = {
-            SpringWolfConfigProperties.class,
-    })
-    @TestPropertySource(properties = {
-            "springwolf.enabled=true",
-            "springwolf.docket.info.title=Info title was loaded from spring properties",
-            "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
-            "springwolf.docket.servers.test-protocol.protocol=test",
-            "springwolf.docket.servers.test-protocol.url=some-server:1234",
-    })
+    @ContextConfiguration(
+            classes = {
+                DefaultAsyncApiDocketService.class,
+                DefaultAsyncApiService.class,
+                DefaultChannelsService.class,
+                DefaultSchemasService.class,
+                DefaultAsyncApiService.class,
+                DefaultAsyncApiSerializerService.class,
+            })
+    @EnableConfigurationProperties(
+            value = {
+                SpringWolfConfigProperties.class,
+            })
+    @TestPropertySource(
+            properties = {
+                "springwolf.enabled=true",
+                "springwolf.docket.info.title=Info title was loaded from spring properties",
+                "springwolf.docket.info.version=1.0.0",
+                "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+                "springwolf.docket.servers.test-protocol.protocol=test",
+                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+            })
     public static class ApplicationPropertiesConfigurationTest {
 
-        @Autowired
-        private ApplicationContext context;
-        @Autowired
-        private AsyncApiService asyncApiService;
+        @Autowired private ApplicationContext context;
+        @Autowired private AsyncApiService asyncApiService;
 
         @Test
         public void testContextWithApplicationProperties() {

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerServiceTest.java
@@ -35,63 +35,74 @@ import java.util.Map;
 @ContextConfiguration(classes = {DefaultAsyncApiSerializerService.class})
 public class DefaultAsyncApiSerializerServiceTest {
 
-    @Autowired
-    private DefaultAsyncApiSerializerService serializer;
+    @Autowired private DefaultAsyncApiSerializerService serializer;
 
     @Test
     public void AsyncAPI_should_map_to_a_valid_asyncapi_json() throws IOException, JSONException {
-        Info info = Info.builder()
-                .title("AsyncAPI Sample App")
-                .version("1.0.1")
-                .description("This is a sample server.")
-                .termsOfService("http://asyncapi.org/terms/")
-                .contact(Contact.builder()
-                        .name("API Support")
-                        .url("http://www.asyncapi.org/support")
-                        .email("support@asyncapi.org")
-                        .build())
-                .license(License.builder()
-                        .name("Apache 2.0")
-                        .url("http://www.apache.org/licenses/LICENSE-2.0.html")
-                        .build())
-                .build();
+        Info info =
+                Info.builder()
+                        .title("AsyncAPI Sample App")
+                        .version("1.0.1")
+                        .description("This is a sample server.")
+                        .termsOfService("http://asyncapi.org/terms/")
+                        .contact(
+                                Contact.builder()
+                                        .name("API Support")
+                                        .url("http://www.asyncapi.org/support")
+                                        .email("support@asyncapi.org")
+                                        .build())
+                        .license(
+                                License.builder()
+                                        .name("Apache 2.0")
+                                        .url("http://www.apache.org/licenses/LICENSE-2.0.html")
+                                        .build())
+                        .build();
 
-        Server productionServer = Server.builder()
-                .url("development.gigantic-server.com")
-                .description("Development server")
-                .protocol("kafka")
-                .protocolVersion("1.0.0")
-                .build();
+        Server productionServer =
+                Server.builder()
+                        .url("development.gigantic-server.com")
+                        .description("Development server")
+                        .protocol("kafka")
+                        .protocolVersion("1.0.0")
+                        .build();
 
-        Message message = Message.builder()
-                .name("io.github.stavshamir.springwolf.ExamplePayload")
-                .title("Example Payload")
-                .payload(PayloadReference.fromModelName("ExamplePayload"))
-                .build();
+        Message message =
+                Message.builder()
+                        .name("io.github.stavshamir.springwolf.ExamplePayload")
+                        .title("Example Payload")
+                        .payload(PayloadReference.fromModelName("ExamplePayload"))
+                        .build();
 
-        OperationBinding operationBinding = KafkaOperationBinding.builder().groupId("myGroupId").build();
+        OperationBinding operationBinding =
+                KafkaOperationBinding.builder().groupId("myGroupId").build();
 
-        Operation newUserOperation = Operation.builder()
-                .description("Auto-generated description")
-                .operationId("new-user_listenerMethod_subscribe")
-                .message(message)
-                .bindings(ImmutableMap.of("kafka", operationBinding))
-                .build();
+        Operation newUserOperation =
+                Operation.builder()
+                        .description("Auto-generated description")
+                        .operationId("new-user_listenerMethod_subscribe")
+                        .message(message)
+                        .bindings(ImmutableMap.of("kafka", operationBinding))
+                        .build();
 
-        ChannelItem newUserChannel = ChannelItem.builder()
-                .description("This channel is used to exchange messages about users signing up")
-                .subscribe(newUserOperation)
-                .build();
+        ChannelItem newUserChannel =
+                ChannelItem.builder()
+                        .description(
+                                "This channel is used to exchange messages about users signing up")
+                        .subscribe(newUserOperation)
+                        .build();
 
-        Map<String, Schema> schemas = ModelConverters.getInstance().read(DefaultAsyncApiSerializerServiceTest.ExamplePayload.class);
+        Map<String, Schema> schemas =
+                ModelConverters.getInstance()
+                        .read(DefaultAsyncApiSerializerServiceTest.ExamplePayload.class);
 
-        AsyncAPI asyncapi = AsyncAPI.builder()
-                .info(info)
-                .defaultContentType("application/json")
-                .servers(ImmutableMap.of("production", productionServer))
-                .channels(ImmutableMap.of("new-user", newUserChannel))
-                .components(Components.builder().schemas(schemas).build())
-                .build();
+        AsyncAPI asyncapi =
+                AsyncAPI.builder()
+                        .info(info)
+                        .defaultContentType("application/json")
+                        .servers(ImmutableMap.of("production", productionServer))
+                        .channels(ImmutableMap.of("new-user", newUserChannel))
+                        .components(Components.builder().schemas(schemas).build())
+                        .build();
 
         String actual = serializer.toJsonString(asyncapi);
         System.out.println("Got: " + actual);
@@ -104,5 +115,4 @@ public class DefaultAsyncApiSerializerServiceTest {
     static class ExamplePayload {
         String s;
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
@@ -27,14 +27,15 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {
-        DefaultAsyncApiDocketService.class,
-        DefaultAsyncApiService.class,
-        DefaultChannelsService.class,
-        DefaultSchemasService.class,
-        ProducerOperationDataScanner.class,
-        ConsumerOperationDataScanner.class
-})
+@ContextConfiguration(
+        classes = {
+            DefaultAsyncApiDocketService.class,
+            DefaultAsyncApiService.class,
+            DefaultChannelsService.class,
+            DefaultSchemasService.class,
+            ProducerOperationDataScanner.class,
+            ConsumerOperationDataScanner.class
+        })
 @Import(DefaultAsyncApiServiceTest.DefaultAsyncApiServiceTestConfiguration.class)
 public class DefaultAsyncApiServiceTest {
 
@@ -43,23 +44,23 @@ public class DefaultAsyncApiServiceTest {
 
         @Bean
         public AsyncApiDocket docket() {
-            Info info = Info.builder()
-                    .title("Test")
-                    .version("1.0.0")
-                    .build();
+            Info info = Info.builder().title("Test").version("1.0.0").build();
 
-            ProducerData kafkaProducerData = ProducerData.builder()
-                    .channelName("producer-topic")
-                    .description("producer-topic-description")
-                    .payloadType(String.class)
-                    .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                    .build();
+            ProducerData kafkaProducerData =
+                    ProducerData.builder()
+                            .channelName("producer-topic")
+                            .description("producer-topic-description")
+                            .payloadType(String.class)
+                            .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                            .build();
 
-            ConsumerData kafkaConsumerData = ConsumerData.builder()
-                    .channelName("consumer-topic")
-                    .description("consumer-topic-description")
-                    .payloadType(String.class)
-                    .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding())).build();
+            ConsumerData kafkaConsumerData =
+                    ConsumerData.builder()
+                            .channelName("consumer-topic")
+                            .description("consumer-topic-description")
+                            .payloadType(String.class)
+                            .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                            .build();
 
             return AsyncApiDocket.builder()
                     .info(info)
@@ -69,38 +70,31 @@ public class DefaultAsyncApiServiceTest {
                     .consumer(kafkaConsumerData)
                     .build();
         }
-
     }
 
-    @Autowired
-    private AsyncApiDocket docket;
+    @Autowired private AsyncApiDocket docket;
 
-    @Autowired
-    private DefaultAsyncApiService asyncApiService;
+    @Autowired private DefaultAsyncApiService asyncApiService;
 
     @Test
     public void getAsyncAPI_info_should_be_correct() {
         Info actualInfo = asyncApiService.getAsyncAPI().getInfo();
 
-        assertThat(actualInfo).
-                isEqualTo(docket.getInfo());
+        assertThat(actualInfo).isEqualTo(docket.getInfo());
     }
 
     @Test
     public void getAsyncAPI_servers_should_be_correct() {
         Map<String, Server> actualServers = asyncApiService.getAsyncAPI().getServers();
 
-        assertThat(actualServers).
-                isEqualTo(docket.getServers());
+        assertThat(actualServers).isEqualTo(docket.getServers());
     }
 
     @Test
     public void getAsyncAPI_producers_should_be_correct() {
         Map<String, ChannelItem> actualChannels = asyncApiService.getAsyncAPI().getChannels();
 
-        assertThat(actualChannels)
-                .isNotEmpty()
-                .containsKey("producer-topic");
+        assertThat(actualChannels).isNotEmpty().containsKey("producer-topic");
 
         final ChannelItem channel = actualChannels.get("producer-topic");
         assertThat(channel.getSubscribe()).isNotNull();
@@ -112,14 +106,11 @@ public class DefaultAsyncApiServiceTest {
     public void getAsyncAPI_consumers_should_be_correct() {
         Map<String, ChannelItem> actualChannels = asyncApiService.getAsyncAPI().getChannels();
 
-        assertThat(actualChannels)
-                .isNotEmpty()
-                .containsKey("consumer-topic");
+        assertThat(actualChannels).isNotEmpty().containsKey("consumer-topic");
 
         final ChannelItem channel = actualChannels.get("consumer-topic");
         assertThat(channel.getPublish()).isNotNull();
         final Message message = (Message) channel.getPublish().getMessage();
         assertThat(message.getDescription()).isEqualTo("consumer-topic-description");
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsServiceTest.java
@@ -16,23 +16,21 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {
-        DefaultChannelsService.class,
-        DefaultChannelsServiceTest.FooChannelScanner.class,
-        DefaultChannelsServiceTest.BarChannelScanner.class,
-        DefaultChannelsServiceTest.SameTopic.SubscribeChannelScanner.class,
-        DefaultChannelsServiceTest.SameTopic.ProduceChannelScanner.class
-})
+@ContextConfiguration(
+        classes = {
+            DefaultChannelsService.class,
+            DefaultChannelsServiceTest.FooChannelScanner.class,
+            DefaultChannelsServiceTest.BarChannelScanner.class,
+            DefaultChannelsServiceTest.SameTopic.SubscribeChannelScanner.class,
+            DefaultChannelsServiceTest.SameTopic.ProduceChannelScanner.class
+        })
 public class DefaultChannelsServiceTest {
 
-    @Autowired
-    private DefaultChannelsService defaultChannelsService;
+    @Autowired private DefaultChannelsService defaultChannelsService;
 
-    @Autowired
-    private FooChannelScanner fooChannelScanner;
+    @Autowired private FooChannelScanner fooChannelScanner;
 
-    @Autowired
-    private BarChannelScanner barChannelScanner;
+    @Autowired private BarChannelScanner barChannelScanner;
 
     @Test
     public void getChannels() {
@@ -62,30 +60,34 @@ public class DefaultChannelsServiceTest {
 
     static class SameTopic {
         static final String topicName = "subscribeProduceTopic";
-        static final ChannelItem expectedMergedChannel = ChannelItem.builder()
-            .publish(SameTopic.ProduceChannelScanner.publishOperation)
-            .subscribe(SameTopic.SubscribeChannelScanner.subscribeOperation)
-            .build();
+        static final ChannelItem expectedMergedChannel =
+                ChannelItem.builder()
+                        .publish(SameTopic.ProduceChannelScanner.publishOperation)
+                        .subscribe(SameTopic.SubscribeChannelScanner.subscribeOperation)
+                        .build();
 
         @Component
         static class ProduceChannelScanner implements ChannelsScanner {
-            static final Operation publishOperation = Operation.builder().message("publish").build();
+            static final Operation publishOperation =
+                    Operation.builder().message("publish").build();
 
             @Override
             public Map<String, ChannelItem> scan() {
-                return ImmutableMap.of(topicName, ChannelItem.builder().publish(publishOperation).build());
+                return ImmutableMap.of(
+                        topicName, ChannelItem.builder().publish(publishOperation).build());
             }
         }
 
         @Component
         static class SubscribeChannelScanner implements ChannelsScanner {
-            static final Operation subscribeOperation = Operation.builder().message("consumer").build();
+            static final Operation subscribeOperation =
+                    Operation.builder().message("consumer").build();
 
             @Override
             public Map<String, ChannelItem> scan() {
-                return ImmutableMap.of(topicName, ChannelItem.builder().subscribe(subscribeOperation).build());
+                return ImmutableMap.of(
+                        topicName, ChannelItem.builder().subscribe(subscribeOperation).build());
             }
         }
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
@@ -24,27 +24,18 @@ public class MessageHelperTest {
 
     @Test
     public void toMessageObjectOrComposition_oneMessage() {
-        Message message = Message.builder()
-                .name("foo")
-                .build();
+        Message message = Message.builder().name("foo").build();
 
         Object asObject = toMessageObjectOrComposition(ImmutableSet.of(message));
 
-        assertThat(asObject)
-                .isInstanceOf(Message.class)
-                .isEqualTo(message);
+        assertThat(asObject).isInstanceOf(Message.class).isEqualTo(message);
     }
-
 
     @Test
     public void toMessageObjectOrComposition_multipleMessages() {
-        Message message1 = Message.builder()
-                .name("foo")
-                .build();
+        Message message1 = Message.builder().name("foo").build();
 
-        Message message2 = Message.builder()
-                .name("bar")
-                .build();
+        Message message2 = Message.builder().name("bar").build();
 
         Object asObject = toMessageObjectOrComposition(ImmutableSet.of(message1, message2));
 
@@ -59,39 +50,29 @@ public class MessageHelperTest {
 
         Set<Message> messages = messageObjectToSet(string);
 
-        assertThat(messages)
-                .isEmpty();
+        assertThat(messages).isEmpty();
     }
 
     @Test
     public void messageObjectToSet_Message() {
-        Message message = Message.builder()
-                .name("foo")
-                .build();
+        Message message = Message.builder().name("foo").build();
         Object asObject = toMessageObjectOrComposition(ImmutableSet.of(message));
 
         Set<Message> messages = messageObjectToSet(asObject);
 
-        assertThat(messages)
-                .containsExactly(message);
+        assertThat(messages).containsExactly(message);
     }
 
     @Test
     public void messageObjectToSet_SetOfMessage() {
-        Message message1 = Message.builder()
-                .name("foo")
-                .build();
+        Message message1 = Message.builder().name("foo").build();
 
-        Message message2 = Message.builder()
-                .name("bar")
-                .build();
+        Message message2 = Message.builder().name("bar").build();
 
         Object asObject = toMessageObjectOrComposition(ImmutableSet.of(message1, message2));
 
         Set<Message> messages = messageObjectToSet(asObject);
 
-        assertThat(messages)
-                .containsExactlyInAnyOrder(message1, message2);
+        assertThat(messages).containsExactlyInAnyOrder(message1, message2);
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/beans/DefaultBeanMethodsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/beans/DefaultBeanMethodsScannerTest.java
@@ -22,31 +22,26 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(classes = {DefaultBeanMethodsScanner.class})
 public class DefaultBeanMethodsScannerTest {
 
-    @Autowired
-    private DefaultBeanMethodsScanner beanMethodsScanner;
+    @Autowired private DefaultBeanMethodsScanner beanMethodsScanner;
 
-    @MockBean
-    private ConfigurationClassScanner configurationClassScanner;
+    @MockBean private ConfigurationClassScanner configurationClassScanner;
 
     @Test
     public void name() {
         when(configurationClassScanner.scan())
                 .thenReturn(ImmutableSet.of(ConfigurationClass.class));
 
-        Set<String> beanMethods = beanMethodsScanner.getBeanMethods().stream()
-                .map(Method::getName)
-                .collect(Collectors.toSet());
+        Set<String> beanMethods =
+                beanMethodsScanner.getBeanMethods().stream()
+                        .map(Method::getName)
+                        .collect(Collectors.toSet());
 
-
-        assertThat(beanMethods)
-                .hasSize(2)
-                .containsExactlyInAnyOrder("stringBean", "consumerBean");
+        assertThat(beanMethods).hasSize(2).containsExactlyInAnyOrder("stringBean", "consumerBean");
     }
 
     private static class ConfigurationClass {
 
-        private void notABean() {
-        }
+        private void notABean() {}
 
         @Bean
         private String stringBean() {
@@ -57,7 +52,5 @@ public class DefaultBeanMethodsScannerTest {
         private Consumer<String> consumerBean() {
             return System.out::println;
         }
-
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
 
-
 import com.asyncapi.v2.model.channel.ChannelItem;
 import com.asyncapi.v2.model.channel.operation.Operation;
 import com.google.common.collect.Maps;
@@ -16,7 +15,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ChannelMergerTest {
 
-
     @Test
     public void shouldNotMergeDifferentChannelNames() {
         // given
@@ -28,20 +26,27 @@ public class ChannelMergerTest {
         ChannelItem subscriberChannel = ChannelItem.builder().subscribe(subscribeOperation).build();
 
         // when
-        Map<String, ChannelItem> mergedChannels = ChannelMerger.merge(Arrays.asList(
-                Maps.immutableEntry(channelName1, publisherChannel),
-                Maps.immutableEntry(channelName2, subscriberChannel)));
+        Map<String, ChannelItem> mergedChannels =
+                ChannelMerger.merge(
+                        Arrays.asList(
+                                Maps.immutableEntry(channelName1, publisherChannel),
+                                Maps.immutableEntry(channelName2, subscriberChannel)));
 
         // then
-        assertThat(mergedChannels).hasSize(2)
-                .hasEntrySatisfying(channelName1, it -> {
-                    assertThat(it.getPublish()).isEqualTo(publishOperation);
-                    assertThat(it.getSubscribe()).isNull();
-                })
-                .hasEntrySatisfying(channelName2, it -> {
-                    assertThat(it.getPublish()).isNull();
-                    assertThat(it.getSubscribe()).isEqualTo(subscribeOperation);
-                });
+        assertThat(mergedChannels)
+                .hasSize(2)
+                .hasEntrySatisfying(
+                        channelName1,
+                        it -> {
+                            assertThat(it.getPublish()).isEqualTo(publishOperation);
+                            assertThat(it.getSubscribe()).isNull();
+                        })
+                .hasEntrySatisfying(
+                        channelName2,
+                        it -> {
+                            assertThat(it.getPublish()).isNull();
+                            assertThat(it.getSubscribe()).isEqualTo(subscribeOperation);
+                        });
     }
 
     @Test
@@ -54,16 +59,21 @@ public class ChannelMergerTest {
         ChannelItem subscriberChannel = ChannelItem.builder().subscribe(subscribeOperation).build();
 
         // when
-        Map<String, ChannelItem> mergedChannels = ChannelMerger.merge(Arrays.asList(
-                Maps.immutableEntry(channelName, publisherChannel),
-                Maps.immutableEntry(channelName, subscriberChannel)));
+        Map<String, ChannelItem> mergedChannels =
+                ChannelMerger.merge(
+                        Arrays.asList(
+                                Maps.immutableEntry(channelName, publisherChannel),
+                                Maps.immutableEntry(channelName, subscriberChannel)));
 
         // then
-        assertThat(mergedChannels).hasSize(1)
-                .hasEntrySatisfying(channelName, it -> {
-                    assertThat(it.getPublish()).isEqualTo(publishOperation);
-                    assertThat(it.getSubscribe()).isEqualTo(subscribeOperation);
-                });
+        assertThat(mergedChannels)
+                .hasSize(1)
+                .hasEntrySatisfying(
+                        channelName,
+                        it -> {
+                            assertThat(it.getPublish()).isEqualTo(publishOperation);
+                            assertThat(it.getSubscribe()).isEqualTo(subscribeOperation);
+                        });
     }
 
     @Test
@@ -76,45 +86,78 @@ public class ChannelMergerTest {
         ChannelItem publisherChannel2 = ChannelItem.builder().publish(publishOperation2).build();
 
         // when
-        Map<String, ChannelItem> mergedChannels = ChannelMerger.merge(Arrays.asList(
-                Maps.immutableEntry(channelName, publisherChannel1),
-                Maps.immutableEntry(channelName, publisherChannel2)));
+        Map<String, ChannelItem> mergedChannels =
+                ChannelMerger.merge(
+                        Arrays.asList(
+                                Maps.immutableEntry(channelName, publisherChannel1),
+                                Maps.immutableEntry(channelName, publisherChannel2)));
 
         // then
-        assertThat(mergedChannels).hasSize(1)
-                .hasEntrySatisfying(channelName, it -> {
-                    assertThat(it.getPublish()).isEqualTo(publishOperation1);
-                    assertThat(it.getSubscribe()).isNull();
-                });
+        assertThat(mergedChannels)
+                .hasSize(1)
+                .hasEntrySatisfying(
+                        channelName,
+                        it -> {
+                            assertThat(it.getPublish()).isEqualTo(publishOperation1);
+                            assertThat(it.getSubscribe()).isNull();
+                        });
     }
 
     @Test
     public void shouldMergeDifferentMessageForSameOperation() {
         // given
         String channelName = "channel";
-        Message message1 = Message.builder().name(String.class.getCanonicalName()).description("This is a string").build();
-        Message message2 = Message.builder().name(Integer.class.getCanonicalName()).description("This is an integer").build();
-        Message message3 = Message.builder().name(Integer.class.getCanonicalName()).description("This is also an integer, but in essence the same payload type").build();
-        Operation publishOperation1 = Operation.builder().operationId("publisher1").message(message1).build();
-        Operation publishOperation2 = Operation.builder().operationId("publisher2").message(message2).build();
-        Operation publishOperation3 = Operation.builder().operationId("publisher3").message(message3).build();
+        Message message1 =
+                Message.builder()
+                        .name(String.class.getCanonicalName())
+                        .description("This is a string")
+                        .build();
+        Message message2 =
+                Message.builder()
+                        .name(Integer.class.getCanonicalName())
+                        .description("This is an integer")
+                        .build();
+        Message message3 =
+                Message.builder()
+                        .name(Integer.class.getCanonicalName())
+                        .description(
+                                "This is also an integer, but in essence the same payload type")
+                        .build();
+        Operation publishOperation1 =
+                Operation.builder().operationId("publisher1").message(message1).build();
+        Operation publishOperation2 =
+                Operation.builder().operationId("publisher2").message(message2).build();
+        Operation publishOperation3 =
+                Operation.builder().operationId("publisher3").message(message3).build();
         ChannelItem publisherChannel1 = ChannelItem.builder().publish(publishOperation1).build();
         ChannelItem publisherChannel2 = ChannelItem.builder().publish(publishOperation2).build();
         ChannelItem publisherChannel3 = ChannelItem.builder().publish(publishOperation3).build();
 
         // when
-        Map<String, ChannelItem> mergedChannels = ChannelMerger.merge(Arrays.asList(
-                Maps.immutableEntry(channelName, publisherChannel1),
-                Maps.immutableEntry(channelName, publisherChannel2),
-                Maps.immutableEntry(channelName, publisherChannel3)));
+        Map<String, ChannelItem> mergedChannels =
+                ChannelMerger.merge(
+                        Arrays.asList(
+                                Maps.immutableEntry(channelName, publisherChannel1),
+                                Maps.immutableEntry(channelName, publisherChannel2),
+                                Maps.immutableEntry(channelName, publisherChannel3)));
 
         // then expectedMessage only includes message1 and message2.
-        // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
-        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message2));
-        assertThat(mergedChannels).hasSize(1)
-                .hasEntrySatisfying(channelName, it -> {
-                    assertThat(it.getPublish()).isEqualTo(Operation.builder().operationId("publisher1").message(expectedMessages).build());
-                    assertThat(it.getSubscribe()).isNull();
-                });
+        // Message3 is not included as it is identical in terms of payload type (Message#name) to
+        // message 2
+        Object expectedMessages =
+                MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message2));
+        assertThat(mergedChannels)
+                .hasSize(1)
+                .hasEntrySatisfying(
+                        channelName,
+                        it -> {
+                            assertThat(it.getPublish())
+                                    .isEqualTo(
+                                            Operation.builder()
+                                                    .operationId("publisher1")
+                                                    .message(expectedMessages)
+                                                    .build());
+                            assertThat(it.getSubscribe()).isNull();
+                        });
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
@@ -144,8 +144,7 @@ public class ChannelMergerTest {
         // then expectedMessage only includes message1 and message2.
         // Message3 is not included as it is identical in terms of payload type (Message#name) to
         // message 2
-        Object expectedMessages =
-                MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message2));
+        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message2));
         assertThat(mergedChannels)
                 .hasSize(1)
                 .hasEntrySatisfying(

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/SpringPayloadAnnotationTypeExtractorTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/SpringPayloadAnnotationTypeExtractorTest.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
-
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.handler.annotation.Payload;
 
@@ -24,7 +23,9 @@ public class SpringPayloadAnnotationTypeExtractorTest {
 
     @Test
     public void getPayloadTypeWithPayloadAnnotation() throws NoSuchMethodException {
-        Method m = TestClass.class.getDeclaredMethod("consumeWithStringAndPayloadAnnotation", String.class, Integer.class);
+        Method m =
+                TestClass.class.getDeclaredMethod(
+                        "consumeWithStringAndPayloadAnnotation", String.class, Integer.class);
 
         Class<?> result = SpringPayloadAnnotationTypeExtractor.getPayloadType(m);
 
@@ -71,7 +72,8 @@ public class SpringPayloadAnnotationTypeExtractorTest {
 
     @Test
     public void getPayloadTypeWithCustomType() throws NoSuchMethodException {
-        Method m = TestClass.class.getDeclaredMethod("consumeWithCustomType", TestClass.MyType.class);
+        Method m =
+                TestClass.class.getDeclaredMethod("consumeWithCustomType", TestClass.MyType.class);
 
         Class<?> result = SpringPayloadAnnotationTypeExtractor.getPayloadType(m);
 
@@ -80,13 +82,19 @@ public class SpringPayloadAnnotationTypeExtractorTest {
 
     public static class TestClass {
         public void consumeWithStringAndPayloadAnnotation(@Payload String value, Integer value2) {}
+
         public void consumeWithString(String value) {}
+
         public void consumeWithGenericClass(Optional<String> value) {}
+
         public void consumeWithListOfStrings(List<String> value) {}
+
         public void consumeWithListOfGenericClasses(List<Optional<String>> value) {}
+
         public void consumeWithListOfStringExtends(List<? extends String> value) {}
+
         public void consumeWithCustomType(MyType value) {}
 
-        public static class MyType extends ArrayList<String> { }
+        public static class MyType extends ArrayList<String> {}
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/TestMethodLevelListenerScanner.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/TestMethodLevelListenerScanner.java
@@ -8,25 +8,31 @@ import lombok.EqualsAndHashCode;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-public class TestMethodLevelListenerScanner extends AbstractMethodLevelListenerScanner<TestMethodLevelListenerScannerTest.TestChannelListener> {
+public class TestMethodLevelListenerScanner
+        extends AbstractMethodLevelListenerScanner<
+                TestMethodLevelListenerScannerTest.TestChannelListener> {
 
     @Override
-    protected Class<TestMethodLevelListenerScannerTest.TestChannelListener> getListenerAnnotationClass() {
+    protected Class<TestMethodLevelListenerScannerTest.TestChannelListener>
+            getListenerAnnotationClass() {
         return TestMethodLevelListenerScannerTest.TestChannelListener.class;
     }
 
     @Override
-    protected String getChannelName(TestMethodLevelListenerScannerTest.TestChannelListener annotation) {
+    protected String getChannelName(
+            TestMethodLevelListenerScannerTest.TestChannelListener annotation) {
         return "test-channel";
     }
 
     @Override
-    protected Map<String, ? extends ChannelBinding> buildChannelBinding(TestMethodLevelListenerScannerTest.TestChannelListener annotation) {
+    protected Map<String, ? extends ChannelBinding> buildChannelBinding(
+            TestMethodLevelListenerScannerTest.TestChannelListener annotation) {
         return ImmutableMap.of("test-channel-binding", new TestChannelBinding());
     }
 
     @Override
-    protected Map<String, ? extends OperationBinding> buildOperationBinding(TestMethodLevelListenerScannerTest.TestChannelListener annotation) {
+    protected Map<String, ? extends OperationBinding> buildOperationBinding(
+            TestMethodLevelListenerScannerTest.TestChannelListener annotation) {
         return ImmutableMap.of("test-operation-binding", new TestOperationBinding());
     }
 
@@ -34,19 +40,16 @@ public class TestMethodLevelListenerScanner extends AbstractMethodLevelListenerS
     protected Class<?> getPayloadType(Method method) {
         Class<?>[] parameterTypes = method.getParameterTypes();
         if (parameterTypes.length != 1) {
-            throw new IllegalArgumentException("Only single parameter listener methods are supported");
+            throw new IllegalArgumentException(
+                    "Only single parameter listener methods are supported");
         }
 
         return parameterTypes[0];
     }
 
     @EqualsAndHashCode(callSuper = true)
-    public static class TestChannelBinding extends ChannelBinding {
-    }
-
+    public static class TestChannelBinding extends ChannelBinding {}
 
     @EqualsAndHashCode(callSuper = true)
-    public static class TestOperationBinding extends OperationBinding {
-    }
-
+    public static class TestOperationBinding extends OperationBinding {}
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/TestMethodLevelListenerScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/TestMethodLevelListenerScannerTest.java
@@ -35,14 +35,11 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(classes = {TestMethodLevelListenerScanner.class, DefaultSchemasService.class})
 public class TestMethodLevelListenerScannerTest {
 
-    @Autowired
-    private TestMethodLevelListenerScanner channelScanner;
+    @Autowired private TestMethodLevelListenerScanner channelScanner;
 
-    @MockBean
-    private ComponentClassScanner componentsScanner;
+    @MockBean private ComponentClassScanner componentsScanner;
 
-    @MockBean
-    private AsyncApiDocket docket;
+    @MockBean private AsyncApiDocket docket;
 
     private void setClassToScan(Class<?> classToScan) {
         Set<Class<?>> classesToScan = singleton(classToScan);
@@ -60,31 +57,43 @@ public class TestMethodLevelListenerScannerTest {
 
     @Test
     public void scan_componentHasListenerMethod() {
-        // Given a class with methods annotated with TestChannelListener, whose topics attribute is hard coded
+        // Given a class with methods annotated with TestChannelListener, whose topics attribute is
+        // hard coded
         setClassToScan(ClassWithListenerAnnotation.class);
 
         // When scan is called
         Map<String, ChannelItem> actualChannels = channelScanner.scan();
 
         // Then the returned collection contains the channel
-        Message message = Message.builder()
-                .name(SimpleFoo.class.getName())
-                .title(SimpleFoo.class.getSimpleName())
-                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
-                .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .build();
+        Message message =
+                Message.builder()
+                        .name(SimpleFoo.class.getName())
+                        .title(SimpleFoo.class.getSimpleName())
+                        .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                        .headers(
+                                HeaderReference.fromModelName(
+                                        AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                        .build();
 
-        Operation operation = Operation.builder()
-                .description("Auto-generated description")
-                .operationId("test-channel_publish_methodWithAnnotation")
-                .bindings(ImmutableMap.of("test-operation-binding", new TestMethodLevelListenerScanner.TestOperationBinding()))
-                .message(message)
-                .build();
+        Operation operation =
+                Operation.builder()
+                        .description("Auto-generated description")
+                        .operationId("test-channel_publish_methodWithAnnotation")
+                        .bindings(
+                                ImmutableMap.of(
+                                        "test-operation-binding",
+                                        new TestMethodLevelListenerScanner.TestOperationBinding()))
+                        .message(message)
+                        .build();
 
-        ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("test-channel-binding", new TestMethodLevelListenerScanner.TestChannelBinding()))
-                .publish(operation)
-                .build();
+        ChannelItem expectedChannel =
+                ChannelItem.builder()
+                        .bindings(
+                                ImmutableMap.of(
+                                        "test-channel-binding",
+                                        new TestMethodLevelListenerScanner.TestChannelBinding()))
+                        .publish(operation)
+                        .build();
 
         assertThat(actualChannels)
                 .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
@@ -92,20 +101,15 @@ public class TestMethodLevelListenerScannerTest {
 
     private static class ClassWithoutListenerAnnotation {
 
-        private void methodWithoutAnnotation() {
-        }
-
+        private void methodWithoutAnnotation() {}
     }
 
     private static class ClassWithListenerAnnotation {
 
         @TestChannelListener
-        private void methodWithAnnotation(SimpleFoo payload) {
-        }
+        private void methodWithAnnotation(SimpleFoo payload) {}
 
-        private void methodWithoutAnnotation() {
-        }
-
+        private void methodWithoutAnnotation() {}
     }
 
     @Data
@@ -117,7 +121,5 @@ public class TestMethodLevelListenerScannerTest {
 
     @Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
     @Retention(RetentionPolicy.RUNTIME)
-    public @interface TestChannelListener {
-    }
-
+    public @interface TestChannelListener {}
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerTest.java
@@ -35,24 +35,23 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(classes = {ConsumerOperationDataScanner.class, DefaultSchemasService.class})
 public class ConsumerOperationDataScannerTest {
 
-    @Autowired
-    private ConsumerOperationDataScanner scanner;
+    @Autowired private ConsumerOperationDataScanner scanner;
 
-    @MockBean
-    private AsyncApiDocketService asyncApiDocketService;
+    @MockBean private AsyncApiDocketService asyncApiDocketService;
 
     @Test
     public void allFieldsConsumerData() {
         // Given a consumer data with all fields set
         String channelName = "example-consumer-topic-foo1";
         String description = channelName + "-description";
-        ConsumerData consumerData = ConsumerData.builder()
-                .channelName(channelName)
-                .description(description)
-                .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .payloadType(ExamplePayloadDto.class)
-                .build();
+        ConsumerData consumerData =
+                ConsumerData.builder()
+                        .channelName(channelName)
+                        .description(description)
+                        .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                        .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                        .payloadType(ExamplePayloadDto.class)
+                        .build();
 
         mockConsumers(ImmutableList.of(consumerData));
 
@@ -60,38 +59,42 @@ public class ConsumerOperationDataScannerTest {
         Map<String, ChannelItem> consumerChannels = scanner.scan();
 
         // Then the channel should be created correctly
-        assertThat(consumerChannels)
-                .containsKey(channelName);
+        assertThat(consumerChannels).containsKey(channelName);
 
-        Operation operation = Operation.builder()
-                .description("Auto-generated description")
-                .operationId("example-consumer-topic-foo1_publish")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .message(Message.builder()
-                        .name(ExamplePayloadDto.class.getName())
-                        .description(description)
-                        .title(ExamplePayloadDto.class.getSimpleName())
-                        .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
-                        .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                        .build())
-                .build();
+        Operation operation =
+                Operation.builder()
+                        .description("Auto-generated description")
+                        .operationId("example-consumer-topic-foo1_publish")
+                        .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                        .message(
+                                Message.builder()
+                                        .name(ExamplePayloadDto.class.getName())
+                                        .description(description)
+                                        .title(ExamplePayloadDto.class.getSimpleName())
+                                        .payload(
+                                                PayloadReference.fromModelName(
+                                                        ExamplePayloadDto.class.getSimpleName()))
+                                        .headers(
+                                                HeaderReference.fromModelName(
+                                                        AsyncHeaders.NOT_DOCUMENTED
+                                                                .getSchemaName()))
+                                        .build())
+                        .build();
 
-        ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .publish(operation)
-                .build();
+        ChannelItem expectedChannel =
+                ChannelItem.builder()
+                        .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                        .publish(operation)
+                        .build();
 
-        assertThat(consumerChannels.get(channelName))
-                .isEqualTo(expectedChannel);
+        assertThat(consumerChannels.get(channelName)).isEqualTo(expectedChannel);
     }
 
     @Test
     public void missingFieldConsumerData() {
         // Given a consumer data with missing fields
         String channelName = "example-consumer-topic-foo1";
-        ConsumerData consumerData = ConsumerData.builder()
-                .channelName(channelName)
-                .build();
+        ConsumerData consumerData = ConsumerData.builder().channelName(channelName).build();
 
         mockConsumers(ImmutableList.of(consumerData));
 
@@ -109,22 +112,24 @@ public class ConsumerOperationDataScannerTest {
         String description1 = channelName + "-description1";
         String description2 = channelName + "-description2";
 
-        ConsumerData consumerData1 = ConsumerData.builder()
-                .channelName(channelName)
-                .description(description1)
-                .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .payloadType(ExamplePayloadDto.class)
-                .build();
+        ConsumerData consumerData1 =
+                ConsumerData.builder()
+                        .channelName(channelName)
+                        .description(description1)
+                        .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                        .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                        .payloadType(ExamplePayloadDto.class)
+                        .build();
 
-        ConsumerData consumerData2 = ConsumerData.builder()
-                .channelName(channelName)
-                .description(description2)
-                .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .payloadType(AnotherExamplePayloadDto.class)
-                .headers(AsyncHeaders.NOT_USED)
-                .build();
+        ConsumerData consumerData2 =
+                ConsumerData.builder()
+                        .channelName(channelName)
+                        .description(description2)
+                        .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                        .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                        .payloadType(AnotherExamplePayloadDto.class)
+                        .headers(AsyncHeaders.NOT_USED)
+                        .build();
 
         mockConsumers(ImmutableList.of(consumerData1, consumerData2));
 
@@ -132,51 +137,60 @@ public class ConsumerOperationDataScannerTest {
         Map<String, ChannelItem> consumerChannels = scanner.scan();
 
         // Then one channel is created for the ConsumerData objects with multiple messages
-        assertThat(consumerChannels)
-                .hasSize(1)
-                .containsKey(channelName);
+        assertThat(consumerChannels).hasSize(1).containsKey(channelName);
 
-        Set<Message> messages = ImmutableSet.of(
-                Message.builder()
-                        .name(ExamplePayloadDto.class.getName())
-                        .description(description1)
-                        .title(ExamplePayloadDto.class.getSimpleName())
-                        .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
-                        .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                        .build(),
-                Message.builder()
-                        .name(AnotherExamplePayloadDto.class.getName())
-                        .description(description2)
-                        .title(AnotherExamplePayloadDto.class.getSimpleName())
-                        .payload(PayloadReference.fromModelName(AnotherExamplePayloadDto.class.getSimpleName()))
-                        .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_USED.getSchemaName()))
-                        .build()
-        );
+        Set<Message> messages =
+                ImmutableSet.of(
+                        Message.builder()
+                                .name(ExamplePayloadDto.class.getName())
+                                .description(description1)
+                                .title(ExamplePayloadDto.class.getSimpleName())
+                                .payload(
+                                        PayloadReference.fromModelName(
+                                                ExamplePayloadDto.class.getSimpleName()))
+                                .headers(
+                                        HeaderReference.fromModelName(
+                                                AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                                .build(),
+                        Message.builder()
+                                .name(AnotherExamplePayloadDto.class.getName())
+                                .description(description2)
+                                .title(AnotherExamplePayloadDto.class.getSimpleName())
+                                .payload(
+                                        PayloadReference.fromModelName(
+                                                AnotherExamplePayloadDto.class.getSimpleName()))
+                                .headers(
+                                        HeaderReference.fromModelName(
+                                                AsyncHeaders.NOT_USED.getSchemaName()))
+                                .build());
 
-        Operation operation = Operation.builder()
-                .description("Auto-generated description")
-                .operationId("example-consumer-topic_publish")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .message(toMessageObjectOrComposition(messages))
-                .build();
+        Operation operation =
+                Operation.builder()
+                        .description("Auto-generated description")
+                        .operationId("example-consumer-topic_publish")
+                        .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                        .message(toMessageObjectOrComposition(messages))
+                        .build();
 
-        ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .publish(operation)
-                .build();
+        ChannelItem expectedChannel =
+                ChannelItem.builder()
+                        .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                        .publish(operation)
+                        .build();
 
-        assertThat(consumerChannels.get(channelName))
-                .isEqualTo(expectedChannel);
+        assertThat(consumerChannels.get(channelName)).isEqualTo(expectedChannel);
     }
 
     private void mockConsumers(Collection<ConsumerData> consumers) {
-        AsyncApiDocket asyncApiDocket = AsyncApiDocket.builder()
-                .info(Info.builder()
-                        .title("ConsumerOperationDataScannerTest-title")
-                        .version("ConsumerOperationDataScannerTest-version")
-                        .build())
-                .consumers(consumers)
-                .build();
+        AsyncApiDocket asyncApiDocket =
+                AsyncApiDocket.builder()
+                        .info(
+                                Info.builder()
+                                        .title("ConsumerOperationDataScannerTest-title")
+                                        .version("ConsumerOperationDataScannerTest-version")
+                                        .build())
+                        .consumers(consumers)
+                        .build();
         when(asyncApiDocketService.getAsyncApiDocket()).thenReturn(asyncApiDocket);
     }
 
@@ -187,5 +201,4 @@ public class ConsumerOperationDataScannerTest {
     static class AnotherExamplePayloadDto {
         private String bar;
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerTest.java
@@ -35,24 +35,23 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(classes = {ProducerOperationDataScanner.class, DefaultSchemasService.class})
 public class ProducerOperationDataScannerTest {
 
-    @Autowired
-    private ProducerOperationDataScanner scanner;
+    @Autowired private ProducerOperationDataScanner scanner;
 
-    @MockBean
-    private AsyncApiDocketService asyncApiDocketService;
+    @MockBean private AsyncApiDocketService asyncApiDocketService;
 
     @Test
     public void allFieldsProducerData() {
         // Given a producer data with all fields set
         String channelName = "example-producer-topic-foo1";
         String description = channelName + "-description";
-        ProducerData producerData = ProducerData.builder()
-                .channelName(channelName)
-                .description(description)
-                .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .payloadType(ExamplePayloadDto.class)
-                .build();
+        ProducerData producerData =
+                ProducerData.builder()
+                        .channelName(channelName)
+                        .description(description)
+                        .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                        .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                        .payloadType(ExamplePayloadDto.class)
+                        .build();
 
         mockProducers(ImmutableList.of(producerData));
 
@@ -60,38 +59,42 @@ public class ProducerOperationDataScannerTest {
         Map<String, ChannelItem> producerChannels = scanner.scan();
 
         // Then the channel should be created correctly
-        assertThat(producerChannels)
-                .containsKey(channelName);
+        assertThat(producerChannels).containsKey(channelName);
 
-        Operation operation = Operation.builder()
-                .description("Auto-generated description")
-                .operationId("example-producer-topic-foo1_subscribe")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .message(Message.builder()
-                        .name(ExamplePayloadDto.class.getName())
-                        .description(description)
-                        .title(ExamplePayloadDto.class.getSimpleName())
-                        .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
-                        .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                        .build())
-                .build();
+        Operation operation =
+                Operation.builder()
+                        .description("Auto-generated description")
+                        .operationId("example-producer-topic-foo1_subscribe")
+                        .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                        .message(
+                                Message.builder()
+                                        .name(ExamplePayloadDto.class.getName())
+                                        .description(description)
+                                        .title(ExamplePayloadDto.class.getSimpleName())
+                                        .payload(
+                                                PayloadReference.fromModelName(
+                                                        ExamplePayloadDto.class.getSimpleName()))
+                                        .headers(
+                                                HeaderReference.fromModelName(
+                                                        AsyncHeaders.NOT_DOCUMENTED
+                                                                .getSchemaName()))
+                                        .build())
+                        .build();
 
-        ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .subscribe(operation)
-                .build();
+        ChannelItem expectedChannel =
+                ChannelItem.builder()
+                        .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                        .subscribe(operation)
+                        .build();
 
-        assertThat(producerChannels.get(channelName))
-                .isEqualTo(expectedChannel);
+        assertThat(producerChannels.get(channelName)).isEqualTo(expectedChannel);
     }
 
     @Test
     public void missingFieldProducerData() {
         // Given a producer data with missing fields
         String channelName = "example-producer-topic-foo1";
-        ProducerData producerData = ProducerData.builder()
-                .channelName(channelName)
-                .build();
+        ProducerData producerData = ProducerData.builder().channelName(channelName).build();
 
         mockProducers(ImmutableList.of(producerData));
 
@@ -109,22 +112,24 @@ public class ProducerOperationDataScannerTest {
         String description1 = channelName + "-description1";
         String description2 = channelName + "-description2";
 
-        ProducerData producerData1 = ProducerData.builder()
-                .channelName(channelName)
-                .description(description1)
-                .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .payloadType(ExamplePayloadDto.class)
-                .build();
+        ProducerData producerData1 =
+                ProducerData.builder()
+                        .channelName(channelName)
+                        .description(description1)
+                        .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                        .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                        .payloadType(ExamplePayloadDto.class)
+                        .build();
 
-        ProducerData producerData2 = ProducerData.builder()
-                .channelName(channelName)
-                .description(description2)
-                .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .payloadType(AnotherExamplePayloadDto.class)
-                .headers(AsyncHeaders.NOT_USED)
-                .build();
+        ProducerData producerData2 =
+                ProducerData.builder()
+                        .channelName(channelName)
+                        .description(description2)
+                        .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                        .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                        .payloadType(AnotherExamplePayloadDto.class)
+                        .headers(AsyncHeaders.NOT_USED)
+                        .build();
 
         mockProducers(ImmutableList.of(producerData1, producerData2));
 
@@ -132,51 +137,60 @@ public class ProducerOperationDataScannerTest {
         Map<String, ChannelItem> producerChannels = scanner.scan();
 
         // Then one channel is created for the ProducerData objects with multiple messages
-        assertThat(producerChannels)
-                .hasSize(1)
-                .containsKey(channelName);
+        assertThat(producerChannels).hasSize(1).containsKey(channelName);
 
-        Set<Message> messages = ImmutableSet.of(
-                Message.builder()
-                        .name(ExamplePayloadDto.class.getName())
-                        .description(description1)
-                        .title(ExamplePayloadDto.class.getSimpleName())
-                        .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
-                        .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                        .build(),
-                Message.builder()
-                        .name(AnotherExamplePayloadDto.class.getName())
-                        .description(description2)
-                        .title(AnotherExamplePayloadDto.class.getSimpleName())
-                        .payload(PayloadReference.fromModelName(AnotherExamplePayloadDto.class.getSimpleName()))
-                        .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_USED.getSchemaName()))
-                        .build()
-        );
+        Set<Message> messages =
+                ImmutableSet.of(
+                        Message.builder()
+                                .name(ExamplePayloadDto.class.getName())
+                                .description(description1)
+                                .title(ExamplePayloadDto.class.getSimpleName())
+                                .payload(
+                                        PayloadReference.fromModelName(
+                                                ExamplePayloadDto.class.getSimpleName()))
+                                .headers(
+                                        HeaderReference.fromModelName(
+                                                AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                                .build(),
+                        Message.builder()
+                                .name(AnotherExamplePayloadDto.class.getName())
+                                .description(description2)
+                                .title(AnotherExamplePayloadDto.class.getSimpleName())
+                                .payload(
+                                        PayloadReference.fromModelName(
+                                                AnotherExamplePayloadDto.class.getSimpleName()))
+                                .headers(
+                                        HeaderReference.fromModelName(
+                                                AsyncHeaders.NOT_USED.getSchemaName()))
+                                .build());
 
-        Operation operation = Operation.builder()
-                .description("Auto-generated description")
-                .operationId("example-producer-topic_subscribe")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .message(toMessageObjectOrComposition(messages))
-                .build();
+        Operation operation =
+                Operation.builder()
+                        .description("Auto-generated description")
+                        .operationId("example-producer-topic_subscribe")
+                        .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                        .message(toMessageObjectOrComposition(messages))
+                        .build();
 
-        ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .subscribe(operation)
-                .build();
+        ChannelItem expectedChannel =
+                ChannelItem.builder()
+                        .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                        .subscribe(operation)
+                        .build();
 
-        assertThat(producerChannels.get(channelName))
-                .isEqualTo(expectedChannel);
+        assertThat(producerChannels.get(channelName)).isEqualTo(expectedChannel);
     }
 
     private void mockProducers(Collection<ProducerData> producers) {
-        AsyncApiDocket asyncApiDocket = AsyncApiDocket.builder()
-                .info(Info.builder()
-                        .title("ProducerOperationDataScannerTest-title")
-                        .version("ProducerOperationDataScannerTest-version")
-                        .build())
-                .producers(producers)
-                .build();
+        AsyncApiDocket asyncApiDocket =
+                AsyncApiDocket.builder()
+                        .info(
+                                Info.builder()
+                                        .title("ProducerOperationDataScannerTest-title")
+                                        .version("ProducerOperationDataScannerTest-version")
+                                        .build())
+                        .producers(producers)
+                        .build();
         when(asyncApiDocketService.getAsyncApiDocket()).thenReturn(asyncApiDocket);
     }
 
@@ -187,5 +201,4 @@ public class ProducerOperationDataScannerTest {
     static class AnotherExamplePayloadDto {
         private String bar;
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
@@ -29,15 +29,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {AsyncListenerAnnotationScanner.class, DefaultSchemasService.class, TestOperationBindingProcessor.class})
-@TestPropertySource(properties = {"test.property.test-channel=test-channel", "test.property.description=description"})
+@ContextConfiguration(
+        classes = {
+            AsyncListenerAnnotationScanner.class,
+            DefaultSchemasService.class,
+            TestOperationBindingProcessor.class
+        })
+@TestPropertySource(
+        properties = {
+            "test.property.test-channel=test-channel",
+            "test.property.description=description"
+        })
 public class AsyncListenerAnnotationScannerTest {
 
-    @Autowired
-    private AsyncListenerAnnotationScanner channelScanner;
+    @Autowired private AsyncListenerAnnotationScanner channelScanner;
 
-    @MockBean
-    private ComponentClassScanner componentClassScanner;
+    @MockBean private ComponentClassScanner componentClassScanner;
 
     private void setClassToScan(Class<?> classToScan) {
         Set<Class<?>> classesToScan = singleton(classToScan);
@@ -53,35 +60,37 @@ public class AsyncListenerAnnotationScannerTest {
         assertThat(channels).isEmpty();
     }
 
-
     @Test
     public void scan_componentHasListenerMethod() {
-        // Given a class with methods annotated with AsyncListener, where only the channel-name is set
+        // Given a class with methods annotated with AsyncListener, where only the channel-name is
+        // set
         setClassToScan(ClassWithListenerAnnotation.class);
 
         // When scan is called
         Map<String, ChannelItem> actualChannels = channelScanner.scan();
 
         // Then the returned collection contains the channel
-        Message message = Message.builder()
-                .name(SimpleFoo.class.getName())
-                .title(SimpleFoo.class.getSimpleName())
-                .description(null)
-                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
-                .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .build();
+        Message message =
+                Message.builder()
+                        .name(SimpleFoo.class.getName())
+                        .title(SimpleFoo.class.getSimpleName())
+                        .description(null)
+                        .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                        .headers(
+                                HeaderReference.fromModelName(
+                                        AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                        .build();
 
-        Operation operation = Operation.builder()
-                .description("Auto-generated description")
-                .operationId("test-channel_publish")
-                .bindings(EMPTY_MAP)
-                .message(message)
-                .build();
+        Operation operation =
+                Operation.builder()
+                        .description("Auto-generated description")
+                        .operationId("test-channel_publish")
+                        .bindings(EMPTY_MAP)
+                        .message(message)
+                        .build();
 
-        ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(null)
-                .publish(operation)
-                .build();
+        ChannelItem expectedChannel =
+                ChannelItem.builder().bindings(null).publish(operation).build();
 
         assertThat(actualChannels)
                 .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
@@ -96,66 +105,65 @@ public class AsyncListenerAnnotationScannerTest {
         Map<String, ChannelItem> actualChannels = channelScanner.scan();
 
         // Then the returned collection contains the channel
-        Message message = Message.builder()
-                .name(SimpleFoo.class.getName())
-                .title(SimpleFoo.class.getSimpleName())
-                .description("description")
-                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
-                .headers(HeaderReference.fromModelName("TestSchema"))
-                .build();
+        Message message =
+                Message.builder()
+                        .name(SimpleFoo.class.getName())
+                        .title(SimpleFoo.class.getSimpleName())
+                        .description("description")
+                        .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                        .headers(HeaderReference.fromModelName("TestSchema"))
+                        .build();
 
-        Operation operation = Operation.builder()
-                .description("Auto-generated description")
-                .operationId("test-channel_publish")
-                .bindings(ImmutableMap.of(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING))
-                .message(message)
-                .build();
+        Operation operation =
+                Operation.builder()
+                        .description("Auto-generated description")
+                        .operationId("test-channel_publish")
+                        .bindings(
+                                ImmutableMap.of(
+                                        TestOperationBindingProcessor.TYPE,
+                                        TestOperationBindingProcessor.BINDING))
+                        .message(message)
+                        .build();
 
-        ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(null)
-                .publish(operation)
-                .build();
+        ChannelItem expectedChannel =
+                ChannelItem.builder().bindings(null).publish(operation).build();
 
         assertThat(actualChannels)
                 .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
     }
 
-
     private static class ClassWithoutListenerAnnotation {
 
-        private void methodWithoutAnnotation() {
-        }
+        private void methodWithoutAnnotation() {}
     }
 
     private static class ClassWithListenerAnnotation {
 
-        @AsyncListener(operation = @AsyncOperation(
-                channelName = "test-channel"
-        ))
-        private void methodWithAnnotation(SimpleFoo payload) {
-        }
+        @AsyncListener(operation = @AsyncOperation(channelName = "test-channel"))
+        private void methodWithAnnotation(SimpleFoo payload) {}
 
-        private void methodWithoutAnnotation() {
-        }
-
+        private void methodWithoutAnnotation() {}
     }
 
     private static class ClassWithListenerAnnotationWithAllAttributes {
 
-        @AsyncListener(operation = @AsyncOperation(
-                channelName = "${test.property.test-channel}",
-                description = "${test.property.description}",
-                headers = @AsyncOperation.Headers(
-                        schemaName = "TestSchema",
-                        values = {@AsyncOperation.Headers.Header(name = "header", value = "value")}
-                )
-        ))
+        @AsyncListener(
+                operation =
+                        @AsyncOperation(
+                                channelName = "${test.property.test-channel}",
+                                description = "${test.property.description}",
+                                headers =
+                                        @AsyncOperation.Headers(
+                                                schemaName = "TestSchema",
+                                                values = {
+                                                    @AsyncOperation.Headers.Header(
+                                                            name = "header",
+                                                            value = "value")
+                                                })))
         @TestOperationBindingProcessor.TestOperationBinding()
-        private void methodWithAnnotation(SimpleFoo payload) {
-        }
+        private void methodWithAnnotation(SimpleFoo payload) {}
 
-        private void methodWithoutAnnotation() {
-        }
+        private void methodWithoutAnnotation() {}
     }
 
     @Data

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
@@ -29,15 +29,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {AsyncPublisherAnnotationScanner.class, DefaultSchemasService.class, TestOperationBindingProcessor.class})
-@TestPropertySource(properties = {"test.property.test-channel=test-channel", "test.property.description=description"})
+@ContextConfiguration(
+        classes = {
+            AsyncPublisherAnnotationScanner.class,
+            DefaultSchemasService.class,
+            TestOperationBindingProcessor.class
+        })
+@TestPropertySource(
+        properties = {
+            "test.property.test-channel=test-channel",
+            "test.property.description=description"
+        })
 public class AsyncPublisherAnnotationScannerTest {
 
-    @Autowired
-    private AsyncPublisherAnnotationScanner channelScanner;
+    @Autowired private AsyncPublisherAnnotationScanner channelScanner;
 
-    @MockBean
-    private ComponentClassScanner componentClassScanner;
+    @MockBean private ComponentClassScanner componentClassScanner;
 
     private void setClassToScan(Class<?> classToScan) {
         Set<Class<?>> classesToScan = singleton(classToScan);
@@ -53,35 +60,37 @@ public class AsyncPublisherAnnotationScannerTest {
         assertThat(channels).isEmpty();
     }
 
-
     @Test
     public void scan_componentHasPublisherMethod() {
-        // Given a class with methods annotated with AsyncPublisher, where only the channel-name is set
+        // Given a class with methods annotated with AsyncPublisher, where only the channel-name is
+        // set
         setClassToScan(ClassWithPublisherAnnotation.class);
 
         // When scan is called
         Map<String, ChannelItem> actualChannels = channelScanner.scan();
 
         // Then the returned collection contains the channel
-        Message message = Message.builder()
-                .name(SimpleFoo.class.getName())
-                .title(SimpleFoo.class.getSimpleName())
-                .description(null)
-                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
-                .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .build();
+        Message message =
+                Message.builder()
+                        .name(SimpleFoo.class.getName())
+                        .title(SimpleFoo.class.getSimpleName())
+                        .description(null)
+                        .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                        .headers(
+                                HeaderReference.fromModelName(
+                                        AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
+                        .build();
 
-        Operation operation = Operation.builder()
-                .description("Auto-generated description")
-                .operationId("test-channel_subscribe")
-                .bindings(EMPTY_MAP)
-                .message(message)
-                .build();
+        Operation operation =
+                Operation.builder()
+                        .description("Auto-generated description")
+                        .operationId("test-channel_subscribe")
+                        .bindings(EMPTY_MAP)
+                        .message(message)
+                        .build();
 
-        ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(null)
-                .subscribe(operation)
-                .build();
+        ChannelItem expectedChannel =
+                ChannelItem.builder().bindings(null).subscribe(operation).build();
 
         assertThat(actualChannels)
                 .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
@@ -96,66 +105,65 @@ public class AsyncPublisherAnnotationScannerTest {
         Map<String, ChannelItem> actualChannels = channelScanner.scan();
 
         // Then the returned collection contains the channel
-        Message message = Message.builder()
-                .name(SimpleFoo.class.getName())
-                .title(SimpleFoo.class.getSimpleName())
-                .description("description")
-                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
-                .headers(HeaderReference.fromModelName("TestSchema"))
-                .build();
+        Message message =
+                Message.builder()
+                        .name(SimpleFoo.class.getName())
+                        .title(SimpleFoo.class.getSimpleName())
+                        .description("description")
+                        .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
+                        .headers(HeaderReference.fromModelName("TestSchema"))
+                        .build();
 
-        Operation operation = Operation.builder()
-                .description("Auto-generated description")
-                .operationId("test-channel_subscribe")
-                .bindings(ImmutableMap.of(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING))
-                .message(message)
-                .build();
+        Operation operation =
+                Operation.builder()
+                        .description("Auto-generated description")
+                        .operationId("test-channel_subscribe")
+                        .bindings(
+                                ImmutableMap.of(
+                                        TestOperationBindingProcessor.TYPE,
+                                        TestOperationBindingProcessor.BINDING))
+                        .message(message)
+                        .build();
 
-        ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(null)
-                .subscribe(operation)
-                .build();
+        ChannelItem expectedChannel =
+                ChannelItem.builder().bindings(null).subscribe(operation).build();
 
         assertThat(actualChannels)
                 .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
     }
 
-
     private static class ClassWithoutPublisherAnnotation {
 
-        private void methodWithoutAnnotation() {
-        }
+        private void methodWithoutAnnotation() {}
     }
 
     private static class ClassWithPublisherAnnotation {
 
-        @AsyncPublisher(operation = @AsyncOperation(
-                channelName = "test-channel"
-        ))
-        private void methodWithAnnotation(SimpleFoo payload) {
-        }
+        @AsyncPublisher(operation = @AsyncOperation(channelName = "test-channel"))
+        private void methodWithAnnotation(SimpleFoo payload) {}
 
-        private void methodWithoutAnnotation() {
-        }
-
+        private void methodWithoutAnnotation() {}
     }
 
     private static class ClassWithPublisherAnnotationWithAllAttributes {
 
-        @AsyncPublisher(operation = @AsyncOperation(
-                channelName = "${test.property.test-channel}",
-                description = "${test.property.description}",
-                headers = @AsyncOperation.Headers(
-                        schemaName = "TestSchema",
-                        values = {@AsyncOperation.Headers.Header(name = "header", value = "value")}
-                )
-        ))
+        @AsyncPublisher(
+                operation =
+                        @AsyncOperation(
+                                channelName = "${test.property.test-channel}",
+                                description = "${test.property.description}",
+                                headers =
+                                        @AsyncOperation.Headers(
+                                                schemaName = "TestSchema",
+                                                values = {
+                                                    @AsyncOperation.Headers.Header(
+                                                            name = "header",
+                                                            value = "value")
+                                                })))
         @TestOperationBindingProcessor.TestOperationBinding()
-        private void methodWithAnnotation(SimpleFoo payload) {
-        }
+        private void methodWithAnnotation(SimpleFoo payload) {}
 
-        private void methodWithoutAnnotation() {
-        }
+        private void methodWithoutAnnotation() {}
     }
 
     @Data

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/TestOperationBindingProcessor.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/TestOperationBindingProcessor.java
@@ -11,8 +11,8 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 
 public class TestOperationBindingProcessor implements OperationBindingProcessor {
-    public final static String TYPE = "testType";
-    public final static OperationBinding BINDING = new OperationBinding();
+    public static final String TYPE = "testType";
+    public static final OperationBinding BINDING = new OperationBinding();
 
     @Override
     public Optional<ProcessedOperationBinding> process(Method method) {
@@ -24,6 +24,5 @@ public class TestOperationBindingProcessor implements OperationBindingProcessor 
 
     @Retention(RetentionPolicy.RUNTIME)
     @Target(value = {ElementType.METHOD})
-    public @interface TestOperationBinding {
-    }
+    public @interface TestOperationBinding {}
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/ComponentClassScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/ComponentClassScannerTest.java
@@ -18,23 +18,22 @@ import static org.mockito.Mockito.when;
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {ComponentClassScanner.class})
 public class ComponentClassScannerTest {
-    @MockBean
-    private AsyncApiDocketService asyncApiDocketService;
+    @MockBean private AsyncApiDocketService asyncApiDocketService;
 
-    @Autowired
-    private ComponentClassScanner componentsScanner;
+    @Autowired private ComponentClassScanner componentsScanner;
 
     @Test
     public void getComponents() {
-        when(asyncApiDocketService.getAsyncApiDocket()).thenReturn(
-                AsyncApiDocket.builder()
-                        .info(Info.builder()
-                                .title("ComponentClassScannerTest-title")
-                                .version("ComponentClassScannerTest-version")
-                                .build())
-                        .basePackage(this.getClass().getPackage().getName())
-                        .build()
-        );
+        when(asyncApiDocketService.getAsyncApiDocket())
+                .thenReturn(
+                        AsyncApiDocket.builder()
+                                .info(
+                                        Info.builder()
+                                                .title("ComponentClassScannerTest-title")
+                                                .version("ComponentClassScannerTest-version")
+                                                .build())
+                                .basePackage(this.getClass().getPackage().getName())
+                                .build());
 
         Set<Class<?>> components = componentsScanner.scan();
 
@@ -43,5 +42,4 @@ public class ComponentClassScannerTest {
                 .contains(ConfigurationClassScanner.class)
                 .doesNotContain(ClassScanner.class);
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/ConfigurationClassScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/ConfigurationClassScannerTest.java
@@ -19,28 +19,25 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(classes = {ConfigurationClassScanner.class})
 public class ConfigurationClassScannerTest {
 
-    @MockBean
-    private AsyncApiDocketService asyncApiDocketService;
+    @MockBean private AsyncApiDocketService asyncApiDocketService;
 
-    @Autowired
-    private ConfigurationClassScanner configurationClassScanner;
+    @Autowired private ConfigurationClassScanner configurationClassScanner;
 
     @Test
     public void getComponents() {
-        when(asyncApiDocketService.getAsyncApiDocket()).thenReturn(
-                AsyncApiDocket.builder()
-                        .info(Info.builder()
-                                .title("ConfigurationClassScannerTest-title")
-                                .version("ConfigurationClassScannerTest-version")
-                                .build())
-                        .basePackage(this.getClass().getPackage().getName())
-                        .build()
-        );
+        when(asyncApiDocketService.getAsyncApiDocket())
+                .thenReturn(
+                        AsyncApiDocket.builder()
+                                .info(
+                                        Info.builder()
+                                                .title("ConfigurationClassScannerTest-title")
+                                                .version("ConfigurationClassScannerTest-version")
+                                                .build())
+                                .basePackage(this.getClass().getPackage().getName())
+                                .build());
 
         Set<Class<?>> configurationClasses = configurationClassScanner.scan();
 
-        assertThat(configurationClasses)
-                .containsExactlyInAnyOrder(TestBeanConfiguration.class);
+        assertThat(configurationClasses).containsExactlyInAnyOrder(TestBeanConfiguration.class);
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/TestBean.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/TestBean.java
@@ -6,5 +6,4 @@ import lombok.Value;
 public class TestBean {
 
     String value;
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/TestBeanConfiguration.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/TestBeanConfiguration.java
@@ -10,5 +10,4 @@ public class TestBeanConfiguration {
     public TestBean testBean() {
         return new TestBean("foo");
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/serializers/KafkaOperationBindingSerializerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/serializers/KafkaOperationBindingSerializerTest.java
@@ -21,12 +21,12 @@ public class KafkaOperationBindingSerializerTest {
 
     @Test
     public void bindingWithGroupId() throws JsonProcessingException, JSONException {
-        KafkaOperationBinding binding = KafkaOperationBinding.builder().groupId("testGroupId").build();
+        KafkaOperationBinding binding =
+                KafkaOperationBinding.builder().groupId("testGroupId").build();
         String actual = objectMapper.writeValueAsString(binding);
         String expected = "{\"groupId\":{\"type\":\"string\",\"enum\":[\"testGroupId\"]}}";
         JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
     }
-
 
     @Test
     public void bindingWithEmptyGroupId() throws JsonProcessingException, JSONException {
@@ -43,5 +43,4 @@ public class KafkaOperationBindingSerializerTest {
         String expected = "{}";
         JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketServiceIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketServiceIntegrationTest.java
@@ -19,66 +19,70 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DefaultAsyncApiDocketServiceIntegrationTest {
 
     @ExtendWith(SpringExtension.class)
-    @ContextConfiguration(classes = {
-            DefaultAsyncApiDocketService.class,
-    })
+    @ContextConfiguration(
+            classes = {
+                DefaultAsyncApiDocketService.class,
+            })
     @EnableConfigurationProperties(SpringWolfConfigProperties.class)
-    @TestPropertySource(properties = {
-            "springwolf.enabled=true",
-            "springwolf.docket.info.title=Info title was loaded from spring properties",
-            "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
-            "springwolf.docket.servers.test-protocol.protocol=test",
-            "springwolf.docket.servers.test-protocol.url=some-server:1234"
-    })
+    @TestPropertySource(
+            properties = {
+                "springwolf.enabled=true",
+                "springwolf.docket.info.title=Info title was loaded from spring properties",
+                "springwolf.docket.info.version=1.0.0",
+                "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+                "springwolf.docket.servers.test-protocol.protocol=test",
+                "springwolf.docket.servers.test-protocol.url=some-server:1234"
+            })
     public static class DocketWillBeAutomaticallyCreateIfNoCustomDocketIsPresentTest {
 
-        @Autowired
-        private DefaultAsyncApiDocketService asyncApiDocketService;
+        @Autowired private DefaultAsyncApiDocketService asyncApiDocketService;
 
         @Test
         public void testDocketContentShouldBeLoadedFromProperties() {
             AsyncApiDocket docket = asyncApiDocketService.getAsyncApiDocket();
             assertThat(docket).isNotNull();
-            assertThat(docket.getInfo().getTitle()).isEqualTo("Info title was loaded from spring properties");
+            assertThat(docket.getInfo().getTitle())
+                    .isEqualTo("Info title was loaded from spring properties");
         }
     }
 
     @ExtendWith(SpringExtension.class)
-    @ContextConfiguration(classes = {
-            DefaultAsyncApiDocketService.class,
-    })
+    @ContextConfiguration(
+            classes = {
+                DefaultAsyncApiDocketService.class,
+            })
     @EnableConfigurationProperties(SpringWolfConfigProperties.class)
-    @TestPropertySource(properties = {
-            "springwolf.enabled=true",
-            "springwolf.docket.info.title=Docket was loaded from spring properties",
-            "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
-            "springwolf.docket.servers.test-protocol.protocol=test",
-            "springwolf.docket.servers.test-protocol.url=some-server:1234"
-    })
-    @Import(DocketWillNotBeAutomaticallyCreateIfCustomDocketIsPresentTest.CustomAsyncApiDocketConfiguration.class)
+    @TestPropertySource(
+            properties = {
+                "springwolf.enabled=true",
+                "springwolf.docket.info.title=Docket was loaded from spring properties",
+                "springwolf.docket.info.version=1.0.0",
+                "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+                "springwolf.docket.servers.test-protocol.protocol=test",
+                "springwolf.docket.servers.test-protocol.url=some-server:1234"
+            })
+    @Import(
+            DocketWillNotBeAutomaticallyCreateIfCustomDocketIsPresentTest
+                    .CustomAsyncApiDocketConfiguration.class)
     public static class DocketWillNotBeAutomaticallyCreateIfCustomDocketIsPresentTest {
 
         @TestConfiguration
         public static class CustomAsyncApiDocketConfiguration {
             @Bean
             public AsyncApiDocket docket() {
-                Info info = Info.builder()
-                        .title("Custom docket was used")
-                        .version("1.0.0")
-                        .build();
+                Info info = Info.builder().title("Custom docket was used").version("1.0.0").build();
 
                 return AsyncApiDocket.builder()
                         .info(info)
                         .basePackage("package")
-                        .server("kafka", Server.builder().protocol("kafka").url("kafka:9092").build())
+                        .server(
+                                "kafka",
+                                Server.builder().protocol("kafka").url("kafka:9092").build())
                         .build();
             }
         }
 
-        @Autowired
-        private DefaultAsyncApiDocketService asyncApiDocketService;
+        @Autowired private DefaultAsyncApiDocketService asyncApiDocketService;
 
         @Test
         public void testDocketContentShouldNotBeLoadedFromProperties() {
@@ -88,5 +92,4 @@ public class DefaultAsyncApiDocketServiceIntegrationTest {
             assertThat(docket.getInfo().getTitle()).isEqualTo("Custom docket was used");
         }
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketServiceTest.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.configuration;
 
-
 import com.asyncapi.v2.model.info.Contact;
 import com.asyncapi.v2.model.info.License;
 import com.asyncapi.v2.model.server.Server;
@@ -23,10 +22,7 @@ public class DefaultAsyncApiDocketServiceTest {
         ConfigDocket configDocket = new ConfigDocket();
         configDocket.setBasePackage("test-base-package");
 
-        Server server = Server.builder()
-                .protocol("some-protocol")
-                .url("some-url")
-                .build();
+        Server server = Server.builder().protocol("some-protocol").url("some-url").build();
         configDocket.setServers(newHashMap("some-protocol", server));
 
         Info info = new Info();
@@ -37,12 +33,12 @@ public class DefaultAsyncApiDocketServiceTest {
         info.setContact(new Contact("contact-name", "contact-url", "contact-email"));
         configDocket.setInfo(info);
 
-
         SpringWolfConfigProperties properties = new SpringWolfConfigProperties();
         properties.setDocket(configDocket);
 
         // when
-        DefaultAsyncApiDocketService docketConfiguration = new DefaultAsyncApiDocketService(Optional.empty(), Optional.of(properties));
+        DefaultAsyncApiDocketService docketConfiguration =
+                new DefaultAsyncApiDocketService(Optional.empty(), Optional.of(properties));
         AsyncApiDocket asyncApiDocket = docketConfiguration.getAsyncApiDocket();
 
         // then
@@ -56,10 +52,13 @@ public class DefaultAsyncApiDocketServiceTest {
 
     @Test
     public void testNoConfigurationShouldThrowException() {
-        assertThatThrownBy(() -> {
-            DefaultAsyncApiDocketService docketConfiguration = new DefaultAsyncApiDocketService(Optional.empty(), Optional.empty());
-            docketConfiguration.getAsyncApiDocket();
-        })
+        assertThatThrownBy(
+                        () -> {
+                            DefaultAsyncApiDocketService docketConfiguration =
+                                    new DefaultAsyncApiDocketService(
+                                            Optional.empty(), Optional.empty());
+                            docketConfiguration.getAsyncApiDocket();
+                        })
                 .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasServiceTest.java
@@ -34,8 +34,7 @@ public class DefaultSchemasServiceTest {
     public void string() throws IOException, JSONException {
         String modelName = schemasService.register(String.class);
 
-        assertThat(modelName)
-                .isEqualTo("String");
+        assertThat(modelName).isEqualTo("String");
 
         assertNotNull(schemasService.getDefinitions().get(modelName));
     }
@@ -44,8 +43,7 @@ public class DefaultSchemasServiceTest {
     public void simpleObject() throws IOException, JSONException {
         String modelName = schemasService.register(SimpleFoo.class);
 
-        assertThat(modelName)
-                .isEqualTo("SimpleFoo");
+        assertThat(modelName).isEqualTo("SimpleFoo");
 
         Schema schema = schemasService.getDefinitions().get(modelName);
         String example = objectMapper.writeValueAsString(schema.getExample());
@@ -93,8 +91,7 @@ public class DefaultSchemasServiceTest {
     public void classWithSchemaAnnotation() {
         String modelName = schemasService.register(ClassWithSchemaAnnotation.class);
 
-        assertThat(modelName)
-                .isEqualTo("DifferentName");
+        assertThat(modelName).isEqualTo("DifferentName");
     }
 
     private String jsonResource(String path) throws IOException {
@@ -113,7 +110,10 @@ public class DefaultSchemasServiceTest {
     @NoArgsConstructor
     @io.swagger.v3.oas.annotations.media.Schema(description = "foo model")
     private static class DocumentedSimpleFoo {
-        @io.swagger.v3.oas.annotations.media.Schema(description = "s field", example = "s value", required = true)
+        @io.swagger.v3.oas.annotations.media.Schema(
+                description = "s field",
+                example = "s value",
+                required = true)
         private String s;
     }
 
@@ -131,7 +131,8 @@ public class DefaultSchemasServiceTest {
         private Bar b;
 
         private enum Bar {
-            BAR1, BAR2
+            BAR1,
+            BAR2
         }
     }
 
@@ -142,5 +143,4 @@ public class DefaultSchemasServiceTest {
         private String s;
         private boolean b;
     }
-
 }


### PR DESCRIPTION
I am started looking into code formatting for java

The build.gradle file of springwolf-core contains an example configuration, including some other formatters to test.
I already run `gradlew -p springwolf-core spotlessApply` so that this PR previews the changes to be made.

So far, the google formatter (aosp) seems to match the current style best,
although annotations are in the same line now and comments are compacted.

Feel free to play around with it. All source files have been updated and adjusted to the formatting automatically.