### PR TITLE
Provide Autoconfiguration, make @EnableAsyncApi deprecated and noop

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfAutoConfiguration.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfAutoConfiguration.java
@@ -1,0 +1,27 @@
+package io.github.stavshamir.springwolf;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.TypeExcludeFilter;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+
+/**
+ * Spring Boot auto-configuration which loads all spring-beans for springwolf core and eventually loaded plugins.
+ * <p>
+ * This configuration uses the spring @{@link ComponentScan} mechanism to detect and load the necessary beans. Both
+ * the core components as well as all plugin components are located underneath the base package 'io.github.stavshamir.springwolf'
+ * so existing springwolf plugins are automatically loaded together with the springwolf core beans.
+ * <p>
+ * To disable this auto-configuration, set the environment property {@code springwolf.enabled=false}.
+ */
+@AutoConfiguration
+@ComponentScan(
+        basePackages = {"io.github.stavshamir.springwolf"},
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+                @ComponentScan.Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class)})
+@ConditionalOnProperty(name = SpringWolfConfigConstants.SPRINGWOLF_ENABLED, matchIfMissing = true)
+public class SpringWolfAutoConfiguration {
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/EnableAsyncApi.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/EnableAsyncApi.java
@@ -16,10 +16,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Enable the documentation of asynchronous consumer endpoints (methods annotated by @KafkaListener in a class annotated with @{@link Component}).
  * <br>
  * This annotation should be applied to a Spring java config and should have an accompanying '@{@link Configuration}' annotation.
+ * @deprecated not necessary any more as springwolf components are loaded via autoconfiguration.
  * @author Stav Shamir
  */
 @Retention(value=RUNTIME)
 @Target(value=TYPE)
-@ComponentScan(basePackages={"io/github/stavshamir/springwolf"})
-@ConditionalOnProperty(name = SpringWolfConfigConstants.SPRINGWOLF_ENABLED, matchIfMissing = true)
+@Deprecated
 public @interface EnableAsyncApi { }

--- a/springwolf-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/springwolf-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.github.stavshamir.springwolf.SpringWolfAutoConfiguration

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/CustomBeanAsyncApiDocketConfiguration.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/CustomBeanAsyncApiDocketConfiguration.java
@@ -2,10 +2,11 @@ package io.github.stavshamir.springwolf;
 
 import com.asyncapi.v2.model.info.Info;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@TestConfiguration
 class CustomBeanAsyncApiDocketConfiguration {
     @Bean
     public AsyncApiDocket docket() {

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/SpringWolfAutoConfigurationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/SpringWolfAutoConfigurationTest.java
@@ -1,0 +1,64 @@
+package io.github.stavshamir.springwolf.integrationtests;
+
+import com.asyncapi.v2.model.info.Info;
+import io.github.stavshamir.springwolf.asyncapi.controller.AsyncApiController;
+import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests loading or ignoring the SpringWolfAutoConfiguration
+ */
+public class SpringWolfAutoConfigurationTest {
+
+    @SpringBootTest(classes = TestApplication.class)
+    public static class TestSpringWolfEnabled{
+        @Autowired
+        private AsyncApiController asyncApiController;
+
+        @Test
+        public void autoconfigurationShouldBeLoaded(){
+            assertThat(asyncApiController).isNotNull();
+        }
+
+    }
+
+    @SpringBootTest(classes = TestApplication.class)
+    @TestPropertySource(properties = {"springwolf.enabled=false"})
+    public static class TestSpringWolfDisabled{
+
+        @Autowired
+        private ObjectProvider<AsyncApiController> asyncApiControllerObjectProvider;
+
+
+        @Test
+        public void autoconfigurationShouldNotBeLoaded(){
+            assertThat(asyncApiControllerObjectProvider.getIfAvailable()).isNull();
+        }
+
+    }
+
+
+    @SpringBootApplication
+    static class TestApplication{
+
+        @Bean
+        public AsyncApiDocket docket() {
+            return AsyncApiDocket.builder()
+                    .info(Info.builder()
+                            .title("AsyncApiDocketConfiguration-title")
+                            .version("AsyncApiDocketConfiguration-version")
+                            .build())
+                    .build();
+        }
+
+    }
+
+}

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
@@ -9,7 +9,6 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.
 import io.github.stavshamir.springwolf.asyncapi.types.AmqpConsumerData;
 import io.github.stavshamir.springwolf.asyncapi.types.AmqpProducerData;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
-import io.github.stavshamir.springwolf.configuration.EnableAsyncApi;
 import io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -17,7 +16,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableAsyncApi
 public class AsyncApiConfiguration {
 
     private final String amqpHost;

--- a/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
@@ -7,14 +7,12 @@ import com.asyncapi.v2.model.server.Server;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncListener;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
-import io.github.stavshamir.springwolf.configuration.EnableAsyncApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableAsyncApi
 public class AsyncApiConfiguration {
 
     private final String BOOTSTRAP_SERVERS;

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/configuration/AsyncApiConfiguration.java
@@ -11,7 +11,6 @@ import io.github.stavshamir.springwolf.asyncapi.types.KafkaProducerData;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeadersForCloudEventsBuilder;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
-import io.github.stavshamir.springwolf.configuration.EnableAsyncApi;
 import io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto;
 import io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,7 +23,6 @@ import static io.github.stavshamir.springwolf.example.configuration.KafkaConfigu
 import static io.github.stavshamir.springwolf.example.configuration.KafkaConfiguration.PRODUCER_TOPIC;
 
 @Configuration
-@EnableAsyncApi
 public class AsyncApiConfiguration {
 
     private final String BOOTSTRAP_SERVERS;

--- a/springwolf-plugins/springwolf-amqp-plugin/README.md
+++ b/springwolf-plugins/springwolf-amqp-plugin/README.md
@@ -38,7 +38,6 @@ Add a configuration class and provide a `AsyncApiDocket` bean:
 ```java
 
 @Configuration
-@EnableAsyncApi
 public class AsyncApiConfiguration {
 
     private final String amqpHost = "localhost";

--- a/springwolf-plugins/springwolf-kafka-plugin/README.md
+++ b/springwolf-plugins/springwolf-kafka-plugin/README.md
@@ -40,7 +40,6 @@ Add a configuration class and provide a `AsyncApiDocket` bean:
 ```java
 
 @Configuration
-@EnableAsyncApi
 public class AsyncApiConfiguration {
 
     private final static String BOOTSTRAP_SERVERS = "localhost:9092"; // Change to your actual bootstrap server


### PR DESCRIPTION
This is a suggestion for a spring boot auto-configuration, replacing the @EnableSpringWolf Annotation. Sie #128 

It is a 1:1 replacement of the componentscan definition in @EnableSpringWolf with a base-package that includes all plugins. (which in my eyes is not perfect, I would prefer separate package namespaces for core and plugins and separate autoconfigurations...)

Not included with this PR are the necessary updates in the documentation - I'am new to github and did not find the sources ... ;-)