### PR TITLE
fix: Fixed JSON serializer to not leak unintended values

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerService.java
@@ -1,15 +1,14 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.PrettyPrinter;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
+import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.Yaml;
 import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
@@ -18,20 +17,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class DefaultAsyncApiSerializerService implements AsyncApiSerializerService {
 
-    private ObjectMapper jsonMapper = new ObjectMapper();
-
+    private ObjectMapper jsonMapper = Json.mapper();
     private ObjectMapper yamlMapper = Yaml.mapper();
     private PrettyPrinter printer = new DefaultPrettyPrinter().withObjectIndenter(new DefaultIndenter("  ", DefaultIndenter.SYS_LF));
 
     @PostConstruct
     void postConstruct() {
-        jsonMapper.setConfig(
-                jsonMapper.getSerializationConfig()
-                        .with(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
-                        .without(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-        );
-        jsonMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-
         ((YAMLFactory)yamlMapper.getFactory()).enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR);
     }
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasService.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.schemas;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -18,7 +17,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -31,7 +35,7 @@ public class DefaultSchemasService implements SchemasService {
 
     public DefaultSchemasService(Optional<List<ModelConverter>> externalModelConverters) {
         externalModelConverters.ifPresent(converters -> converters.forEach(converter::addConverter));
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
         SimpleModule simpleModule = new SimpleModule().addSerializer(new JsonNodeExampleSerializer());
         objectMapper.registerModule(simpleModule);
     }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasService.java
@@ -10,6 +10,7 @@ import io.swagger.oas.inflector.examples.models.Example;
 import io.swagger.oas.inflector.processors.JsonNodeExampleSerializer;
 import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.media.MapSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
@@ -24,7 +25,7 @@ import java.util.*;
 public class DefaultSchemasService implements SchemasService {
 
     private final ModelConverters converter = ModelConverters.getInstance();
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = Json.mapper();
 
     private final Map<String, Schema> definitions = new HashMap<>();
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/dtos/MessageDtoDeserializationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/dtos/MessageDtoDeserializationTest.java
@@ -1,6 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.controller.dtos;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.util.Json;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -9,12 +10,13 @@ import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MessageDtoDeserializationTest {
+    private static final ObjectMapper objectMapper = Json.mapper();
 
     @Test
     public void testCanBeSerialized() throws IOException {
         String content = "{\"headers\": { \"some-header-key\" : \"some-header-value\" }, \"payload\": { \"some-payload-key\" : \"some-payload-value\" }}";
 
-        MessageDto value = new ObjectMapper().readValue(content, MessageDto.class);
+        MessageDto value = objectMapper.readValue(content, MessageDto.class);
 
         assertThat(value).isNotNull();
         assertThat(value.getHeaders()).isEqualTo(singletonMap("some-header-key", "some-header-value"));

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasServiceTest.java
@@ -2,6 +2,7 @@ package io.github.stavshamir.springwolf.schemas;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -24,7 +25,7 @@ public class DefaultSchemasServiceTest {
     private final SchemasService schemasService = new DefaultSchemasService(Optional.empty());
 
     private static final String EXAMPLES_PATH = "/schemas/examples";
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = Json.mapper();
 
     static {
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/DefaultSchemasServiceTest.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.schemas;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.media.Schema;
@@ -26,10 +25,6 @@ public class DefaultSchemasServiceTest {
 
     private static final String EXAMPLES_PATH = "/schemas/examples";
     private static final ObjectMapper objectMapper = Json.mapper();
-
-    static {
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    }
 
     @Test
     public void string() throws IOException, JSONException {

--- a/springwolf-core/src/test/resources/asyncapi/asyncapi.json
+++ b/springwolf-core/src/test/resources/asyncapi/asyncapi.json
@@ -49,9 +49,7 @@
           "bindings" : {
             "kafka" : {
               "key" : {
-                "type" : "string",
-                "exampleSetFlag" : false,
-                "types" : [ "string" ]
+                "type" : "string"
               },
               "bindingVersion" : "binding-version-1"
             }
@@ -66,12 +64,9 @@
         "type" : "object",
         "properties" : {
           "s" : {
-            "type" : "string",
-            "exampleSetFlag" : false,
-            "types" : [ "string" ]
+            "type" : "string"
           }
-        },
-        "exampleSetFlag" : false
+        }
       }
     }
   },

--- a/springwolf-core/src/test/resources/schemas/definitions.json
+++ b/springwolf-core/src/test/resources/schemas/definitions.json
@@ -3,15 +3,10 @@
     "type": "object",
     "properties": {
       "s": {
-        "type": "string",
-        "exampleSetFlag": false,
-        "types": [
-          "string"
-        ]
+        "type": "string"
       },
       "f": {
-        "$ref": "#/components/schemas/SimpleFoo",
-        "exampleSetFlag": false
+        "$ref": "#/components/schemas/SimpleFoo"
       }
     },
     "example": {
@@ -20,25 +15,16 @@
         "s": "string",
         "b": true
       }
-    },
-    "exampleSetFlag": true
+    }
   },
   "FooWithEnum": {
     "type": "object",
     "properties": {
       "s": {
-        "type": "string",
-        "exampleSetFlag": false,
-        "types": [
-          "string"
-        ]
+        "type": "string"
       },
       "b": {
         "type": "string",
-        "exampleSetFlag": false,
-        "types": [
-          "string"
-        ],
         "enum": [
           "BAR1",
           "BAR2"
@@ -48,31 +34,21 @@
     "example": {
       "s": "string",
       "b": "BAR1"
-    },
-    "exampleSetFlag": true
+    }
   },
   "SimpleFoo": {
     "type": "object",
     "properties": {
       "s": {
-        "type": "string",
-        "exampleSetFlag": false,
-        "types": [
-          "string"
-        ]
+        "type": "string"
       },
       "b": {
-        "type": "boolean",
-        "exampleSetFlag": false,
-        "types": [
-          "boolean"
-        ]
+        "type": "boolean"
       }
     },
     "example": {
       "s": "string",
       "b": true
-    },
-    "exampleSetFlag": true
+    }
   }
 }

--- a/springwolf-core/src/test/resources/schemas/documented-definitions.json
+++ b/springwolf-core/src/test/resources/schemas/documented-definitions.json
@@ -6,17 +6,12 @@
       "s": {
         "description": "s field",
         "type": "string",
-        "example": "s value",
-        "exampleSetFlag": true,
-        "types": [
-          "string"
-        ]
+        "example": "s value"
       }
     },
     "example": {
       "s": "s value"
     },
-    "exampleSetFlag": true,
     "required": [
       "s"
     ]

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -293,15 +293,12 @@
         "type" : "object",
         "properties" : {
           "example" : {
-            "$ref" : "#/components/schemas/ExamplePayloadDto",
-            "exampleSetFlag" : false
+            "$ref" : "#/components/schemas/ExamplePayloadDto"
           },
           "foo" : {
             "type" : "string",
             "description" : "Foo field",
-            "example" : "bar",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ]
+            "example" : "bar"
           }
         },
         "description" : "Another payload model",
@@ -312,8 +309,7 @@
             "someString" : "some string value"
           },
           "foo" : "bar"
-        },
-        "exampleSetFlag" : true
+        }
       },
       "ExamplePayloadDto" : {
         "required" : [ "someEnum", "someString" ],
@@ -323,24 +319,18 @@
             "type" : "string",
             "description" : "Some enum field",
             "example" : "FOO2",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "FOO1", "FOO2", "FOO3" ]
           },
           "someLong" : {
             "type" : "integer",
             "description" : "Some long field",
             "format" : "int64",
-            "example" : 5,
-            "exampleSetFlag" : true,
-            "types" : [ "integer" ]
+            "example" : 5
           },
           "someString" : {
             "type" : "string",
             "description" : "Some string field",
-            "example" : "some string value",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ]
+            "example" : "some string value"
           }
         },
         "description" : "Example payload model",
