### PR TITLE
Feat: Improved docket configuration

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigProperties.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigProperties.java
@@ -41,6 +41,14 @@ public class SpringWolfConfigProperties {
         @Nullable
         private String basePackage;
 
+        /**
+         * A string representing the default content type to use when encoding/decoding a message's payload.
+         *
+         * @see com.asyncapi.v2._0_0.model.AsyncAPI#defaultContentType
+         */
+        @Nullable
+        private String defaultContentType;
+
         @Nullable
         private Map<String, Server> servers;
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigProperties.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigProperties.java
@@ -42,6 +42,14 @@ public class SpringWolfConfigProperties {
         private String basePackage;
 
         /**
+         * Identifier of the application the AsyncAPI document is defining.
+         *
+         * @see com.asyncapi.v2._0_0.model.AsyncAPI#id
+         */
+        @Nullable
+        private String id;
+
+        /**
          * A string representing the default content type to use when encoding/decoding a message's payload.
          *
          * @see com.asyncapi.v2._0_0.model.AsyncAPI#defaultContentType

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.java
@@ -33,8 +33,8 @@ public class DefaultAsyncApiService implements AsyncApiService {
 
         asyncAPI = AsyncAPI.builder()
                 .info(docket.getInfo())
-                .id(docket.id)
-                .defaultContentType(docket.defaultContentType)
+                .id(docket.getId())
+                .defaultContentType(docket.getDefaultContentType())
                 .servers(docket.getServers())
                 .channels(channelsService.getChannels())
                 .components(components)

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.java
@@ -33,6 +33,7 @@ public class DefaultAsyncApiService implements AsyncApiService {
 
         asyncAPI = AsyncAPI.builder()
                 .info(docket.getInfo())
+                .defaultContentType(docket.defaultContentType)
                 .servers(docket.getServers())
                 .channels(channelsService.getChannels())
                 .components(components)

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.java
@@ -33,6 +33,7 @@ public class DefaultAsyncApiService implements AsyncApiService {
 
         asyncAPI = AsyncAPI.builder()
                 .info(docket.getInfo())
+                .id(docket.id)
                 .defaultContentType(docket.defaultContentType)
                 .servers(docket.getServers())
                 .channels(channelsService.getChannels())

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AsyncAPI.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AsyncAPI.java
@@ -4,7 +4,11 @@ import com.asyncapi.v2._0_0.model.Tag;
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.info.Info;
 import com.asyncapi.v2._0_0.model.server.Server;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 import javax.validation.constraints.NotNull;
 import java.util.Collections;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AsyncAPI.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AsyncAPI.java
@@ -36,6 +36,17 @@ public class AsyncAPI {
     private String asyncapi = "2.0.0";
 
     /**
+     * Identifier of the application the AsyncAPI document is defining.
+     * <p>
+     * This field represents a unique universal identifier of the application the AsyncAPI document is defining.
+     * It must conform to the URI format, according to RFC3986.
+     * <p>
+     * It is RECOMMENDED to use a URN to globally and uniquely identify the application during long periods of time,
+     * even after it becomes unavailable or ceases to exist.
+     */
+    private String id;
+
+    /**
      * <b>Required.</b>
      * Provides metadata about the API. The metadata can be used by the clients if needed.
      */

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/AsyncApiDocket.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/AsyncApiDocket.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.Singular;
+import org.springframework.http.MediaType;
 
 import java.util.List;
 import java.util.Map;
@@ -56,12 +57,13 @@ public class AsyncApiDocket {
      *
      * @see <a href="https://www.asyncapi.com/docs/reference/specification/v2.0.0#defaultContentTypeString">Default Content Type</a>
      */
-    public final String defaultContentType;
+    @Builder.Default
+    private final String defaultContentType = MediaType.APPLICATION_JSON_VALUE;
 
     /**
      * A string representing the default content type to use when encoding/decoding a message's payload.
      *
      * @see <a href="https://www.asyncapi.com/docs/reference/specification/v2.0.0#A2SIdString">Identifier</a>
      */
-    public final String id;
+    private final String id;
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/AsyncApiDocket.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/AsyncApiDocket.java
@@ -57,4 +57,11 @@ public class AsyncApiDocket {
      * @see <a href="https://www.asyncapi.com/docs/reference/specification/v2.0.0#defaultContentTypeString">Default Content Type</a>
      */
     public final String defaultContentType;
+
+    /**
+     * A string representing the default content type to use when encoding/decoding a message's payload.
+     *
+     * @see <a href="https://www.asyncapi.com/docs/reference/specification/v2.0.0#A2SIdString">Identifier</a>
+     */
+    public final String id;
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/AsyncApiDocket.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/AsyncApiDocket.java
@@ -51,4 +51,10 @@ public class AsyncApiDocket {
     @Singular
     private final List<ConsumerData> consumers;
 
+    /**
+     * A string representing the default content type to use when encoding/decoding a message's payload.
+     *
+     * @see <a href="https://www.asyncapi.com/docs/reference/specification/v2.0.0#defaultContentTypeString">Default Content Type</a>
+     */
+    public final String defaultContentType;
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketService.java
@@ -52,6 +52,7 @@ public class DefaultAsyncApiDocketService implements AsyncApiDocketService {
                 .basePackage(configProperties.getDocket().getBasePackage())
                 .info(info)
                 .servers(configProperties.getDocket().getServers())
+                .defaultContentType(configProperties.getDocket().getDefaultContentType())
                 .build();
     }
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketService.java
@@ -48,13 +48,17 @@ public class DefaultAsyncApiDocketService implements AsyncApiDocketService {
 
         Info info = buildInfo(configProperties.getDocket().getInfo());
 
-        return AsyncApiDocket.builder()
+        AsyncApiDocket.AsyncApiDocketBuilder builder = AsyncApiDocket.builder()
                 .basePackage(configProperties.getDocket().getBasePackage())
                 .info(info)
                 .servers(configProperties.getDocket().getServers())
-                .id(configProperties.getDocket().getId())
-                .defaultContentType(configProperties.getDocket().getDefaultContentType())
-                .build();
+                .id(configProperties.getDocket().getId());
+
+        if(configProperties.getDocket().getDefaultContentType() != null) {
+           builder.defaultContentType(configProperties.getDocket().getDefaultContentType());
+        }
+
+        return builder.build();
     }
 
     private static Info buildInfo(@Nullable SpringWolfConfigProperties.ConfigDocket.Info info) {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketService.java
@@ -52,6 +52,7 @@ public class DefaultAsyncApiDocketService implements AsyncApiDocketService {
                 .basePackage(configProperties.getDocket().getBasePackage())
                 .info(info)
                 .servers(configProperties.getDocket().getServers())
+                .id(configProperties.getDocket().getId())
                 .defaultContentType(configProperties.getDocket().getDefaultContentType())
                 .build();
     }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/SpringContextTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/SpringContextTest.java
@@ -62,6 +62,7 @@ public class SpringContextTest {
             "springwolf.enabled=true",
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
+            "springwolf.docket.id=urn:io:github:stavshamir:springwolf:example",
             "springwolf.docket.default-content-type=application/yaml",
             "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=test",
@@ -81,6 +82,7 @@ public class SpringContextTest {
             assertThat(asyncApiService.getAsyncAPI()).isNotNull();
             assertThat(asyncApiService.getAsyncAPI().getInfo().getTitle()).isEqualTo("Info title was loaded from spring properties");
             assertThat(asyncApiService.getAsyncAPI().getDefaultContentType()).isEqualTo("application/yaml");
+            assertThat(asyncApiService.getAsyncAPI().getId()).isEqualTo("urn:io:github:stavshamir:springwolf:example");
         }
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/SpringContextTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/SpringContextTest.java
@@ -62,6 +62,7 @@ public class SpringContextTest {
             "springwolf.enabled=true",
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
+            "springwolf.docket.default-content-type=application/yaml",
             "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=test",
             "springwolf.docket.servers.test-protocol.url=some-server:1234",
@@ -78,6 +79,8 @@ public class SpringContextTest {
             assertNotNull(context);
 
             assertThat(asyncApiService.getAsyncAPI()).isNotNull();
+            assertThat(asyncApiService.getAsyncAPI().getInfo().getTitle()).isEqualTo("Info title was loaded from spring properties");
+            assertThat(asyncApiService.getAsyncAPI().getDefaultContentType()).isEqualTo("application/yaml");
         }
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketServiceTest.java
@@ -23,6 +23,8 @@ public class DefaultAsyncApiDocketServiceTest {
         ConfigDocket configDocket = new ConfigDocket();
         configDocket.setBasePackage("test-base-package");
 
+        configDocket.setDefaultContentType("application/json");
+
         Server server = Server.builder()
                 .protocol("some-protocol")
                 .url("some-url")
@@ -46,6 +48,7 @@ public class DefaultAsyncApiDocketServiceTest {
         AsyncApiDocket asyncApiDocket = docketConfiguration.getAsyncApiDocket();
 
         // then
+        assertThat(asyncApiDocket.getDefaultContentType()).isEqualTo(configDocket.getDefaultContentType());
         assertThat(asyncApiDocket.getServers()).isEqualTo(configDocket.getServers());
         assertThat(asyncApiDocket.getInfo().getTitle()).isEqualTo(info.getTitle());
         assertThat(asyncApiDocket.getInfo().getVersion()).isEqualTo(info.getVersion());

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -13,6 +13,7 @@
       "name" : "Apache License 2.0"
     }
   },
+  "defaultContentType" : "application/json",
   "servers" : {
     "amqp" : {
       "url" : "amqp:5672",

--- a/springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json
@@ -13,6 +13,7 @@
       "name": "Apache License 2.0"
     }
   },
+  "defaultContentType" : "application/json",
   "servers": {
     "kafka": {
       "url": "kafka:29092",

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -13,6 +13,7 @@
       "name" : "Apache License 2.0"
     }
   },
+  "defaultContentType" : "application/json",
   "servers" : {
     "kafka" : {
       "url" : "localhost:9092",


### PR DESCRIPTION
Looking at the AsyncAPI specification I was missing support to provide the next elements:

- [x] defaultContentType
- [x] id

The configuration for `defaultContentType` was not possible via SpringBoot Properties (only programatically)

Now we can indicate something like `springwolf.docket.default-content-type=application/json` (or `springwolf.docket.defaultContentType=application/json` to configure the value
 
It was not possible to configure the AsyncAPI identifier either (`id`)

Now we can indicate something like `springwolf.docket.id=urn:something:something` (or `springwolf.docket.id=https://something` to configure the identifier value