### PR TITLE
feat: Enable/Disable listeners per configuration

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigConstants.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigConstants.java
@@ -1,9 +1,18 @@
 package io.github.stavshamir.springwolf;
 
 public class SpringWolfConfigConstants {
+    public static final String ENABLED =  ".enabled";
+
+    public static final String SCANNER =  ".scanner";
 
     public static final String SPRINGWOLF_CONFIG_PREFIX = "springwolf";
 
-    public static final String SPRINGWOLF_ENABLED = SPRINGWOLF_CONFIG_PREFIX + ".enabled";
+    public static final String SPRINGWOLF_ENABLED = SPRINGWOLF_CONFIG_PREFIX + ENABLED;
     public static final String SPRINGWOLF_PLUGIN_CONFIG_PREFIX = SPRINGWOLF_CONFIG_PREFIX + ".plugin";
+
+    public static final String SPRINGWOLF_SCANNER_PREFIX = SPRINGWOLF_CONFIG_PREFIX + SCANNER;
+    public static final String SPRINGWOLF_SCANNER_ASYNC_LISTENER_ENABLED = SPRINGWOLF_SCANNER_PREFIX + ".async-listener" + ENABLED;
+    public static final String SPRINGWOLF_SCANNER_ASYNC_PUBLISHER_ENABLED = SPRINGWOLF_SCANNER_PREFIX + ".async-publisher" + ENABLED;
+    public static final String SPRINGWOLF_SCANNER_CONSUMER_DATA_ENABLED = SPRINGWOLF_SCANNER_PREFIX + ".consumer-data" + ENABLED;
+    public static final String SPRINGWOLF_SCANNER_PRODUCER_DATA_ENABLED = SPRINGWOLF_SCANNER_PREFIX + ".producer-data" + ENABLED;
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigProperties.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigProperties.java
@@ -26,6 +26,9 @@ public class SpringWolfConfigProperties {
     @Nullable
     private ConfigDocket docket;
 
+    @Nullable
+    private Scanner scanner;
+
     @Getter
     @Setter
     public static class ConfigDocket {
@@ -96,4 +99,60 @@ public class SpringWolfConfigProperties {
     }
 
 
+    @Getter
+    @Setter
+    public static class Scanner {
+
+        @Nullable
+        private static AsyncListener asyncListener;
+
+        @Nullable
+        private static AsyncPublisher asyncPublisher;
+
+        @Nullable
+        private static ConsumerData consumerData;
+
+        @Nullable
+        private static ProducerData producerData;
+
+        @Getter
+        @Setter
+        public static class AsyncListener {
+
+            /**
+             * This mirrors the ConfigConstant {@see SpringWolfConfigConstants#SPRINGWOLF_SCANNER_ASYNC_LISTENER_ENABLED}
+             */
+            private boolean enabled = true;
+        }
+
+        @Getter
+        @Setter
+        public static class AsyncPublisher {
+
+            /**
+             * This mirrors the ConfigConstant {@see SpringWolfConfigConstants#SPRINGWOLF_SCANNER_ASYNC_PUBLISHER_ENABLED}
+             */
+            private boolean enabled = true;
+        }
+
+        @Getter
+        @Setter
+        public static class ConsumerData {
+
+            /**
+             * This mirrors the ConfigConstant {@see SpringWolfConfigConstants#SPRINGWOLF_SCANNER_PRODUCER_DATA_ENABLED}
+             */
+            private boolean enabled = true;
+        }
+
+        @Getter
+        @Setter
+        public static class ProducerData {
+
+            /**
+             * This mirrors the ConfigConstant {@see SpringWolfConfigConstants#SPRINGWOLF_SCANNER_RABBIT_LISTENER_ENABLED}
+             */
+            private boolean enabled = true;
+        }
+    }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScanner.java
@@ -5,14 +5,18 @@ import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.github.stavshamir.springwolf.SpringWolfConfigConstants.*;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
+@ConditionalOnProperty(name = SPRINGWOLF_SCANNER_CONSUMER_DATA_ENABLED, matchIfMissing = true)
 public class ConsumerOperationDataScanner extends AbstractOperationDataScanner {
 
     private final AsyncApiDocketService asyncApiDocketService;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScanner.java
@@ -5,14 +5,18 @@ import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.github.stavshamir.springwolf.SpringWolfConfigConstants.*;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
+@ConditionalOnProperty(name = SPRINGWOLF_SCANNER_PRODUCER_DATA_ENABLED, matchIfMissing = true)
 public class ProducerOperationDataScanner extends AbstractOperationDataScanner {
 
     private final AsyncApiDocketService asyncApiDocketService;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
@@ -11,6 +11,7 @@ import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -21,12 +22,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import static io.github.stavshamir.springwolf.SpringWolfConfigConstants.SPRINGWOLF_SCANNER_ASYNC_LISTENER_ENABLED;
 import java.util.stream.Stream;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
 @Order(value = ChannelPriority.ASYNC_ANNOTATION)
+@ConditionalOnProperty(name = SPRINGWOLF_SCANNER_ASYNC_LISTENER_ENABLED, matchIfMissing = true)
 public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner implements EmbeddedValueResolverAware {
     private StringValueResolver resolver;
     private final ComponentClassScanner componentClassScanner;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
@@ -11,6 +11,7 @@ import io.github.stavshamir.springwolf.asyncapi.types.ProducerData;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -21,12 +22,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import static io.github.stavshamir.springwolf.SpringWolfConfigConstants.*;
 import java.util.stream.Stream;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
 @Order(value = ChannelPriority.ASYNC_ANNOTATION)
+@ConditionalOnProperty(name = SPRINGWOLF_SCANNER_ASYNC_PUBLISHER_ENABLED, matchIfMissing = true)
 public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanner implements EmbeddedValueResolverAware {
     private StringValueResolver resolver;
     private final ComponentClassScanner componentClassScanner;

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/SpringContextTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/SpringContextTest.java
@@ -62,7 +62,7 @@ public class SpringContextTest {
             "springwolf.enabled=true",
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=test",
             "springwolf.docket.servers.test-protocol.url=some-server:1234",
     })

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketServiceIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketServiceIntegrationTest.java
@@ -27,7 +27,7 @@ public class DefaultAsyncApiDocketServiceIntegrationTest {
             "springwolf.enabled=true",
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=test",
             "springwolf.docket.servers.test-protocol.url=some-server:1234"
     })
@@ -53,7 +53,7 @@ public class DefaultAsyncApiDocketServiceIntegrationTest {
             "springwolf.enabled=true",
             "springwolf.docket.info.title=Docket was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=test",
             "springwolf.docket.servers.test-protocol.url=some-server:1234"
     })

--- a/springwolf-examples/springwolf-amqp-example/src/main/resources/application.properties
+++ b/springwolf-examples/springwolf-amqp-example/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.rabbitmq.password=guest
 spring.application.name=Springwolf example project - Amqp
 
 springwolf.enabled=true
-springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers
+springwolf.docket.base-package=io.github.stavshamir.springwolf.example
 springwolf.docket.info.title=${spring.application.name}
 springwolf.docket.info.version=1.0.0
 springwolf.docket.info.description=Springwolf example project to demonstrate springwolfs abilities

--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/SpringContextTest.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/SpringContextTest.java
@@ -27,6 +27,11 @@ public class SpringContextTest {
 
             assertThat(asyncApiService.getAsyncAPI()).isNotNull();
         }
+
+        @Test
+        public void testAllChannelsAreFound() {
+            assertThat(asyncApiService.getAsyncAPI().getChannels()).hasSize(7);
+        }
     }
 
     @SpringBootTest(classes = SpringwolfExampleApplication.class)
@@ -35,7 +40,7 @@ public class SpringContextTest {
             "springwolf.enabled=true",
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=amqp",
             "springwolf.docket.servers.test-protocol.url=some-server:1234",
     })
@@ -51,6 +56,31 @@ public class SpringContextTest {
             assertNotNull(context);
 
             assertThat(asyncApiService.getAsyncAPI()).isNotNull();
+        }
+
+        @Test
+        public void testAllChannelsAreFound() {
+            // 2 channels defined in the AsyncDocket are not found (7 - 2 = 5)
+            assertThat(asyncApiService.getAsyncAPI().getChannels()).hasSize(5);
+        }
+    }
+
+    @SpringBootTest(classes = SpringwolfExampleApplication.class)
+    @TestPropertySource(properties = {
+            "springwolf.scanner.async-listener.enabled=false",
+            "springwolf.scanner.async-publisher.enabled=false",
+            "springwolf.scanner.consumer-data.enabled=false",
+            "springwolf.scanner.producer-data.enabled=false",
+            "springwolf.plugin.amqp.scanner.rabbit-listener.enabled=false",
+    })
+    public static class DisabledScannerTest {
+
+        @Autowired
+        private AsyncApiService asyncApiService;
+
+        @Test
+        public void testNoChannelsAreFound() {
+            assertThat(asyncApiService.getAsyncAPI().getChannels()).isEmpty();
         }
     }
 }

