### PR TITLE
Fix: Fixed autogenerated description

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
@@ -59,9 +59,14 @@ public abstract class AbstractOperationDataScanner implements ChannelsScanner {
         Map<String, ? extends ChannelBinding> channelBinding = operationDataList.get(0).getChannelBinding();
         Map<String, ? extends OperationBinding> operationBinding = operationDataList.get(0).getOperationBinding();
         String operationId = operationDataList.get(0).getChannelName() + "_" + this.getOperationType().operationName;
+        String description = operationDataList.get(0).getDescription();
+
+        if (description.isEmpty()) {
+            description = "Auto-generated description";
+        }
 
         Operation operation = Operation.builder()
-                .description("Auto-generated description")
+                .description(description)
                 .operationId(operationId)
                 .message(getMessageObject(operationDataList))
                 .bindings(operationBinding)
@@ -96,6 +101,7 @@ public abstract class AbstractOperationDataScanner implements ChannelsScanner {
         return Message.builder()
                 .name(payloadType.getName())
                 .title(modelName)
+                // FIXME? Using operation description in the message?
                 .description(operationData.getDescription())
                 .payload(PayloadReference.fromModelName(modelName))
                 .headers(HeaderReference.fromModelName(headerModelName))

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
@@ -101,8 +101,7 @@ public abstract class AbstractOperationDataScanner implements ChannelsScanner {
         return Message.builder()
                 .name(payloadType.getName())
                 .title(modelName)
-                // FIXME? Using operation description in the message?
-                .description(operationData.getDescription())
+                // FIXME: Add support for Message Description
                 .payload(PayloadReference.fromModelName(modelName))
                 .headers(HeaderReference.fromModelName(headerModelName))
                 .bindings(operationData.getMessageBinding())

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
@@ -109,7 +109,8 @@ class DefaultAsyncApiServiceTest {
         final ChannelItem channel = actualChannels.get("producer-topic");
         assertThat(channel.getSubscribe()).isNotNull();
         final Message message = (Message) channel.getSubscribe().getMessage();
-        assertThat(message.getDescription()).isEqualTo("producer-topic-description");
+        // Message description is not supported yet
+        assertThat(message.getDescription()).isNull();
         assertThat(message.getBindings()).isEqualTo(ImmutableMap.of("kafka", new KafkaMessageBinding()));
     }
 
@@ -124,7 +125,8 @@ class DefaultAsyncApiServiceTest {
         final ChannelItem channel = actualChannels.get("consumer-topic");
         assertThat(channel.getPublish()).isNotNull();
         final Message message = (Message) channel.getPublish().getMessage();
-        assertThat(message.getDescription()).isEqualTo("consumer-topic-description");
+        // Message description is not supported yet
+        assertThat(message.getDescription()).isNull();
         assertThat(message.getBindings()).isEqualTo(ImmutableMap.of("kafka", new KafkaMessageBinding()));
     }
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerTest.java
@@ -71,7 +71,8 @@ class ConsumerOperationDataScannerTest {
                 .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .message(Message.builder()
                         .name(ExamplePayloadDto.class.getName())
-                        .description(description)
+                        // Message description is not supported yet
+//                        .description(description)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
@@ -144,7 +145,8 @@ class ConsumerOperationDataScannerTest {
         Set<Message> messages = ImmutableSet.of(
                 Message.builder()
                         .name(ExamplePayloadDto.class.getName())
-                        .description(description1)
+                        // Message description is not supported yet
+//                        .description(description1)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
@@ -152,7 +154,8 @@ class ConsumerOperationDataScannerTest {
                         .build(),
                 Message.builder()
                         .name(AnotherExamplePayloadDto.class.getName())
-                        .description(description2)
+                        // Message description is not supported yet
+//                        .description(description2)
                         .title(AnotherExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(AnotherExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_USED.getSchemaName()))

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerTest.java
@@ -66,7 +66,7 @@ class ConsumerOperationDataScannerTest {
                 .containsKey(channelName);
 
         Operation operation = Operation.builder()
-                .description("Auto-generated description")
+                .description(description)
                 .operationId("example-consumer-topic-foo1_publish")
                 .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .message(Message.builder()
@@ -161,7 +161,7 @@ class ConsumerOperationDataScannerTest {
         );
 
         Operation operation = Operation.builder()
-                .description("Auto-generated description")
+                .description(description1)
                 .operationId("example-consumer-topic_publish")
                 .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .message(toMessageObjectOrComposition(messages))

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerTest.java
@@ -66,7 +66,7 @@ class ProducerOperationDataScannerTest {
                 .containsKey(channelName);
 
         Operation operation = Operation.builder()
-                .description("Auto-generated description")
+                .description(description)
                 .operationId("example-producer-topic-foo1_subscribe")
                 .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .message(Message.builder()
@@ -161,7 +161,7 @@ class ProducerOperationDataScannerTest {
         );
 
         Operation operation = Operation.builder()
-                .description("Auto-generated description")
+                .description(description1)
                 .operationId("example-producer-topic_subscribe")
                 .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .message(toMessageObjectOrComposition(messages))

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerTest.java
@@ -71,7 +71,8 @@ class ProducerOperationDataScannerTest {
                 .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .message(Message.builder()
                         .name(ExamplePayloadDto.class.getName())
-                        .description(description)
+                        // Message description is not supported yet
+//                        .description(description)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
@@ -144,7 +145,8 @@ class ProducerOperationDataScannerTest {
         Set<Message> messages = ImmutableSet.of(
                 Message.builder()
                         .name(ExamplePayloadDto.class.getName())
-                        .description(description1)
+                        // Message description is not supported yet
+//                        .description(description1)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
@@ -152,7 +154,8 @@ class ProducerOperationDataScannerTest {
                         .build(),
                 Message.builder()
                         .name(AnotherExamplePayloadDto.class.getName())
-                        .description(description2)
+                        // Message description is not supported yet
+//                        .description(description2)
                         .title(AnotherExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(AnotherExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_USED.getSchemaName()))

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
@@ -66,8 +66,8 @@ class AsyncListenerAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                // FIXME
-                .description("test channel operation description")
+                // Message description is not supported yet
+//                .description("test channel operation description")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
                 .bindings(EMPTY_MAP)
@@ -101,7 +101,8 @@ class AsyncListenerAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                .description("description")
+                // Message description is not supported yet
+//                .description("description")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("TestSchema"))
                 .bindings(EMPTY_MAP)
@@ -143,7 +144,8 @@ class AsyncListenerAnnotationScannerTest {
                 .description("test-channel-1-description")
                 .operationId("test-channel-1_publish")
                 .bindings(EMPTY_MAP)
-                .message(builder.description("test-channel-1-description").build())
+                // Message description is not supported yet
+                .message(builder/*.description("test-channel-1-description")*/.build())
                 .build();
 
         ChannelItem expectedChannel1 = ChannelItem.builder()
@@ -155,7 +157,8 @@ class AsyncListenerAnnotationScannerTest {
                 .description("test-channel-2-description")
                 .operationId("test-channel-2_publish")
                 .bindings(EMPTY_MAP)
-                .message(builder.description("test-channel-2-description").build())
+                // Message description is not supported yet
+                .message(builder/*.description("test-channel-2-description")*/.build())
                 .build();
 
         ChannelItem expectedChannel2 = ChannelItem.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
@@ -66,14 +66,15 @@ class AsyncListenerAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                .description("")
+                // FIXME
+                .description("test channel operation description")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
                 .bindings(EMPTY_MAP)
                 .build();
 
         Operation operation = Operation.builder()
-                .description("Auto-generated description")
+                .description("test channel operation description")
                 .operationId("test-channel_publish")
                 .bindings(EMPTY_MAP)
                 .message(message)
@@ -107,7 +108,7 @@ class AsyncListenerAnnotationScannerTest {
                 .build();
 
         Operation operation = Operation.builder()
-                .description("Auto-generated description")
+                .description("description")
                 .operationId("test-channel_publish")
                 .bindings(ImmutableMap.of(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING))
                 .message(message)
@@ -131,20 +132,18 @@ class AsyncListenerAnnotationScannerTest {
         Map<String, ChannelItem> actualChannels = channelScanner.scan();
 
         // Then the returned collection contains the channel
-        Message message = Message.builder()
+        Message.MessageBuilder builder = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                .description("")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(EMPTY_MAP)
-                .build();
+                .bindings(EMPTY_MAP);
 
         Operation operation1 = Operation.builder()
-                .description("Auto-generated description")
+                .description("test-channel-1-description")
                 .operationId("test-channel-1_publish")
                 .bindings(EMPTY_MAP)
-                .message(message)
+                .message(builder.description("test-channel-1-description").build())
                 .build();
 
         ChannelItem expectedChannel1 = ChannelItem.builder()
@@ -153,10 +152,10 @@ class AsyncListenerAnnotationScannerTest {
                 .build();
 
         Operation operation2 = Operation.builder()
-                .description("Auto-generated description")
+                .description("test-channel-2-description")
                 .operationId("test-channel-2_publish")
                 .bindings(EMPTY_MAP)
-                .message(message)
+                .message(builder.description("test-channel-2-description").build())
                 .build();
 
         ChannelItem expectedChannel2 = ChannelItem.builder()
@@ -181,7 +180,8 @@ class AsyncListenerAnnotationScannerTest {
     private static class ClassWithListenerAnnotation {
 
         @AsyncListener(operation = @AsyncOperation(
-                channelName = "test-channel"
+                channelName = "test-channel",
+                description = "test channel operation description"
         ))
         private void methodWithAnnotation(SimpleFoo payload) {
         }
@@ -212,10 +212,12 @@ class AsyncListenerAnnotationScannerTest {
     private static class ClassWithMultipleListenerAnnotations {
 
         @AsyncListener(operation = @AsyncOperation(
-                channelName = "test-channel-1"
+                channelName = "test-channel-1",
+                description = "test-channel-1-description"
         ))
         @AsyncListener(operation = @AsyncOperation(
-                channelName = "test-channel-2"
+                channelName = "test-channel-2",
+                description = "test-channel-2-description"
         ))
         private void methodWithMultipleAnnotation(SimpleFoo payload) {
         }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
@@ -66,7 +66,8 @@ class AsyncPublisherAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                .description("")
+                // Message description is not supported yet
+//                .description("")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
                 .bindings(EMPTY_MAP)
@@ -100,7 +101,8 @@ class AsyncPublisherAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                .description("description")
+                // Message description is not supported yet
+//                .description("description")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("TestSchema"))
                 .bindings(EMPTY_MAP)
@@ -134,7 +136,8 @@ class AsyncPublisherAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                .description("")
+                // Message description is not supported yet
+//                .description("")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
                 .bindings(EMPTY_MAP)

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
@@ -107,7 +107,7 @@ class AsyncPublisherAnnotationScannerTest {
                 .build();
 
         Operation operation = Operation.builder()
-                .description("Auto-generated description")
+                .description("description")
                 .operationId("test-channel_subscribe")
                 .bindings(ImmutableMap.of(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING))
                 .message(message)

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -100,7 +100,7 @@
     "example-manual-consumer-channel" : {
       "publish" : {
         "operationId" : "example-manual-consumer-channel_publish",
-        "description" : "Auto-generated description",
+        "description" : "example-manual-consumer-channel-description",
         "bindings" : {
           "amqp" : {
             "cc" : [ "example-consumer-topic-routing-key" ],
@@ -139,7 +139,7 @@
     "example-producer-channel" : {
       "subscribe" : {
         "operationId" : "example-producer-channel_subscribe",
-        "description" : "Auto-generated description",
+        "description" : "example-producer-channel-description",
         "bindings" : {
           "amqp" : {
             "cc" : [ "example-topic-routing-key" ],
@@ -178,7 +178,7 @@
     "example-producer-channel-publisher" : {
       "subscribe" : {
         "operationId" : "example-producer-channel-publisher_subscribe",
-        "description" : "Auto-generated description",
+        "description" : "Custom, optional description defined in the AsyncPublisher annotation",
         "bindings" : {
           "amqp" : {
             "expiration" : 0,

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -111,7 +111,6 @@
           "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
           "name" : "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
           "title" : "AnotherPayloadDto",
-          "description" : "example-manual-consumer-channel-description",
           "payload" : {
             "$ref" : "#/components/schemas/AnotherPayloadDto"
           },
@@ -150,7 +149,6 @@
           "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
           "name" : "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
           "title" : "AnotherPayloadDto",
-          "description" : "example-producer-channel-description",
           "payload" : {
             "$ref" : "#/components/schemas/AnotherPayloadDto"
           },
@@ -195,7 +193,6 @@
           "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
           "name" : "io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto",
           "title" : "ExamplePayloadDto",
-          "description" : "Custom, optional description defined in the AsyncPublisher annotation",
           "payload" : {
             "$ref" : "#/components/schemas/ExamplePayloadDto"
           },

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -60,7 +60,7 @@
     "example-consumer-topic" : {
       "publish" : {
         "operationId" : "example-consumer-topic_publish",
-        "description" : "Auto-generated description",
+        "description" : "Custom, optional description for this consumed topic",
         "bindings" : {
           "kafka" : {
             "bindingVersion" : "0.4.0"
@@ -93,7 +93,7 @@
     "example-producer-topic" : {
       "subscribe" : {
         "operationId" : "example-producer-topic_subscribe",
-        "description" : "Auto-generated description",
+        "description" : "Custom, optional description for this produced to topic",
         "bindings" : {
           "kafka" : {
             "bindingVersion" : "0.4.0"
@@ -158,7 +158,7 @@
     "multi-payload-topic" : {
       "publish" : {
         "operationId" : "multi-payload-topic_publish",
-        "description" : "Auto-generated description",
+        "description" : "Override description in the AsyncListener annotation with servers at localhost:9092",
         "bindings" : {
           "kafka" : {
             "groupId" : {
@@ -231,7 +231,7 @@
     "topic-defined-via-asyncPublisher-annotation" : {
       "subscribe" : {
         "operationId" : "topic-defined-via-asyncPublisher-annotation_subscribe",
-        "description" : "Auto-generated description",
+        "description" : "Custom, optional description defined in the AsyncPublisher annotation",
         "bindings" : {
           "kafka" : {
             "clientId" : {

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -70,7 +70,6 @@
           "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
           "name" : "io.github.stavshamir.springwolf.example.kafka.dtos.ExamplePayloadDto",
           "title" : "ExamplePayloadDto",
-          "description" : "Custom, optional description for this consumed topic",
           "payload" : {
             "$ref" : "#/components/schemas/ExamplePayloadDto"
           },
@@ -103,7 +102,6 @@
           "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
           "name" : "io.github.stavshamir.springwolf.example.kafka.dtos.AnotherPayloadDto",
           "title" : "AnotherPayloadDto",
-          "description" : "Custom, optional description for this produced to topic",
           "payload" : {
             "$ref" : "#/components/schemas/AnotherPayloadDto"
           },
@@ -207,7 +205,6 @@
             "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
             "name" : "javax.money.MonetaryAmount",
             "title" : "MonetaryAmount",
-            "description" : "Override description in the AsyncListener annotation with servers at localhost:9092",
             "payload" : {
               "$ref" : "#/components/schemas/MonetaryAmount"
             },
@@ -245,7 +242,6 @@
           "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
           "name" : "io.github.stavshamir.springwolf.example.kafka.dtos.NestedPayloadDto",
           "title" : "NestedPayloadDto",
-          "description" : "Custom, optional description defined in the AsyncPublisher annotation",
           "payload" : {
             "$ref" : "#/components/schemas/NestedPayloadDto"
           },


### PR DESCRIPTION
When defining an `@AsyncOperation` description like in

```
@AsyncOperation(
    channelName = "channel-name",
    description = "My channel description")
```

The generated AsyncAPI schema was always showing `Auto-generated description`
now properly shows the defined `description` value.