@@ -348,15 +338,12 @@
           "someEnum" : "FOO2",
           "someLong" : 5,
           "someString" : "some string value"
-        },
-        "exampleSetFlag" : true
+        }
       },
       "HeadersNotDocumented" : {
         "type" : "object",
         "properties" : { },
-        "example" : { },
-        "exampleSetFlag" : true,
-        "types" : [ "object" ]
+        "example" : { }
       }
     }
   },

--- a/springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json
@@ -96,51 +96,30 @@
         "type": "object",
         "properties": {
           "payloadString": {
-            "type": "string",
-            "exampleSetFlag": false,
-            "types": [
-              "string"
-            ]
+            "type": "string"
           }
         },
         "example": {
           "payloadString": "string"
-        },
-        "exampleSetFlag": true
+        }
       },
       "HeadersNotDocumented": {
         "type": "object",
         "properties": {},
-        "example": {},
-        "exampleSetFlag": true,
-        "types": [
-          "object"
-        ]
+        "example": {}
       },
       "InputPayload": {
         "type": "object",
         "properties": {
           "foo": {
             "type": "array",
-            "exampleSetFlag": false,
             "items": {
-              "type": "string",
-              "exampleSetFlag": false,
-              "types": [
-                "string"
-              ]
-            },
-            "types": [
-              "array"
-            ]
+              "type": "string"
+            }
           },
           "bar": {
             "type": "integer",
-            "format": "int32",
-            "exampleSetFlag": false,
-            "types": [
-              "integer"
-            ]
+            "format": "int32"
           }
         },
         "description": "Input payload model",