--- a/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/stavshamir/springwolf/example/SpringContextTest.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/stavshamir/springwolf/example/SpringContextTest.java
@@ -41,7 +41,7 @@ public class SpringContextTest {
             "springwolf.enabled=true",
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=kafka",
             "springwolf.docket.servers.test-protocol.url=some-server:1234",
     })

--- a/springwolf-examples/springwolf-kafka-example/src/main/resources/application.properties
+++ b/springwolf-examples/springwolf-kafka-example/src/main/resources/application.properties
@@ -27,7 +27,7 @@ spring.kafka.consumer.properties.spring.json.trusted.packages=io.github.stavsham
 #########
 # Springwolf configuration
 springwolf.enabled=true
-springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers
+springwolf.docket.base-package=io.github.stavshamir.springwolf.example
 springwolf.docket.info.title=${spring.application.name}
 springwolf.docket.info.version=1.0.0
 springwolf.docket.info.description=Springwolf example project to demonstrate springwolfs abilities

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/SpringContextTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/SpringContextTest.java
@@ -1,7 +1,6 @@
 package io.github.stavshamir.springwolf.example;
 
 import io.github.stavshamir.springwolf.asyncapi.AsyncApiService;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,7 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
-@Nested
 public class SpringContextTest {
 
     @SpringBootTest(classes = SpringwolfExampleApplication.class)
@@ -33,6 +31,11 @@ public class SpringContextTest {
 
             assertThat(asyncApiService.getAsyncAPI()).isNotNull();
         }
+
+        @Test
+        public void testAllChannelsAreFound() {
+            assertThat(asyncApiService.getAsyncAPI().getChannels()).hasSize(5);
+        }
     }
 
     @SpringBootTest(classes = SpringwolfExampleApplication.class)
