### PR TITLE
Chore/javax dependency cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,6 @@ ext {
 
     javaMoneyMonetaVersion = '1.4.2'
 
-    jaxbApiVersion = '2.3.1'
-
     jsonAssertVersion = '1.5.1'
 
     junitJupiterVersion = '5.9.3'

--- a/springwolf-add-ons/springwolf-common-model-converters/build.gradle
+++ b/springwolf-add-ons/springwolf-common-model-converters/build.gradle
@@ -18,11 +18,9 @@ repositories {
 
 dependencies {
     implementation "org.javamoney.moneta:moneta-core:${javaMoneyMonetaVersion}"
-    implementation "io.swagger.core.v3:swagger-core:${swaggerCoreVersion}"
+    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
 
     implementation "org.springframework:spring-context"
-
-    implementation "javax.xml.bind:jaxb-api:${jaxbApiVersion}"
 
     testImplementation "org.junit.platform:junit-platform-engine:${junitPlatformVersion}"
     testImplementation "org.junit.platform:junit-platform-commons:${junitPlatformVersion}"

--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -20,10 +20,22 @@ repositories {
 dependencies {
     api "com.asyncapi:asyncapi-core:${asyncApiCoreVersion}"
 
-    implementation "io.swagger:swagger-inflector:${swaggerInflectorVersion}"
-    implementation "io.swagger.core.v3:swagger-core:${swaggerCoreVersion}"
+    implementation("io.swagger:swagger-inflector:${swaggerInflectorVersion}") {
+        // swagger-inflector (2.0.9) transiently pulls two swagger-core dependencies:
+        // - io.swagger.core.v3:swagger-core  2.x
+        // - io.swagger:swagger-core  1.6.9
+        // these deps should be excluded because we need 'io.swagger.core.v3:swagger-core-jakarkta 2.x'
+        // Unfortunatly, io.swagger.swagger-core is still used in one place in swagger-inflector (io.swagger.util.Json)
+        // so we cannot exclude the old 'io.swagger:swagger-core 1.6.9' dependeny. Instead, we exclude explicitly
+        // the 'old' javax.validation groupid.
+
+        exclude group: "io.swagger.core.v3"
+//        exclude group: "io.swagger"  // not possible
+        exclude group: "javax.validation"
+    }
+
+    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
     implementation "io.swagger.parser.v3:swagger-parser-core:${swaggerParserVersion}"
-    implementation "javax.xml.bind:jaxb-api:${jaxbApiVersion}"
 
     implementation "org.springframework:spring-web"
     implementation "org.springframework:spring-context"

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AsyncAPI.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AsyncAPI.java
@@ -10,7 +10,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
-import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -89,7 +88,7 @@ public class AsyncAPI {
      * <b>Required.</b>
      * A set of tags used by the specification with additional metadata. Each tag name in the set MUST be unique.
      */
-    @NotNull
+    @NonNull
     @Builder.Default
     private Set<Tag> tags = Collections.emptySet();
 

--- a/springwolf-examples/springwolf-amqp-example/build.gradle
+++ b/springwolf-examples/springwolf-amqp-example/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation "org.springframework.amqp:spring-rabbit"
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api"
-    implementation "io.swagger.core.v3:swagger-core:${swaggerCoreVersion}"
+    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
 
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"

--- a/springwolf-examples/springwolf-cloud-stream-example/build.gradle
+++ b/springwolf-examples/springwolf-cloud-stream-example/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "org.springframework.cloud:spring-cloud-stream-binder-kafka-streams"
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api"
-    implementation "io.swagger.core.v3:swagger-core:${swaggerCoreVersion}"
+    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
 
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     testImplementation "org.springframework.kafka:spring-kafka-test"
@@ -74,6 +74,9 @@ java {
 }
 
 test {
+    minHeapSize = "128m" // initial heap size
+    maxHeapSize = "1024m" // maximum heap size
+
     dependsOn dockerBuildImage
 
     useJUnitPlatform()

--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api"
     implementation "org.javamoney:moneta:${javaMoneyMonetaVersion}"
-    implementation "io.swagger.core.v3:swagger-core:${swaggerCoreVersion}"
+    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
 
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     testImplementation "org.springframework.kafka:spring-kafka-test"

--- a/springwolf-plugins/springwolf-amqp-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-amqp-plugin/build.gradle
@@ -26,7 +26,6 @@ dependencies {
 
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api"
-    implementation "javax.xml.bind:jaxb-api:${jaxbApiVersion}"
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api"
-    implementation "javax.xml.bind:jaxb-api:${jaxbApiVersion}"
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/springwolf-plugins/springwolf-kafka-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-kafka-plugin/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     implementation "org.springframework:spring-web"
     implementation "org.springframework.kafka:spring-kafka"
     implementation "io.swagger.core.v3:swagger-models:${swaggerCoreVersion}"
-    implementation "javax.xml.bind:jaxb-api:${jaxbApiVersion}"
 
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api"


### PR DESCRIPTION
This PR explicitly declares a `io.swagger.core.v3:swagger-core-jakarta` dependency instead of `io.swagger.core.v3:swagger-core`. 
The latter one came transiently via swagger-inflector and is now excluded.  This change allowed it to remove the dependency of `javax.xml.bind:jaxb-api`. 

swagger-inflector also pulls transiently the 'older'  `io.swagger:swagger-core` dependency (v1.6.9, other group-id, other package-names) which unfortunately cannot be excluded, because swagger-inflector needs some utility classes from this dependency (`io.swagger.util.Json`) 

This necessary old swagger-core dependency has itself a dependency to javax.validation, which should not be part of the springwolf dependency tree because springwolf changed to SpringBoot 3.x and jakarta.  So, the groupId javax.validation is explicitly excluded from the transient deps of swagger-inflector.

There was **one** usage of javax.validation.NotNull in `AsyncAPI` which seems to be accidently defined. This annotation was changed to lombok.NonNull  (like all other methods in `AsyncAPI`)







