### PR TITLE
Fix: Packaging jars without -plain archiveClassifier

### DIFF
--- a/springwolf-add-ons/springwolf-common-model-converters/build.gradle
+++ b/springwolf-add-ons/springwolf-common-model-converters/build.gradle
@@ -29,7 +29,10 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
 }
 
-jar.enabled = true
+jar {
+    enabled = true
+    archiveClassifier = ''
+}
 bootJar.enabled = false
 
 java {

--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -47,7 +47,10 @@ dependencies {
     testImplementation 'org.springframework.kafka:spring-kafka'
 }
 
-jar.enabled = true
+jar {
+    enabled = true
+    archiveClassifier = ''
+}
 bootJar.enabled = false
 
 java {

--- a/springwolf-plugins/springwolf-amqp-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-amqp-plugin/build.gradle
@@ -40,7 +40,10 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 
-jar.enabled = true
+jar {
+    enabled = true
+    archiveClassifier = ''
+}
 bootJar.enabled = false
 
 java {

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/build.gradle
@@ -45,7 +45,10 @@ dependencies {
     testImplementation('org.apache.kafka:kafka-streams:3.4.0')
 }
 
-jar.enabled = true
+jar {
+    enabled = true
+    archiveClassifier = ''
+}
 bootJar.enabled = false
 
 java {

--- a/springwolf-plugins/springwolf-kafka-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-kafka-plugin/build.gradle
@@ -40,7 +40,10 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 
-jar.enabled = true
+jar {
+    enabled = true
+    archiveClassifier = ''
+}
 bootJar.enabled = false
 
 java {


### PR DESCRIPTION
Regression of the spring boot update released in springwolf 0.10.3

Current artifact name: springwolf-kafka-0.10.3-plain.jar
Should be (previous behaviour): springwolf-kafka-0.10.3.jar

Relates to: https://github.com/springwolf/springwolf-core/issues/136