@@ -43,7 +46,7 @@ public class SpringContextTest {
             "springwolf.enabled=true",
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=kafka",
             "springwolf.docket.servers.test-protocol.url=some-server:1234",
     })
@@ -59,6 +62,34 @@ public class SpringContextTest {
             assertNotNull(context);
 
             assertThat(asyncApiService.getAsyncAPI()).isNotNull();
+        }
+
+        @Test
+        public void testAllChannelsAreFound() {
+            // 2 channels defined in the AsyncDocket are not found,
+            // however PRODUCER_TOPIC is also used in ExampleProducer (5 - 2 + 1 = 4)
+            assertThat(asyncApiService.getAsyncAPI().getChannels()).hasSize(4);
+        }
+    }
+
+    @SpringBootTest(classes = SpringwolfExampleApplication.class)
+    @EmbeddedKafka(partitions = 1, brokerProperties = { "listeners=PLAINTEXT://localhost:9092", "port=9092" })
+    @DirtiesContext
+    @TestPropertySource(properties = {
+            "springwolf.scanner.async-listener.enabled=false",
+            "springwolf.scanner.async-publisher.enabled=false",
+            "springwolf.scanner.consumer-data.enabled=false",
+            "springwolf.scanner.producer-data.enabled=false",
+            "springwolf.plugin.kafka.scanner.kafka-listener.enabled=false"
+    })
+    public static class DisabledScannerTest {
+
+        @Autowired
+        private AsyncApiService asyncApiService;
+
+        @Test
+        public void testNoChannelsAreFound() {
+            assertThat(asyncApiService.getAsyncAPI().getChannels()).isEmpty();
         }
     }
 }

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/SpringWolfAmqpConfigConstants.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/SpringWolfAmqpConfigConstants.java
@@ -1,5 +1,7 @@
 package io.github.stavshamir.springwolf;
 
