### PR TITLE
Export to YAML

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/AsyncApiSerializerService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/AsyncApiSerializerService.java
@@ -7,4 +7,7 @@ public interface AsyncApiSerializerService {
 
     String toJsonString(AsyncAPI asyncAPI) throws JsonProcessingException;
 
+    default String toYaml(AsyncAPI asyncAPI) throws JsonProcessingException {
+        throw new UnsupportedOperationException("The 'toYaml' method is not implemented");
+    }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
 import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,8 @@ import org.springframework.stereotype.Service;
 public class DefaultAsyncApiSerializerService implements AsyncApiSerializerService {
 
     private ObjectMapper jsonMapper = new ObjectMapper();
+
+    private ObjectMapper yamlMapper;
     private PrettyPrinter printer = new DefaultPrettyPrinter().withObjectIndenter(new DefaultIndenter("  ", DefaultIndenter.SYS_LF));
 
     @PostConstruct
@@ -26,28 +30,78 @@ public class DefaultAsyncApiSerializerService implements AsyncApiSerializerServi
                         .without(SerializationFeature.FAIL_ON_EMPTY_BEANS)
         );
         jsonMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    }
 
+        final YAMLFactory factory = new YAMLFactory()
+                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+                .enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR)
+                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+        yamlMapper = new ObjectMapper(factory);
+        yamlMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    }
 
     @Override
     public String toJsonString(AsyncAPI asyncAPI) throws JsonProcessingException {
         return jsonMapper.writer(printer).writeValueAsString(asyncAPI);
     }
 
+    @Override
+    public String toYaml(AsyncAPI asyncAPI) throws JsonProcessingException {
+        return yamlMapper.writer(printer).writeValueAsString(asyncAPI);
+    }
+
     /**
      * Get the current object mapper configuration.
+     *
+     * @deprecated
+     * This method is replaced by {@link DefaultAsyncApiSerializerService#getJsonObjectMapper()}
      */
+    @Deprecated(since = "0.11.0", forRemoval = true)
     public ObjectMapper getObjectMapper() {
+        return getJsonObjectMapper();
+    }
+
+    /**
+     * Get the current JSON object mapper configuration.
+     */
+    public ObjectMapper getJsonObjectMapper() {
         return jsonMapper;
+    }
+
+    /**
+     * Get the current YAML object mapper configuration.
+     */
+    public ObjectMapper getYamlObjectMapper() {
+        return yamlMapper;
     }
 
     /**
      * Allows to customize the used objectMapper
      * <p>
-     * Use {@link #getObjectMapper()} as a starting point
+     * Use {@link #getJsonObjectMapper()} as a starting point
+     * @deprecated
+     * This method is replaced by {@link DefaultAsyncApiSerializerService#setJsonObjectMapper(ObjectMapper)}
      */