@@ -149,8 +128,7 @@
             "string"
           ],
           "bar": 0
-        },
-        "exampleSetFlag": true
+        }
       },
       "OutputPayload": {
         "required": [
@@ -161,29 +139,20 @@
           "someString": {
             "type": "string",
             "description": "Some string field",
-            "example": "some string value",
-            "exampleSetFlag": true,
-            "types": [
-              "string"
-            ]
+            "example": "some string value"
           },
           "someLong": {
             "type": "integer",
             "description": "Some long field",
             "format": "int64",
-            "example": 5,
-            "exampleSetFlag": true,
-            "types": [
-              "integer"
-            ]
+            "example": 5
           }
         },
         "description": "Output payload model",
         "example": {
           "someString": "some string value",
           "someLong": 5
-        },
-        "exampleSetFlag": true
+        }
       }
     }
   },

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -218,9 +218,7 @@
                 "key" : {
                   "type" : "string",
                   "description" : "Kafka Consumer Message Key",
-                  "example" : "example-key",
-                  "exampleSetFlag" : true,
-                  "types" : [ "string" ]
+                  "example" : "example-key"
                 },
                 "bindingVersion" : "1"
               }
@@ -258,9 +256,7 @@
               "key" : {
                 "type" : "string",
                 "description" : "Kafka Producer Message Key",
-                "example" : "example-key",
-                "exampleSetFlag" : true,
-                "types" : [ "string" ]
+                "example" : "example-key"
               },
               "bindingVersion" : "1"
             }
@@ -276,15 +272,12 @@
         "type" : "object",
         "properties" : {
           "example" : {
-            "$ref" : "#/components/schemas/ExamplePayloadDto",
-            "exampleSetFlag" : false
+            "$ref" : "#/components/schemas/ExamplePayloadDto"
           },
           "foo" : {
             "type" : "string",
             "description" : "Foo field",
-            "example" : "bar",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ]
+            "example" : "bar"
           }
         },
         "description" : "Another payload model",
@@ -295,8 +288,7 @@
             "someString" : "some string value"
           },
           "foo" : "bar"
-        },
-        "exampleSetFlag" : true
+        }
       },
       "CloudEventHeadersForAnotherPayloadDtoEndpoint" : {
         "type" : "object",
@@ -305,56 +297,42 @@
             "type" : "string",
             "description" : "CloudEvent Id Header",
             "example" : "1234-1234-1234",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "1234-1234-1234" ]
           },
           "ce_source" : {
             "type" : "string",
             "description" : "CloudEvent Source Header",
             "example" : "springwolf-kafka-example/anotherPayloadDtoEndpoint",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "springwolf-kafka-example/anotherPayloadDtoEndpoint" ]
           },
           "ce_specversion" : {
             "type" : "string",
             "description" : "CloudEvent Spec Version Header",
             "example" : "1.0",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "1.0" ]
           },
           "ce_subject" : {
             "type" : "string",
             "description" : "CloudEvent Subject Header",
             "example" : "Test Subject",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "Test Subject" ]
           },
           "ce_time" : {
             "type" : "string",
             "description" : "CloudEvent Time Header",
             "example" : "2015-07-20T15:49:04-07:00",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "2015-07-20T15:49:04-07:00" ]
           },
           "ce_type" : {
             "type" : "string",
             "description" : "CloudEvent Payload Type Header",
             "example" : "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint" ]
           },
           "content-type" : {
             "type" : "string",
             "description" : "CloudEvent Content-Type Header",
             "example" : "application/json",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "application/json" ]
           }
         },
@@ -366,9 +344,7 @@
           "ce_time" : "2015-07-20T15:49:04-07:00",
           "ce_type" : "io.github.stavshamir.springwolf.CloudEventHeadersForAnotherPayloadDtoEndpoint",
           "content-type" : "application/json"
-        },
-        "exampleSetFlag" : true,
-        "types" : [ "object" ]
+        }
       },
       "ExamplePayloadDto" : {
         "required" : [ "someEnum", "someString" ],
@@ -378,24 +354,18 @@
             "type" : "string",
             "description" : "Some enum field",
             "example" : "FOO2",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "FOO1", "FOO2", "FOO3" ]
           },
           "someLong" : {
             "type" : "integer",
             "description" : "Some long field",
             "format" : "int64",
-            "example" : 5,
-            "exampleSetFlag" : true,
-            "types" : [ "integer" ]
+            "example" : 5
           },
           "someString" : {
             "type" : "string",
             "description" : "Some string field",
-            "example" : "some string value",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ]
+            "example" : "some string value"
           }
         },
         "description" : "Example payload model",
