### PR TITLE
chore: Sort asyncapi doc elements via objectMapper

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.PrettyPrinter;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.github.stavshamir.springwolf.asyncapi.serializers.EmptyChannelBindingSerializer;
 import io.github.stavshamir.springwolf.asyncapi.serializers.EmptyOperationBindingSerializer;
@@ -30,7 +31,12 @@ public class DefaultAsyncApiSerializerService implements AsyncApiSerializerServi
 
     @PostConstruct
     void postConstruct() {
+        jsonMapper.setConfig(
+            jsonMapper.getSerializationConfig()
+                .with(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+        );
         jsonMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
         registerKafkaOperationBindingSerializer();
     }
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsService.java
@@ -9,9 +9,9 @@ import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 @Slf4j
 @Service
@@ -19,7 +19,7 @@ import java.util.TreeMap;
 public class DefaultChannelsService implements ChannelsService {
 
     private final List<? extends ChannelsScanner> channelsScanners;
-    private final Map<String, ChannelItem> channels = new TreeMap<>();
+    private final Map<String, ChannelItem> channels = new HashMap<>();
 
     @PostConstruct
     void findChannels() {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMerger.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMerger.java
@@ -5,13 +5,12 @@ import com.asyncapi.v2.model.channel.operation.Operation;
 import io.github.stavshamir.springwolf.asyncapi.MessageHelper;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -34,7 +33,7 @@ public class ChannelMerger {
      * @return A map of channelName to a single ChannelItem
      */
     public static Map<String, ChannelItem> merge(List<Map.Entry<String, ChannelItem>> channelEntries) {
-        Map<String, ChannelItem> mergedChannels = new TreeMap<>();
+        Map<String, ChannelItem> mergedChannels = new HashMap<>();
 
         for (Map.Entry<String, ChannelItem> entry : channelEntries) {
             if (!mergedChannels.containsKey(entry.getKey())) {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeaders.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeaders.java
@@ -2,9 +2,9 @@ package io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message
 
 import io.swagger.v3.oas.models.media.Schema;
 
-import java.util.TreeMap;
+import java.util.HashMap;
 
-public class AsyncHeaders extends TreeMap<String, Schema> {
+public class AsyncHeaders extends HashMap<String, Schema> {
     /**
      * Per default, if no headers are explicitly defined, NOT_DOCUMENTED is used.
      * There can be headers, but don't have to be.

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasService.java
@@ -26,7 +26,7 @@ public class DefaultSchemasService implements SchemasService {
     private final ModelConverters converter = ModelConverters.getInstance();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private final Map<String, Schema> definitions = new TreeMap<>();
+    private final Map<String, Schema> definitions = new HashMap<>();
 
     public DefaultSchemasService(Optional<List<ModelConverter>> externalModelConverters) {
         externalModelConverters.ifPresent(converters -> converters.forEach(converter::addConverter));

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerServiceTest.java
@@ -100,7 +100,7 @@ public class DefaultAsyncApiSerializerServiceTest {
         System.out.println("Got: " + actual);
         InputStream s = this.getClass().getResourceAsStream("/asyncapi/asyncapi.json");
         String expected = IOUtils.toString(s, StandardCharsets.UTF_8);
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 
     @Data

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/serializers/KafkaOperationBindingSerializerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/serializers/KafkaOperationBindingSerializerTest.java
@@ -24,7 +24,7 @@ public class KafkaOperationBindingSerializerTest {
         KafkaOperationBinding binding = KafkaOperationBinding.builder().clientId("testClientId").build();
         String actual = objectMapper.writeValueAsString(binding);
         String expected = "{\"clientId\":{\"type\":\"string\",\"enum\":[\"testClientId\"]}}";
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 
 
@@ -33,7 +33,7 @@ public class KafkaOperationBindingSerializerTest {
         KafkaOperationBinding binding = KafkaOperationBinding.builder().clientId("").build();
         String actual = objectMapper.writeValueAsString(binding);
         String expected = "{\"clientId\":{\"type\":\"string\",\"enum\":[\"\"]}}";
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 
 
@@ -42,7 +42,7 @@ public class KafkaOperationBindingSerializerTest {
         KafkaOperationBinding binding = KafkaOperationBinding.builder().groupId("testGroupId").build();
         String actual = objectMapper.writeValueAsString(binding);
         String expected = "{\"groupId\":{\"type\":\"string\",\"enum\":[\"testGroupId\"]}}";
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 
 
@@ -51,7 +51,7 @@ public class KafkaOperationBindingSerializerTest {
         KafkaOperationBinding binding = KafkaOperationBinding.builder().groupId("").build();
         String actual = objectMapper.writeValueAsString(binding);
         String expected = "{\"groupId\":{\"type\":\"string\",\"enum\":[\"\"]}}";
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 
 
@@ -60,7 +60,7 @@ public class KafkaOperationBindingSerializerTest {
         KafkaOperationBinding binding = KafkaOperationBinding.builder().bindingVersion("v1").build();
         String actual = objectMapper.writeValueAsString(binding);
         String expected = "{\"bindingVersion\":{\"type\":\"string\",\"enum\":[\"v1\"]}}";
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 
 
@@ -69,7 +69,7 @@ public class KafkaOperationBindingSerializerTest {
         KafkaOperationBinding binding = KafkaOperationBinding.builder().bindingVersion("").build();
         String actual = objectMapper.writeValueAsString(binding);
         String expected = "{\"bindingVersion\":{\"type\":\"string\",\"enum\":[\"\"]}}";
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class KafkaOperationBindingSerializerTest {
         KafkaOperationBinding binding = new KafkaOperationBinding();
         String actual = objectMapper.writeValueAsString(binding);
         String expected = "{}";
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 
     @Test
@@ -89,7 +89,7 @@ public class KafkaOperationBindingSerializerTest {
                 "\"groupId\":{\"type\":\"string\",\"enum\":[\"testGroupId\"]}," +
                 "\"bindingVersion\":{\"type\":\"string\",\"enum\":[\"v1\"]}" +
                 "}";
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasServiceTest.java
@@ -52,7 +52,7 @@ public class DefaultSchemasServiceTest {
 
         String expectedExample = jsonResource(EXAMPLES_PATH + "/simple-foo.json");
 
-        JSONAssert.assertEquals(expectedExample, example, JSONCompareMode.STRICT_ORDER);
+        JSONAssert.assertEquals(expectedExample, example, JSONCompareMode.STRICT);
     }
 
     @Test
@@ -65,7 +65,7 @@ public class DefaultSchemasServiceTest {
         String expectedExample = jsonResource(EXAMPLES_PATH + "/composite-foo.json");
 
         // Then it returns the correct example object as json
-        JSONAssert.assertEquals(expectedExample, example, JSONCompareMode.STRICT_ORDER);
+        JSONAssert.assertEquals(expectedExample, example, JSONCompareMode.STRICT);
     }
 
     @Test
@@ -76,7 +76,8 @@ public class DefaultSchemasServiceTest {
         String actualDefinitions = objectMapper.writeValueAsString(schemasService.getDefinitions());
         String expected = jsonResource("/schemas/definitions.json");
 
-        JSONAssert.assertEquals(expected, actualDefinitions, JSONCompareMode.STRICT_ORDER);
+        System.out.println("Got: " + actualDefinitions);
+        JSONAssert.assertEquals(expected, actualDefinitions, JSONCompareMode.STRICT);
     }
 
     @Test
@@ -86,7 +87,8 @@ public class DefaultSchemasServiceTest {
         String actualDefinitions = objectMapper.writeValueAsString(schemasService.getDefinitions());
         String expected = jsonResource("/schemas/documented-definitions.json");
 
-        JSONAssert.assertEquals(expected, actualDefinitions, JSONCompareMode.STRICT_ORDER);
+        System.out.println("Got: " + actualDefinitions);
+        JSONAssert.assertEquals(expected, actualDefinitions, JSONCompareMode.STRICT);
     }
 
     @Test

--- a/springwolf-core/src/test/resources/asyncapi/asyncapi.json
+++ b/springwolf-core/src/test/resources/asyncapi/asyncapi.json
@@ -45,15 +45,13 @@
             "$ref" : "#/components/schemas/ExamplePayload"
           },
           "bindings" : {
-            "kafka": {
-              "key": {
-                "type": "string",
-                "exampleSetFlag": false,
-                "types": [
-                  "string"
-                ]
+            "kafka" : {
+              "key" : {
+                "type" : "string",
+                "exampleSetFlag" : false,
+                "types" : [ "string" ]
               },
-              "bindingVersion": "binding-version-1"
+              "bindingVersion" : "binding-version-1"
             }
           }
         }
@@ -66,9 +64,12 @@
         "type" : "object",
         "properties" : {
           "s" : {
-            "type" : "string"
+            "type" : "string",
+            "exampleSetFlag" : false,
+            "types" : [ "string" ]
           }
-        }
+        },
+        "exampleSetFlag" : false
       }
     }
   },

--- a/springwolf-core/src/test/resources/schemas/documented-definitions.json
+++ b/springwolf-core/src/test/resources/schemas/documented-definitions.json
@@ -6,12 +6,17 @@
       "s": {
         "description": "s field",
         "type": "string",
-        "example": "s value"
+        "example": "s value",
+        "exampleSetFlag": true,
+        "types": [
+          "string"
+        ]
       }
     },
     "example": {
       "s": "s value"
     },
+    "exampleSetFlag": true,
     "required": [
       "s"
     ]

--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTest.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTest.java
@@ -32,6 +32,6 @@ public class ApiIntegrationTest {
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expected = IOUtils.toString(s, StandardCharsets.UTF_8);
 
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 }

--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationWithDockerTest.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationWithDockerTest.java
@@ -46,6 +46,6 @@ public class ApiIntegrationWithDockerTest {
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expected = IOUtils.toString(s, StandardCharsets.UTF_8);
 
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 }

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -43,6 +43,9 @@
           },
           "headers" : {
             "$ref" : "#/components/schemas/HeadersNotDocumented"
+          },
+          "bindings" : {
+            "amqp" : { }
           }
         }
       },
@@ -79,6 +82,9 @@
           },
           "headers" : {
             "$ref" : "#/components/schemas/HeadersNotDocumented"
+          },
+          "bindings" : {
+            "amqp" : { }
           }
         }
       },
@@ -190,7 +196,8 @@
           },
           "headers" : {
             "$ref" : "#/components/schemas/HeadersNotDocumented"
-          }
+          },
+          "bindings" : { }
         }
       }
     },
@@ -217,6 +224,9 @@
           },
           "headers" : {
             "$ref" : "#/components/schemas/HeadersNotDocumented"
+          },
+          "bindings" : {
+            "amqp" : { }
           }
         }
       },
@@ -253,6 +263,9 @@
           },
           "headers" : {
             "$ref" : "#/components/schemas/HeadersNotDocumented"
+          },
+          "bindings" : {
+            "amqp" : { }
           }
         }
       },
@@ -273,26 +286,26 @@
         "required" : [ "example" ],
         "type" : "object",
         "properties" : {
+          "example" : {
+            "$ref" : "#/components/schemas/ExamplePayloadDto",
+            "exampleSetFlag" : false
+          },
           "foo" : {
             "type" : "string",
             "description" : "Foo field",
             "example" : "bar",
             "exampleSetFlag" : true,
             "types" : [ "string" ]
-          },
-          "example" : {
-            "$ref" : "#/components/schemas/ExamplePayloadDto",
-            "exampleSetFlag" : false
           }
         },
         "description" : "Another payload model",
         "example" : {
-          "foo" : "bar",
           "example" : {
-            "someString" : "some string value",
+            "someEnum" : "FOO2",
             "someLong" : 5,
-            "someEnum" : "FOO2"
-          }
+            "someString" : "some string value"
+          },
+          "foo" : "bar"
         },
         "exampleSetFlag" : true
       },
@@ -300,12 +313,13 @@
         "required" : [ "someEnum", "someString" ],
         "type" : "object",
         "properties" : {
-          "someString" : {
+          "someEnum" : {
             "type" : "string",
-            "description" : "Some string field",
-            "example" : "some string value",
+            "description" : "Some enum field",
+            "example" : "FOO2",
             "exampleSetFlag" : true,
-            "types" : [ "string" ]
+            "types" : [ "string" ],
+            "enum" : [ "FOO1", "FOO2", "FOO3" ]
           },
           "someLong" : {
             "type" : "integer",
@@ -315,20 +329,19 @@
             "exampleSetFlag" : true,
             "types" : [ "integer" ]
           },
-          "someEnum" : {
+          "someString" : {
             "type" : "string",
-            "description" : "Some enum field",
-            "example" : "FOO2",
+            "description" : "Some string field",
+            "example" : "some string value",
             "exampleSetFlag" : true,
-            "types" : [ "string" ],
-            "enum" : [ "FOO1", "FOO2", "FOO3" ]
+            "types" : [ "string" ]
           }
         },
         "description" : "Example payload model",
         "example" : {
-          "someString" : "some string value",
+          "someEnum" : "FOO2",
           "someLong" : 5,
-          "someEnum" : "FOO2"
+          "someString" : "some string value"
         },
         "exampleSetFlag" : true
       },

--- a/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
@@ -35,7 +35,7 @@ public class AsyncApiConfiguration {
     public AsyncApiDocket asyncApiDocket() {
         Info info = Info.builder()
                 .version("1.0.0")
-                .title("Springwolf example project - Kafka")
+                .title("Springwolf example project - CloudStream")
                 .contact(Contact.builder().name("springwolf").url("https://github.com/springwolf/springwolf-core").email("example@example.com").build())
                 .description("Springwolf example project")
                 .license(License.builder().name("Apache License 2.0").build())

--- a/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTest.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTest.java
@@ -38,6 +38,6 @@ public class ApiIntegrationTest {
         // When running with EmbeddedKafka, localhost is used as hostname
         String expected = expectedWithoutServersKafkaUrlPatch.replace("\"kafka:29092\"", "\"localhost:29092\"");
 
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 }

--- a/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationWithDockerTest.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationWithDockerTest.java
@@ -46,6 +46,6 @@ public class ApiIntegrationWithDockerTest {
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expected = IOUtils.toString(s, StandardCharsets.UTF_8);
 
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 }

--- a/springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json
@@ -1,7 +1,7 @@
 {
   "asyncapi": "2.0.0",
   "info": {
-    "title": "Springwolf example project - Kafka",
+    "title": "Springwolf example project - CloudStream",
     "version": "1.0.0",
     "description": "Springwolf example project",
     "contact": {

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationTest.java
@@ -40,6 +40,6 @@ public class ApiIntegrationTest {
         String actual = restTemplate.getForObject(url, String.class);
         System.out.println("Got: " + actual);
 
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 }

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationWithDockerTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/ApiIntegrationWithDockerTest.java
@@ -47,6 +47,6 @@ public class ApiIntegrationWithDockerTest {
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expected = IOUtils.toString(s, StandardCharsets.UTF_8);
 
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 }

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/OpenApiGeneratorTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/OpenApiGeneratorTest.java
@@ -28,6 +28,6 @@ public class OpenApiGeneratorTest {
         String actual = IOUtils.toString(actualStream, StandardCharsets.UTF_8);
         System.out.println("Got: " + actual);
 
-        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT_ORDER);
+        JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
     }
 }

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -246,26 +246,26 @@
         "required" : [ "example" ],
         "type" : "object",
         "properties" : {
+          "example" : {
+            "$ref" : "#/components/schemas/ExamplePayloadDto",
+            "exampleSetFlag" : false
+          },
           "foo" : {
             "type" : "string",
             "description" : "Foo field",
             "example" : "bar",
             "exampleSetFlag" : true,
             "types" : [ "string" ]
-          },
-          "example" : {
-            "$ref" : "#/components/schemas/ExamplePayloadDto",
-            "exampleSetFlag" : false
           }
         },
         "description" : "Another payload model",
         "example" : {
-          "foo" : "bar",
           "example" : {
-            "someString" : "some string value",
+            "someEnum" : "FOO2",
             "someLong" : 5,
-            "someEnum" : "FOO2"
-          }
+            "someString" : "some string value"
+          },
+          "foo" : "bar"
         },
         "exampleSetFlag" : true
       },
@@ -345,12 +345,13 @@
         "required" : [ "someEnum", "someString" ],
         "type" : "object",
         "properties" : {
-          "someString" : {
+          "someEnum" : {
             "type" : "string",
-            "description" : "Some string field",
-            "example" : "some string value",
+            "description" : "Some enum field",
+            "example" : "FOO2",
             "exampleSetFlag" : true,
-            "types" : [ "string" ]
+            "types" : [ "string" ],
+            "enum" : [ "FOO1", "FOO2", "FOO3" ]
           },
           "someLong" : {
             "type" : "integer",
@@ -360,20 +361,19 @@
             "exampleSetFlag" : true,
             "types" : [ "integer" ]
           },
-          "someEnum" : {
+          "someString" : {
             "type" : "string",
-            "description" : "Some enum field",
-            "example" : "FOO2",
+            "description" : "Some string field",
+            "example" : "some string value",
             "exampleSetFlag" : true,
-            "types" : [ "string" ],
-            "enum" : [ "FOO1", "FOO2", "FOO3" ]
+            "types" : [ "string" ]
           }
         },
         "description" : "Example payload model",
         "example" : {
-          "someString" : "some string value",
+          "someEnum" : "FOO2",
           "someLong" : 5,
-          "someEnum" : "FOO2"
+          "someString" : "some string value"
         },
         "exampleSetFlag" : true
       },


### PR DESCRIPTION
Avoid usage of sorted data structures in code (like TreeMap, etc)
Library internal data structures should not have an impact on the order of the elements in the resulting asyncapi.json doc file