+    @Deprecated(since = "0.11.0", forRemoval = true)
     public void setObjectMapper(ObjectMapper mapper) {
         jsonMapper = mapper;
+    }
+
+    /**
+     * Allows to customize the used objectMapper
+     * <p>
+     * Use {@link #getJsonObjectMapper()} as a starting point
+     */
+    public void setJsonObjectMapper(ObjectMapper mapper) {
+        jsonMapper = mapper;
+    }
+
+    /**
+     * Allows to customize the used objectMapper
+     * <p>
+     * Use {@link #getJsonObjectMapper()} as a starting point
+     */
+    public void setYamlObjectMapper(ObjectMapper mapper) {
+        yamlMapper = mapper;
     }
 
     /**

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
+import io.swagger.v3.core.util.Yaml;
 import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
 
@@ -19,7 +20,7 @@ public class DefaultAsyncApiSerializerService implements AsyncApiSerializerServi
 
     private ObjectMapper jsonMapper = new ObjectMapper();
 
-    private ObjectMapper yamlMapper;
+    private ObjectMapper yamlMapper = Yaml.mapper();
     private PrettyPrinter printer = new DefaultPrettyPrinter().withObjectIndenter(new DefaultIndenter("  ", DefaultIndenter.SYS_LF));
 
     @PostConstruct
@@ -31,12 +32,7 @@ public class DefaultAsyncApiSerializerService implements AsyncApiSerializerServi
         );
         jsonMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-        final YAMLFactory factory = new YAMLFactory()
-                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
-                .enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR)
-                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
-        yamlMapper = new ObjectMapper(factory);
-        yamlMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        ((YAMLFactory)yamlMapper.getFactory()).enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR);
     }
 
     @Override

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/controller/AsyncApiController.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/controller/AsyncApiController.java
@@ -8,22 +8,25 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("${springwolf.paths.docs:/springwolf/docs}")
 @RequiredArgsConstructor
 public class AsyncApiController {
 
     private final AsyncApiService asyncApiService;
     private final AsyncApiSerializerService serializer;
 
-    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public String asyncApi() throws JsonProcessingException {
+    @GetMapping(path ="${springwolf.paths.docs:/springwolf/docs}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public String asyncApiJson() throws JsonProcessingException {
         AsyncAPI asyncAPI = asyncApiService.getAsyncAPI();
         return serializer.toJsonString(asyncAPI);
     }
 
+    @GetMapping(path ="${springwolf.paths.docs:/springwolf/docs}.yaml", produces = "application/yaml")
+    public String asyncApiYaml() throws JsonProcessingException {
+        AsyncAPI asyncAPI = asyncApiService.getAsyncAPI();
+        return serializer.toYaml(asyncAPI);
+    }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerServiceTest.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.models.media.StringSchema;
 import lombok.Data;
 import org.apache.commons.io.IOUtils;
 import org.json.JSONException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -37,13 +38,12 @@ import java.util.Map;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {DefaultAsyncApiSerializerService.class})
-public class DefaultAsyncApiSerializerServiceTest {
+class DefaultAsyncApiSerializerServiceTest {
 
     @Autowired
     private DefaultAsyncApiSerializerService serializer;
 
-    @Test
-    public void AsyncAPI_should_map_to_a_valid_asyncapi_json() throws IOException, JSONException {
+    private AsyncAPI getAsyncAPITestObject() {
         Info info = Info.builder()
                 .title("AsyncAPI Sample App")
                 .version("1.0.1")
@@ -101,11 +101,25 @@ public class DefaultAsyncApiSerializerServiceTest {
                 .components(Components.builder().schemas(schemas).build())
                 .build();
 
+        return asyncapi;
+    }
+
+    @Test
+    void AsyncAPI_should_map_to_a_valid_asyncapi_json() throws IOException, JSONException {
+        var asyncapi = getAsyncAPITestObject();
         String actual = serializer.toJsonString(asyncapi);
-        System.out.println("Got: " + actual);
         InputStream s = this.getClass().getResourceAsStream("/asyncapi/asyncapi.json");
         String expected = IOUtils.toString(s, StandardCharsets.UTF_8);
         JSONAssert.assertEquals(expected, actual, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    void AsyncAPI_should_map_to_a_valid_asyncapi_yaml() throws IOException, JSONException {
+        var asyncapi = getAsyncAPITestObject();
+        String actual = serializer.toYaml(asyncapi);
+        InputStream s = this.getClass().getResourceAsStream("/asyncapi/asyncapi.yaml");
+        String expected = IOUtils.toString(s, StandardCharsets.UTF_8);
+        Assertions.assertEquals(expected, actual);
     }
 
     @Data

--- a/springwolf-core/src/test/resources/asyncapi/asyncapi.yaml
+++ b/springwolf-core/src/test/resources/asyncapi/asyncapi.yaml
@@ -1,0 +1,59 @@
+asyncapi: 2.0.0
+info:
+  title: AsyncAPI Sample App
+  version: 1.0.1
+  description: This is a sample server.
+  termsOfService: http://asyncapi.org/terms/
+  contact:
+    name: API Support
+    url: http://www.asyncapi.org/support
+    email: support@asyncapi.org
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+defaultContentType: application/json
+servers:
+  production:
+    url: development.gigantic-server.com
+    protocol: kafka
+    protocolVersion: 1.0.0
+    description: Development server
+channels:
+  new-user:
+    description: This channel is used to exchange messages about users signing up
+    subscribe:
+      operationId: new-user_listenerMethod_subscribe
+      description: Auto-generated description
+      bindings:
+        kafka:
+          groupId:
+            type: string
+            enum:
+              - myGroupId
+          bindingVersion: 0.4.0
+      message:
+        schemaFormat: application/vnd.oai.openapi+json;version=3.0.0
+        name: io.github.stavshamir.springwolf.ExamplePayload
+        title: Example Payload
+        payload:
+          $ref: '#/components/schemas/ExamplePayload'
+        bindings:
+          kafka:
+            key:
+              type: string
+              exampleSetFlag: false
+              types:
+                - string
+            bindingVersion: binding-version-1
+components:
+  schemas:
+    ExamplePayload:
+      type: object
+      properties:
+        s:
+          type: string
+          exampleSetFlag: false
+          types:
+            - string
+      exampleSetFlag: false
+tags: []

--- a/springwolf-core/src/test/resources/asyncapi/asyncapi.yaml
+++ b/springwolf-core/src/test/resources/asyncapi/asyncapi.yaml
@@ -41,9 +41,6 @@ channels:
           kafka:
             key:
               type: string
-              exampleSetFlag: false
-              types:
-                - string
             bindingVersion: binding-version-1
 components:
   schemas:
@@ -52,8 +49,4 @@ components:
       properties:
         s:
           type: string
-          exampleSetFlag: false
-          types:
-            - string
-      exampleSetFlag: false
 tags: []


### PR DESCRIPTION
Added support to create the `asyncapi` specification file in YAML.

Requesting the file to `/springwolf/docs.yaml` will provide it in YAML format. Otherwise, using the path defined by `springwolf.paths.docs` variable, concatenating `.yaml` at the end will produce the same effect