+import static io.github.stavshamir.springwolf.SpringWolfConfigConstants.ENABLED;
+import static io.github.stavshamir.springwolf.SpringWolfConfigConstants.SCANNER;
 import static io.github.stavshamir.springwolf.SpringWolfConfigConstants.SPRINGWOLF_PLUGIN_CONFIG_PREFIX;
 
 public class SpringWolfAmqpConfigConstants {
@@ -8,5 +10,6 @@ public class SpringWolfAmqpConfigConstants {
 
     public static final String SPRINGWOLF_AMQP_PLUGIN_PUBLISHING_ENABLED = "publishing.enabled";
 
-
+    public static final String SPRINGWOLF_SCANNER_RABBIT_LISTENER_ENABLED =
+            SPRINGWOLF_AMQP_CONFIG_PREFIX + SCANNER + ".rabbit-listener" + ENABLED;
 }

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/SpringWolfAmqpConfigProperties.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/SpringWolfAmqpConfigProperties.java
@@ -10,6 +10,10 @@ import javax.annotation.Nullable;
 
 import static io.github.stavshamir.springwolf.SpringWolfAmqpConfigConstants.SPRINGWOLF_AMQP_CONFIG_PREFIX;
 
+/**
+ * This class is used to create metadata for auto-completion in spring configuration properties/yaml by using
+ * the spring-boot-configuration-processor.
+ */
 @Configuration
 @ConfigurationProperties(prefix = SPRINGWOLF_AMQP_CONFIG_PREFIX)
 @ConditionalOnProperty(name = SpringWolfConfigConstants.SPRINGWOLF_ENABLED, matchIfMissing = true)
@@ -20,6 +24,9 @@ public class SpringWolfAmqpConfigProperties {
     @Nullable
     private Publishing publishing;
 
+    @Nullable
+    private Scanner scanner;
+
     @Getter
     @Setter
     public static class Publishing {
@@ -29,6 +36,23 @@ public class SpringWolfAmqpConfigProperties {
          */
         private boolean enabled = false;
 
+    }
+
+    @Getter
+    @Setter
+    public static class Scanner {
+
+        private static RabbitListener rabbitListener;
+
+        @Getter
+        @Setter
+        public static class RabbitListener {
+
+            /**
+             * This mirrors the ConfigConstant {@see SpringWolfAmqpConfigConstants#SPRINGWOLF_SCANNER_RABBIT_LISTENER_ENABLED}
+             */
+            private boolean enabled = true;
+        }
     }
 
 }

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScanner.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScanner.java
@@ -12,6 +12,7 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanne
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
@@ -26,9 +27,12 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.github.stavshamir.springwolf.SpringWolfAmqpConfigConstants.SPRINGWOLF_SCANNER_RABBIT_LISTENER_ENABLED;
+
 @Slf4j
 @Service
 @Order(value = ChannelPriority.AUTO_DISCOVERED)
+@ConditionalOnProperty(name = SPRINGWOLF_SCANNER_RABBIT_LISTENER_ENABLED, matchIfMissing = true)
 public class MethodLevelRabbitListenerScanner extends AbstractMethodLevelListenerScanner<RabbitListener>
         implements ChannelsScanner, EmbeddedValueResolverAware {
 

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfAmqpProducerConfigurationIntegrationTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfAmqpProducerConfigurationIntegrationTest.java
@@ -36,7 +36,7 @@ public class SpringwolfAmqpProducerConfigurationIntegrationTest {
             "springwolf.enabled=true",
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=test",
             "springwolf.docket.servers.test-protocol.url=some-server:1234",
             "springwolf.plugin.amqp.publishing.enabled=true"
@@ -73,7 +73,7 @@ public class SpringwolfAmqpProducerConfigurationIntegrationTest {
             "springwolf.enabled=true",
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=test",
             "springwolf.docket.servers.test-protocol.url=some-server:1234",
             "springwolf.plugin.amqp.publishing.enabled=false"

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/SpringWolfKafkaConfigConstants.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/SpringWolfKafkaConfigConstants.java
@@ -1,5 +1,7 @@
 package io.github.stavshamir.springwolf;
 
+import static io.github.stavshamir.springwolf.SpringWolfConfigConstants.ENABLED;
+import static io.github.stavshamir.springwolf.SpringWolfConfigConstants.SCANNER;
 import static io.github.stavshamir.springwolf.SpringWolfConfigConstants.SPRINGWOLF_PLUGIN_CONFIG_PREFIX;
 
 public class SpringWolfKafkaConfigConstants {
@@ -7,6 +9,9 @@ public class SpringWolfKafkaConfigConstants {
     public static final String SPRINGWOLF_KAFKA_CONFIG_PREFIX = SPRINGWOLF_PLUGIN_CONFIG_PREFIX + ".kafka";
 
     public static final String SPRINGWOLF_KAFKA_PLUGIN_PUBLISHING_ENABLED = "publishing.enabled";
+
+    public static final String SPRINGWOLF_SCANNER_KAFKA_LISTENER_ENABLED =
+            SPRINGWOLF_KAFKA_CONFIG_PREFIX + SCANNER + ".kafka-listener" + ENABLED;
 
 
 }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/SpringWolfKafkaConfigProperties.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/SpringWolfKafkaConfigProperties.java
@@ -12,6 +12,10 @@ import javax.annotation.Nullable;
 
 import static io.github.stavshamir.springwolf.SpringWolfKafkaConfigConstants.SPRINGWOLF_KAFKA_CONFIG_PREFIX;
 
+/**
+ * This class is used to create metadata for auto-completion in spring configuration properties/yaml by using
+ * the spring-boot-configuration-processor.
+ */
 @Configuration
 @ConfigurationProperties(prefix = SPRINGWOLF_KAFKA_CONFIG_PREFIX)
 @ConditionalOnProperty(name = SpringWolfConfigConstants.SPRINGWOLF_ENABLED, matchIfMissing = true)
@@ -21,6 +25,9 @@ public class SpringWolfKafkaConfigProperties {
 
     @Nullable
     private Publishing publishing;
+
+    @Nullable
+    private Scanner scanner;
 
     @Getter
     @Setter
@@ -33,7 +40,22 @@ public class SpringWolfKafkaConfigProperties {
 
         @NestedConfigurationProperty
         private KafkaProperties.Producer producer;
-
     }
 
+    @Getter
+    @Setter
+    public static class Scanner {
+
+        private static KafkaListener kafkaListener;
+
+        @Getter
+        @Setter
+        public static class KafkaListener {
+
+            /**
+             * This mirrors the ConfigConstant {@see SpringWolfKafkaConfigConstants#SPRINGWOLF_SCANNER_KAFKA_LISTENER_ENABLED}
+             */
+            private boolean enabled = true;
+        }
+    }
 }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScanner.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScanner.java
@@ -9,6 +9,7 @@ import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeadersForSpringKafkaBuilder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.core.annotation.Order;
 import org.springframework.kafka.annotation.KafkaHandler;
@@ -19,12 +20,14 @@ import org.springframework.util.StringValueResolver;
 import java.lang.reflect.Method;
 import java.util.Map;
 
+import static io.github.stavshamir.springwolf.SpringWolfKafkaConfigConstants.SPRINGWOLF_SCANNER_KAFKA_LISTENER_ENABLED;
 import static io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.SpringPayloadAnnotationTypeExtractor.getPayloadType;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Order(value = ChannelPriority.AUTO_DISCOVERED)
+@ConditionalOnProperty(name = SPRINGWOLF_SCANNER_KAFKA_LISTENER_ENABLED, matchIfMissing = true)
 public class ClassLevelKafkaListenerScanner extends AbstractClassLevelListenerScanner<KafkaListener, KafkaHandler>
         implements ChannelsScanner, EmbeddedValueResolverAware {
 

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelKafkaListenerScanner.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelKafkaListenerScanner.java
@@ -7,6 +7,7 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriorit
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.core.annotation.Order;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -16,10 +17,13 @@ import org.springframework.util.StringValueResolver;
 import java.lang.reflect.Method;
 import java.util.Map;
 
+import static io.github.stavshamir.springwolf.SpringWolfKafkaConfigConstants.SPRINGWOLF_SCANNER_KAFKA_LISTENER_ENABLED;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Order(value = ChannelPriority.AUTO_DISCOVERED)
+@ConditionalOnProperty(name = SPRINGWOLF_SCANNER_KAFKA_LISTENER_ENABLED, matchIfMissing = true)
 public class MethodLevelKafkaListenerScanner extends AbstractMethodLevelListenerScanner<KafkaListener>
         implements ChannelsScanner, EmbeddedValueResolverAware {
 

--- a/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfKafkaProducerConfigurationIntegrationTest.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfKafkaProducerConfigurationIntegrationTest.java
@@ -33,7 +33,7 @@ public class SpringwolfKafkaProducerConfigurationIntegrationTest {
             "springwolf.enabled=true",
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=test",
             "springwolf.docket.servers.test-protocol.url=some-server:1234",
             "springwolf.plugin.kafka.publishing.enabled=true"
@@ -66,7 +66,7 @@ public class SpringwolfKafkaProducerConfigurationIntegrationTest {
             "springwolf.enabled=true",
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example.consumers",
+            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=test",
             "springwolf.docket.servers.test-protocol.url=some-server:1234",
             "springwolf.plugin.kafka.publishing.enabled=false"


### PR DESCRIPTION
Allows for more fine-grain configuration, avoiding exceptions if certain listeners are broken, or if multiple scanners discover the same consumer/producer