@@ -403,62 +373,47 @@
           "someEnum" : "FOO2",
           "someLong" : 5,
           "someString" : "some string value"
-        },
-        "exampleSetFlag" : true
+        }
       },
       "HeadersNotDocumented" : {
         "type" : "object",
         "properties" : { },
-        "example" : { },
-        "exampleSetFlag" : true,
-        "types" : [ "object" ]
+        "example" : { }
       },
       "MonetaryAmount" : {
         "type" : "object",
         "properties" : {
           "amount" : {
             "type" : "number",
-            "example" : 99.99,
-            "exampleSetFlag" : true,
-            "types" : [ "number" ]
+            "example" : 99.99
           },
           "currency" : {
             "type" : "string",
-            "example" : "USD",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ]
+            "example" : "USD"
           }
         },
         "example" : {
           "amount" : 99.99,
           "currency" : "USD"
-        },
-        "exampleSetFlag" : true
+        }
       },
       "NestedPayloadDto" : {
         "type" : "object",
         "properties" : {
           "examplePayloads" : {
             "type" : "array",
-            "exampleSetFlag" : false,
             "items" : {
-              "$ref" : "#/components/schemas/ExamplePayloadDto",
-              "exampleSetFlag" : false
-            },
-            "types" : [ "array" ]
+              "$ref" : "#/components/schemas/ExamplePayloadDto"
+            }
           },
           "someStrings" : {
             "uniqueItems" : true,
             "type" : "array",
-            "exampleSetFlag" : false,
             "items" : {
               "type" : "string",
               "description" : "Some string field",
-              "example" : "some string value",
-              "exampleSetFlag" : true,
-              "types" : [ "string" ]
-            },
-            "types" : [ "array" ]
+              "example" : "some string value"
+            }
           }
         },
         "description" : "Payload model with nested complex types",
@@ -469,8 +424,7 @@
             "someString" : "some string value"
           } ],
           "someStrings" : [ "some string value" ]
-        },
-        "exampleSetFlag" : true
+        }
       },
       "SpringKafkaDefaultHeaders" : {
         "type" : "object",
@@ -479,16 +433,12 @@
             "type" : "string",
             "description" : "Spring Type Id Header",
             "example" : "io.github.stavshamir.springwolf.example.dtos.NestedPayloadDto",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "io.github.stavshamir.springwolf.example.dtos.NestedPayloadDto" ]
           }
         },
         "example" : {
           "__TypeId__" : "io.github.stavshamir.springwolf.example.dtos.NestedPayloadDto"
-        },
-        "exampleSetFlag" : true,
-        "types" : [ "object" ]
+        }
       },
       "SpringKafkaDefaultHeaders-AnotherPayloadDto" : {
         "type" : "object",
@@ -497,16 +447,12 @@
             "type" : "string",
             "description" : "Spring Type Id Header",
             "example" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto" ]
           }
         },
         "example" : {
           "__TypeId__" : "io.github.stavshamir.springwolf.example.dtos.AnotherPayloadDto"
-        },
-        "exampleSetFlag" : true,
-        "types" : [ "object" ]
+        }
       },
       "SpringKafkaDefaultHeaders-ExamplePayloadDto" : {
         "type" : "object",
@@ -515,16 +461,12 @@
             "type" : "string",
             "description" : "Spring Type Id Header",
             "example" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto" ]
           }
         },
         "example" : {
           "__TypeId__" : "io.github.stavshamir.springwolf.example.dtos.ExamplePayloadDto"
-        },
-        "exampleSetFlag" : true,
-        "types" : [ "object" ]
+        }
       },
       "SpringKafkaDefaultHeaders-MonetaryAmount" : {
         "type" : "object",
@@ -533,16 +475,12 @@
             "type" : "string",
             "description" : "Spring Type Id Header",
             "example" : "javax.money.MonetaryAmount",
-            "exampleSetFlag" : true,
-            "types" : [ "string" ],
             "enum" : [ "javax.money.MonetaryAmount" ]
           }
         },
         "example" : {
           "__TypeId__" : "javax.money.MonetaryAmount"
-        },
-        "exampleSetFlag" : true,
-        "types" : [ "object" ]
+        }
       }
     }
   },


### PR DESCRIPTION
Fixes https://github.com/springwolf/springwolf-core/issues/169

The `exampleSetFlag` and `types` properties belong to `swagger-core` internals and are not part of the AsyncAPI specification.

See https://github.com/swagger-api/swagger-core/pull/3637#issuecomment-682370287 for some details.

This PR replaces the custom JSON ObjectMapper by the `swagger-core` one, which already contains all the needed `mixins` to properly serialize the specification.

Fixes #169 for Json Serialization