### PR TITLE
feat: Remove usage of Guava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,6 @@ ext {
 
     commonsIoVersion = '2.12.0'
 
-    guavaVersion = '32.0.0-jre'
-
     javaMoneyMonetaVersion = '1.4.2'
 
     jsonAssertVersion = '1.5.1'

--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -38,8 +38,6 @@ dependencies {
     implementation "org.springframework:spring-messaging"
     implementation "org.springframework.boot:spring-boot-autoconfigure"
 
-    implementation "com.google.guava:guava:${guavaVersion}"
-
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigProperties.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringWolfConfigProperties.java
@@ -11,7 +11,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.Nullable;
+import org.springframework.lang.Nullable;
 import java.util.Map;
 
 @Configuration

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
-import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,14 +27,14 @@ public class MessageHelper {
             case 0 -> throw new IllegalArgumentException("messages must not be empty");
             case 1 -> messages.toArray()[0];
             default ->
-                    ImmutableMap.of(ONE_OF, new ArrayList<>(messages.stream().collect(Collectors.toCollection(messageSupplier))));
+                    Map.of(ONE_OF, new ArrayList<>(messages.stream().collect(Collectors.toCollection(messageSupplier))));
         };
     }
 
     @SuppressWarnings("unchecked")
     public static Set<Message> messageObjectToSet(Object messageObject) {
-        if (messageObject instanceof Message) {
-            return new HashSet<>(Collections.singletonList((Message) messageObject));
+        if (messageObject instanceof Message message) {
+            return new HashSet<>(Collections.singletonList(message));
         }
 
         if (messageObject instanceof Map) {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AbstractClassLevelListenerScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AbstractClassLevelListenerScanner.java
@@ -5,7 +5,6 @@ import com.asyncapi.v2.binding.message.MessageBinding;
 import com.asyncapi.v2.binding.operation.OperationBinding;
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
-import com.google.common.collect.Maps;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelMerger;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
@@ -126,7 +125,7 @@ public abstract class AbstractClassLevelListenerScanner<ClassAnnotation extends 
         }
 
         ChannelItem channelItem = buildChannel(component.getSimpleName(), annotatedMethods, channelBinding, operationBinding);
-        return Optional.of(Maps.immutableEntry(channelName, channelItem));
+        return Optional.of(Map.entry(channelName, channelItem));
     }
 
     private Set<Method> getAnnotatedMethods(Class<?> component) {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AbstractMethodLevelListenerScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AbstractMethodLevelListenerScanner.java
@@ -5,7 +5,6 @@ import com.asyncapi.v2.binding.message.MessageBinding;
 import com.asyncapi.v2.binding.operation.OperationBinding;
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
-import com.google.common.collect.Maps;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
@@ -104,7 +103,7 @@ public abstract class AbstractMethodLevelListenerScanner<T extends Annotation> i
         String operationId = channelName + "_publish_" + method.getName();
         ChannelItem channel = buildChannel(channelBinding, payload, operationBinding, messageBinding, operationId);
 
-        return Maps.immutableEntry(channelName, channel);
+        return Map.entry(channelName, channel);
     }
 
     private ChannelItem buildChannel(Map<String, ? extends ChannelBinding> channelBinding,

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
@@ -54,7 +54,7 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
         return componentClassScanner.scan().stream()
                 .flatMap(this::getAnnotatedMethods)
                 .flatMap(this::toOperationData)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private Stream<Method> getAnnotatedMethods(Class<?> type) {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ConsumerData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ConsumerData.java
@@ -36,7 +36,7 @@ public class ConsumerData implements OperationData {
      * <br>
      * For example:
      * <code>
-     *     ImmutableMap.of("kafka", new KafkaChannelBinding())
+     *     Map.of("kafka", new KafkaChannelBinding())
      * </code>
      */
     protected Map<String, ? extends ChannelBinding> channelBinding;
@@ -57,7 +57,7 @@ public class ConsumerData implements OperationData {
      * <br>
      * For example:
      * <code>
-     *     ImmutableMap.of("kafka", new KafkaOperationBinding())
+     *     Map.of("kafka", new KafkaOperationBinding())
      * </code>
      */
     protected Map<String, ? extends OperationBinding> operationBinding;
@@ -67,7 +67,7 @@ public class ConsumerData implements OperationData {
      * <br>
      * For example:
      * <code>
-     *     ImmutableMap.of("kafka", new KafkaMessageBinding())
+     *     Map.of("kafka", new KafkaMessageBinding())
      * </code>
      */
     protected Map<String, ? extends MessageBinding> messageBinding;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ProducerData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ProducerData.java
@@ -36,7 +36,7 @@ public class ProducerData implements OperationData {
      * <br>
      * For example:
      * <code>
-     *     ImmutableMap.of("kafka", new KafkaChannelBinding())
+     *     Map.of("kafka", new KafkaChannelBinding())
      * </code>
      */
     protected Map<String, ? extends ChannelBinding> channelBinding;
@@ -57,7 +57,7 @@ public class ProducerData implements OperationData {
      * <br>
      * For example:
      * <code>
-     *     ImmutableMap.of("kafka", new KafkaOperationBinding())
+     *     Map.of("kafka", new KafkaOperationBinding())
      * </code>
      */
     protected Map<String, ? extends OperationBinding> operationBinding;
@@ -67,7 +67,7 @@ public class ProducerData implements OperationData {
      * <br>
      * For example:
      * <code>
-     *     ImmutableMap.of("kafka", new KafkaMessageBinding())
+     *     Map.of("kafka", new KafkaMessageBinding())
      * </code>
      */
     protected Map<String, ? extends MessageBinding> messageBinding;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeadersForCloudEventsBuilder.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeadersForCloudEventsBuilder.java
@@ -5,9 +5,6 @@ import org.springframework.util.MimeType;
 
 import java.util.List;
 
-import static com.google.common.collect.ImmutableList.of;
-import static java.util.stream.Collectors.toList;
-
 public class AsyncHeadersForCloudEventsBuilder {
 
     private final AsyncHeaders headers;
@@ -25,11 +22,11 @@ public class AsyncHeadersForCloudEventsBuilder {
     }
 
     public AsyncHeadersForCloudEventsBuilder withContentTypeHeader(MediaType contentType) {
-        return withContentTypeHeader(contentType, of(contentType));
+        return withContentTypeHeader(contentType, List.of(contentType));
     }
 
     public AsyncHeadersForCloudEventsBuilder withContentTypeHeader(MediaType exampleContentType, List<MediaType> contentTypeValues) {
-        List<String> contentTypeStringValues = contentTypeValues.stream().map(MimeType::toString).collect(toList());
+        List<String> contentTypeStringValues = contentTypeValues.stream().map(MimeType::toString).toList();
         return withHeader(
                 "content-type",
                 contentTypeStringValues,
@@ -39,7 +36,7 @@ public class AsyncHeadersForCloudEventsBuilder {
     }
 
     public AsyncHeadersForCloudEventsBuilder withSpecVersionHeader(String specVersion) {
-        return withSpecVersionHeader(specVersion, of(specVersion));
+        return withSpecVersionHeader(specVersion, List.of(specVersion));
     }
 
     public AsyncHeadersForCloudEventsBuilder withSpecVersionHeader(String specVersion, List<String> specValues) {
@@ -52,7 +49,7 @@ public class AsyncHeadersForCloudEventsBuilder {
     }
 
     public AsyncHeadersForCloudEventsBuilder withIdHeader(String idExample) {
-        return withIdHeader(idExample, of(idExample));
+        return withIdHeader(idExample, List.of(idExample));
     }
 
     public AsyncHeadersForCloudEventsBuilder withIdHeader(String idExample, List<String> idValues) {
@@ -65,7 +62,7 @@ public class AsyncHeadersForCloudEventsBuilder {
     }
 
     public AsyncHeadersForCloudEventsBuilder withTimeHeader(String timeExample) {
-        return withTimeHeader(timeExample, of(timeExample));
+        return withTimeHeader(timeExample, List.of(timeExample));
     }
 
     public AsyncHeadersForCloudEventsBuilder withTimeHeader(String timeExample, List<String> timeValues) {
@@ -78,7 +75,7 @@ public class AsyncHeadersForCloudEventsBuilder {
     }
 
     public AsyncHeadersForCloudEventsBuilder withTypeHeader(String typeExample) {
-        return withTypeHeader(typeExample, of(typeExample));
+        return withTypeHeader(typeExample, List.of(typeExample));
     }
 
     public AsyncHeadersForCloudEventsBuilder withTypeHeader(String typeExample, List<String> typeValues) {
@@ -91,7 +88,7 @@ public class AsyncHeadersForCloudEventsBuilder {
     }
 
     public AsyncHeadersForCloudEventsBuilder withSourceHeader(String sourceExample) {
-        return withSourceHeader(sourceExample, of(sourceExample));
+        return withSourceHeader(sourceExample, List.of(sourceExample));
     }
 
     public AsyncHeadersForCloudEventsBuilder withSourceHeader(String sourceExample, List<String> sourceValues) {
@@ -104,7 +101,7 @@ public class AsyncHeadersForCloudEventsBuilder {
     }
 
     public AsyncHeadersForCloudEventsBuilder withSubjectHeader(String subjectExample) {
-        return withSubjectHeader(subjectExample, of(subjectExample));
+        return withSubjectHeader(subjectExample, List.of(subjectExample));
     }
 
     public AsyncHeadersForCloudEventsBuilder withSubjectHeader(String subjectExample, List<String> subjectValues) {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/DefaultAsyncApiDocketService.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.Nullable;
+import org.springframework.lang.Nullable;
 import java.util.Optional;
 
 @Slf4j

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiSerializerServiceTest.java
@@ -10,7 +10,6 @@ import com.asyncapi.v2.binding.message.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.operation.OperationBinding;
 import com.asyncapi.v2.binding.operation.kafka.KafkaOperationBinding;
 import com.asyncapi.v2.schema.Type;
-import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
 import io.github.stavshamir.springwolf.asyncapi.types.Components;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
@@ -72,7 +71,7 @@ class DefaultAsyncApiSerializerServiceTest {
                 .name("io.github.stavshamir.springwolf.ExamplePayload")
                 .title("Example Payload")
                 .payload(PayloadReference.fromModelName("ExamplePayload"))
-                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding(new StringSchema(), null, null, null, "binding-version-1")))
+                .bindings(Map.of("kafka", new KafkaMessageBinding(new StringSchema(), null, null, null, "binding-version-1")))
                 .build();
 
         com.asyncapi.v2.schema.Schema groupId = new com.asyncapi.v2.schema.Schema();
@@ -84,7 +83,7 @@ class DefaultAsyncApiSerializerServiceTest {
                 .description("Auto-generated description")
                 .operationId("new-user_listenerMethod_subscribe")
                 .message(message)
-                .bindings(ImmutableMap.of("kafka", operationBinding))
+                .bindings(Map.of("kafka", operationBinding))
                 .build();
 
         ChannelItem newUserChannel = ChannelItem.builder()
@@ -97,8 +96,8 @@ class DefaultAsyncApiSerializerServiceTest {
         AsyncAPI asyncapi = AsyncAPI.builder()
                 .info(info)
                 .defaultContentType("application/json")
-                .servers(ImmutableMap.of("production", productionServer))
-                .channels(ImmutableMap.of("new-user", newUserChannel))
+                .servers(Map.of("production", productionServer))
+                .channels(Map.of("new-user", newUserChannel))
                 .components(Components.builder().schemas(schemas).build())
                 .build();
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
@@ -5,7 +5,6 @@ import com.asyncapi.v2.binding.operation.kafka.KafkaOperationBinding;
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.info.Info;
 import com.asyncapi.v2._0_0.model.server.Server;
-import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ConsumerOperationDataScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProducerOperationDataScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.ConsumerData;
@@ -53,16 +52,16 @@ class DefaultAsyncApiServiceTest {
                     .channelName("producer-topic")
                     .description("producer-topic-description")
                     .payloadType(String.class)
-                    .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                    .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                    .operationBinding(Map.of("kafka", new KafkaOperationBinding()))
+                    .messageBinding(Map.of("kafka", new KafkaMessageBinding()))
                     .build();
 
             ConsumerData kafkaConsumerData = ConsumerData.builder()
                     .channelName("consumer-topic")
                     .description("consumer-topic-description")
                     .payloadType(String.class)
-                    .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                    .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                    .operationBinding(Map.of("kafka", new KafkaOperationBinding()))
+                    .messageBinding(Map.of("kafka", new KafkaMessageBinding()))
                     .build();
 
             return AsyncApiDocket.builder()
@@ -110,7 +109,7 @@ class DefaultAsyncApiServiceTest {
         assertThat(channel.getSubscribe()).isNotNull();
         final Message message = (Message) channel.getSubscribe().getMessage();
         assertThat(message.getDescription()).isNull();
-        assertThat(message.getBindings()).isEqualTo(ImmutableMap.of("kafka", new KafkaMessageBinding()));
+        assertThat(message.getBindings()).isEqualTo(Map.of("kafka", new KafkaMessageBinding()));
     }
 
     @Test
@@ -125,7 +124,7 @@ class DefaultAsyncApiServiceTest {
         assertThat(channel.getPublish()).isNotNull();
         final Message message = (Message) channel.getPublish().getMessage();
         assertThat(message.getDescription()).isNull();
-        assertThat(message.getBindings()).isEqualTo(ImmutableMap.of("kafka", new KafkaMessageBinding()));
+        assertThat(message.getBindings()).isEqualTo(Map.of("kafka", new KafkaMessageBinding()));
     }
 
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsServiceTest.java
@@ -2,7 +2,6 @@ package io.github.stavshamir.springwolf.asyncapi;
 
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
-import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,7 +47,7 @@ class DefaultChannelsServiceTest {
     static class FooChannelScanner implements ChannelsScanner {
         @Override
         public Map<String, ChannelItem> scan() {
-            return ImmutableMap.of("foo", new ChannelItem());
+            return Map.of("foo", new ChannelItem());
         }
     }
 
@@ -56,7 +55,7 @@ class DefaultChannelsServiceTest {
     static class BarChannelScanner implements ChannelsScanner {
         @Override
         public Map<String, ChannelItem> scan() {
-            return ImmutableMap.of("bar", new ChannelItem());
+            return Map.of("bar", new ChannelItem());
         }
     }
 
@@ -73,7 +72,7 @@ class DefaultChannelsServiceTest {
 
             @Override
             public Map<String, ChannelItem> scan() {
-                return ImmutableMap.of(topicName, ChannelItem.builder().publish(publishOperation).build());
+                return Map.of(topicName, ChannelItem.builder().publish(publishOperation).build());
             }
         }
 
@@ -83,7 +82,7 @@ class DefaultChannelsServiceTest {
 
             @Override
             public Map<String, ChannelItem> scan() {
-                return ImmutableMap.of(topicName, ChannelItem.builder().subscribe(subscribeOperation).build());
+                return Map.of(topicName, ChannelItem.builder().subscribe(subscribeOperation).build());
             }
         }
     }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
@@ -1,12 +1,10 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,7 +27,7 @@ class MessageHelperTest {
                 .name("foo")
                 .build();
 
-        Object asObject = toMessageObjectOrComposition(ImmutableSet.of(message));
+        Object asObject = toMessageObjectOrComposition(Set.of(message));
 
         assertThat(asObject)
                 .isInstanceOf(Message.class)
@@ -47,11 +45,11 @@ class MessageHelperTest {
                 .name("bar")
                 .build();
 
-        Object asObject = toMessageObjectOrComposition(ImmutableSet.of(message1, message2));
+        Object asObject = toMessageObjectOrComposition(Set.of(message1, message2));
 
         assertThat(asObject)
                 .isInstanceOf(Map.class)
-                .isEqualTo(ImmutableMap.of("oneOf", ImmutableList.of(message2, message1)));
+                .isEqualTo(Map.of("oneOf", List.of(message2, message1)));
     }
 
     @Test
@@ -71,12 +69,16 @@ class MessageHelperTest {
                 .description("This is message 3, but in essence the same payload type as message 2")
                 .build();
 
-        Object asObject = toMessageObjectOrComposition(ImmutableSet.of(message1, message2, message3));
+        Object asObject = toMessageObjectOrComposition(Set.of(message1, message2, message3));
 
-        // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
-        assertThat(asObject)
-                .isInstanceOf(Map.class)
-                .isEqualTo(ImmutableMap.of("oneOf", ImmutableList.of(message2, message1)));
+        Map<String, List<Message>> oneOfMap = (Map<String, List<Message>>) asObject;
+        assertThat(oneOfMap).hasSize(1);
+        List<Message> deduplicatedMessageList = oneOfMap.get("oneOf");
+        // we do not have any guarantee wether message2 or message3 won the deduplication.
+        assertThat(deduplicatedMessageList)
+                .hasSize(2)
+                .contains(message1)
+                .containsAnyOf(message2, message3);
     }
 
     @Test
@@ -91,7 +93,7 @@ class MessageHelperTest {
                 .description("This is actual message 2")
                 .build();
 
-        Object actualObject = toMessageObjectOrComposition(ImmutableSet.of(actualMessage1, actualMessage2));
+        Object actualObject = toMessageObjectOrComposition(Set.of(actualMessage1, actualMessage2));
 
         Message expectedMessage1 = Message.builder()
                 .name("foo")
@@ -103,7 +105,7 @@ class MessageHelperTest {
                 .description("This is expected message 2")
                 .build();
 
-        Object expectedObject = toMessageObjectOrComposition(ImmutableSet.of(expectedMessage1, expectedMessage2));
+        Object expectedObject = toMessageObjectOrComposition(Set.of(expectedMessage1, expectedMessage2));
 
         assertThat(actualObject).isNotEqualTo(expectedObject);
     }
@@ -123,7 +125,7 @@ class MessageHelperTest {
         Message message = Message.builder()
                 .name("foo")
                 .build();
-        Object asObject = toMessageObjectOrComposition(ImmutableSet.of(message));
+        Object asObject = toMessageObjectOrComposition(Set.of(message));
 
         Set<Message> messages = messageObjectToSet(asObject);
 
@@ -141,7 +143,7 @@ class MessageHelperTest {
                 .name("bar")
                 .build();
 
-        Object asObject = toMessageObjectOrComposition(ImmutableSet.of(message1, message2));
+        Object asObject = toMessageObjectOrComposition(Set.of(message1, message2));
 
         Set<Message> messages = messageObjectToSet(asObject);
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/beans/DefaultBeanMethodsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/beans/DefaultBeanMethodsScannerTest.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.beans;
 
-import com.google.common.collect.ImmutableSet;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ConfigurationClassScanner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +30,7 @@ class DefaultBeanMethodsScannerTest {
     @Test
     void name() {
         when(configurationClassScanner.scan())
-                .thenReturn(ImmutableSet.of(ConfigurationClass.class));
+                .thenReturn(Set.of(ConfigurationClass.class));
 
         Set<String> beanMethods = beanMethodsScanner.getBeanMethods().stream()
                 .map(Method::getName)

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
@@ -3,14 +3,13 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
 
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import io.github.stavshamir.springwolf.asyncapi.MessageHelper;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,8 +27,8 @@ class ChannelMergerTest {
 
         // when
         Map<String, ChannelItem> mergedChannels = ChannelMerger.merge(Arrays.asList(
-                Maps.immutableEntry(channelName1, publisherChannel),
-                Maps.immutableEntry(channelName2, subscriberChannel)));
+                Map.entry(channelName1, publisherChannel),
+                Map.entry(channelName2, subscriberChannel)));
 
         // then
         assertThat(mergedChannels).hasSize(2)
@@ -54,8 +53,8 @@ class ChannelMergerTest {
 
         // when
         Map<String, ChannelItem> mergedChannels = ChannelMerger.merge(Arrays.asList(
-                Maps.immutableEntry(channelName, publisherChannel),
-                Maps.immutableEntry(channelName, subscriberChannel)));
+                Map.entry(channelName, publisherChannel),
+                Map.entry(channelName, subscriberChannel)));
 
         // then
         assertThat(mergedChannels).hasSize(1)
@@ -76,8 +75,8 @@ class ChannelMergerTest {
 
         // when
         Map<String, ChannelItem> mergedChannels = ChannelMerger.merge(Arrays.asList(
-                Maps.immutableEntry(channelName, publisherChannel1),
-                Maps.immutableEntry(channelName, publisherChannel2)));
+                Map.entry(channelName, publisherChannel1),
+                Map.entry(channelName, publisherChannel2)));
 
         // then
         assertThat(mergedChannels).hasSize(1)
@@ -103,13 +102,13 @@ class ChannelMergerTest {
 
         // when
         Map<String, ChannelItem> mergedChannels = ChannelMerger.merge(Arrays.asList(
-                Maps.immutableEntry(channelName, publisherChannel1),
-                Maps.immutableEntry(channelName, publisherChannel2),
-                Maps.immutableEntry(channelName, publisherChannel3)));
+                Map.entry(channelName, publisherChannel1),
+                Map.entry(channelName, publisherChannel2),
+                Map.entry(channelName, publisherChannel3)));
 
         // then expectedMessage only includes message1 and message2.
         // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
-        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message1, message2));
+        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Set.of(message1, message2));
         assertThat(mergedChannels).hasSize(1)
                 .hasEntrySatisfying(channelName, it -> {
                     assertThat(it.getPublish()).isEqualTo(Operation.builder().operationId("publisher1").message(expectedMessages).build());
@@ -129,11 +128,11 @@ class ChannelMergerTest {
 
         // when
         Map<String, ChannelItem> mergedChannels = ChannelMerger.merge(Arrays.asList(
-                Maps.immutableEntry(channelName, publisherChannel1),
-                Maps.immutableEntry(channelName, publisherChannel2)));
+                Map.entry(channelName, publisherChannel1),
+                Map.entry(channelName, publisherChannel2)));
 
         // then expectedMessage message2
-        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Sets.newHashSet(message2));
+        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Set.of(message2));
         assertThat(mergedChannels).hasSize(1)
                 .hasEntrySatisfying(channelName, it -> {
                     assertThat(it.getPublish()).isEqualTo(Operation.builder().operationId("publisher1").message(expectedMessages).build());

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/TestMethodLevelListenerScanner.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/TestMethodLevelListenerScanner.java
@@ -3,7 +3,6 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 import com.asyncapi.v2.binding.channel.ChannelBinding;
 import com.asyncapi.v2.binding.message.MessageBinding;
 import com.asyncapi.v2.binding.operation.OperationBinding;
-import com.google.common.collect.ImmutableMap;
 import lombok.EqualsAndHashCode;
 
 import java.lang.reflect.Method;
@@ -23,17 +22,17 @@ public class TestMethodLevelListenerScanner extends AbstractMethodLevelListenerS
 
     @Override
     protected Map<String, ? extends ChannelBinding> buildChannelBinding(TestMethodLevelListenerScannerTest.TestChannelListener annotation) {
-        return ImmutableMap.of("test-channel-binding", new TestChannelBinding());
+        return Map.of("test-channel-binding", new TestChannelBinding());
     }
 
     @Override
     protected Map<String, ? extends OperationBinding> buildOperationBinding(TestMethodLevelListenerScannerTest.TestChannelListener annotation) {
-        return ImmutableMap.of("test-operation-binding", new TestOperationBinding());
+        return Map.of("test-operation-binding", new TestOperationBinding());
     }
 
     @Override
     protected Map<String, ? extends MessageBinding> buildMessageBinding(TestMethodLevelListenerScannerTest.TestChannelListener annotation) {
-        return ImmutableMap.of("test-message-binding", new TestMessageBinding());
+        return Map.of("test-message-binding", new TestMessageBinding());
     }
 
     @Override

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/TestMethodLevelListenerScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/TestMethodLevelListenerScannerTest.java
@@ -2,8 +2,6 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
@@ -72,23 +70,23 @@ class TestMethodLevelListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("test-message-binding", new TestMethodLevelListenerScanner.TestMessageBinding()))
+                .bindings(Map.of("test-message-binding", new TestMethodLevelListenerScanner.TestMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("test-channel_publish_methodWithAnnotation")
-                .bindings(ImmutableMap.of("test-operation-binding", new TestMethodLevelListenerScanner.TestOperationBinding()))
+                .bindings(Map.of("test-operation-binding", new TestMethodLevelListenerScanner.TestOperationBinding()))
                 .message(message)
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("test-channel-binding", new TestMethodLevelListenerScanner.TestChannelBinding()))
+                .bindings(Map.of("test-channel-binding", new TestMethodLevelListenerScanner.TestChannelBinding()))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
+                .containsExactly(Map.entry("test-channel", expectedChannel));
     }
 
     private static class ClassWithoutListenerAnnotation {

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerTest.java
@@ -6,9 +6,6 @@ import com.asyncapi.v2.binding.operation.kafka.KafkaOperationBinding;
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
 import com.asyncapi.v2._0_0.model.info.Info;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.github.stavshamir.springwolf.asyncapi.types.ConsumerData;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
@@ -26,6 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -51,13 +49,13 @@ class ConsumerOperationDataScannerTest {
         ConsumerData consumerData = ConsumerData.builder()
                 .channelName(channelName)
                 .description(description)
-                .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .channelBinding(Map.of("kafka", new KafkaChannelBinding()))
+                .operationBinding(Map.of("kafka", new KafkaOperationBinding()))
+                .messageBinding(Map.of("kafka", new KafkaMessageBinding()))
                 .payloadType(ExamplePayloadDto.class)
                 .build();
 
-        mockConsumers(ImmutableList.of(consumerData));
+        mockConsumers(List.of(consumerData));
 
         // When scanning for consumers
         Map<String, ChannelItem> consumerChannels = scanner.scan();
@@ -70,19 +68,19 @@ class ConsumerOperationDataScannerTest {
         Operation operation = Operation.builder()
                 .description(description)
                 .operationId("example-consumer-topic-foo1_publish")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .bindings(Map.of("kafka", new KafkaOperationBinding()))
                 .message(Message.builder()
                         .name(ExamplePayloadDto.class.getName())
                         .description(messageDescription)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                        .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                        .bindings(Map.of("kafka", new KafkaMessageBinding()))
                         .build())
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                .bindings(Map.of("kafka", new KafkaChannelBinding()))
                 .publish(operation)
                 .build();
 
@@ -98,7 +96,7 @@ class ConsumerOperationDataScannerTest {
                 .channelName(channelName)
                 .build();
 
-        mockConsumers(ImmutableList.of(consumerData));
+        mockConsumers(List.of(consumerData));
 
         // When scanning for consumers
         Map<String, ChannelItem> consumerChannels = scanner.scan();
@@ -117,23 +115,23 @@ class ConsumerOperationDataScannerTest {
         ConsumerData consumerData1 = ConsumerData.builder()
                 .channelName(channelName)
                 .description(description1)
-                .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .channelBinding(Map.of("kafka", new KafkaChannelBinding()))
+                .operationBinding(Map.of("kafka", new KafkaOperationBinding()))
+                .messageBinding(Map.of("kafka", new KafkaMessageBinding()))
                 .payloadType(ExamplePayloadDto.class)
                 .build();
 
         ConsumerData consumerData2 = ConsumerData.builder()
                 .channelName(channelName)
                 .description(description2)
-                .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .channelBinding(Map.of("kafka", new KafkaChannelBinding()))
+                .operationBinding(Map.of("kafka", new KafkaOperationBinding()))
+                .messageBinding(Map.of("kafka", new KafkaMessageBinding()))
                 .payloadType(AnotherExamplePayloadDto.class)
                 .headers(AsyncHeaders.NOT_USED)
                 .build();
 
-        mockConsumers(ImmutableList.of(consumerData1, consumerData2));
+        mockConsumers(List.of(consumerData1, consumerData2));
 
         // When scanning for consumers
         Map<String, ChannelItem> consumerChannels = scanner.scan();
@@ -145,14 +143,14 @@ class ConsumerOperationDataScannerTest {
 
         String messageDescription1 = "Example Payload DTO Description";
         String messageDescription2 = "Another Example Payload DTO Description";
-        Set<Message> messages = ImmutableSet.of(
+        Set<Message> messages = Set.of(
                 Message.builder()
                         .name(ExamplePayloadDto.class.getName())
                         .description(messageDescription1)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                        .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                        .bindings(Map.of("kafka", new KafkaMessageBinding()))
                         .build(),
                 Message.builder()
                         .name(AnotherExamplePayloadDto.class.getName())
@@ -160,19 +158,19 @@ class ConsumerOperationDataScannerTest {
                         .title(AnotherExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(AnotherExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_USED.getSchemaName()))
-                        .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                        .bindings(Map.of("kafka", new KafkaMessageBinding()))
                         .build()
         );
 
         Operation operation = Operation.builder()
                 .description(description1)
                 .operationId("example-consumer-topic_publish")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .bindings(Map.of("kafka", new KafkaOperationBinding()))
                 .message(toMessageObjectOrComposition(messages))
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                .bindings(Map.of("kafka", new KafkaChannelBinding()))
                 .publish(operation)
                 .build();
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerTest.java
@@ -6,9 +6,6 @@ import com.asyncapi.v2.binding.operation.kafka.KafkaOperationBinding;
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
 import com.asyncapi.v2._0_0.model.info.Info;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.github.stavshamir.springwolf.asyncapi.types.ProducerData;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
@@ -26,6 +23,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -51,13 +49,13 @@ class ProducerOperationDataScannerTest {
         ProducerData producerData = ProducerData.builder()
                 .channelName(channelName)
                 .description(description)
-                .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .channelBinding(Map.of("kafka", new KafkaChannelBinding()))
+                .operationBinding(Map.of("kafka", new KafkaOperationBinding()))
+                .messageBinding(Map.of("kafka", new KafkaMessageBinding()))
                 .payloadType(ExamplePayloadDto.class)
                 .build();
 
-        mockProducers(ImmutableList.of(producerData));
+        mockProducers(List.of(producerData));
 
         // When scanning for producers
         Map<String, ChannelItem> producerChannels = scanner.scan();
@@ -70,19 +68,19 @@ class ProducerOperationDataScannerTest {
         Operation operation = Operation.builder()
                 .description(description)
                 .operationId("example-producer-topic-foo1_subscribe")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .bindings(Map.of("kafka", new KafkaOperationBinding()))
                 .message(Message.builder()
                         .name(ExamplePayloadDto.class.getName())
                         .description(messageDescription1)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                        .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                        .bindings(Map.of("kafka", new KafkaMessageBinding()))
                         .build())
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                .bindings(Map.of("kafka", new KafkaChannelBinding()))
                 .subscribe(operation)
                 .build();
 
@@ -98,7 +96,7 @@ class ProducerOperationDataScannerTest {
                 .channelName(channelName)
                 .build();
 
-        mockProducers(ImmutableList.of(producerData));
+        mockProducers(List.of(producerData));
 
         // When scanning for producers
         Map<String, ChannelItem> producerChannels = scanner.scan();
@@ -117,23 +115,23 @@ class ProducerOperationDataScannerTest {
         ProducerData producerData1 = ProducerData.builder()
                 .channelName(channelName)
                 .description(description1)
-                .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .channelBinding(Map.of("kafka", new KafkaChannelBinding()))
+                .operationBinding(Map.of("kafka", new KafkaOperationBinding()))
+                .messageBinding(Map.of("kafka", new KafkaMessageBinding()))
                 .payloadType(ExamplePayloadDto.class)
                 .build();
 
         ProducerData producerData2 = ProducerData.builder()
                 .channelName(channelName)
                 .description(description2)
-                .channelBinding(ImmutableMap.of("kafka", new KafkaChannelBinding()))
-                .operationBinding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .messageBinding(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .channelBinding(Map.of("kafka", new KafkaChannelBinding()))
+                .operationBinding(Map.of("kafka", new KafkaOperationBinding()))
+                .messageBinding(Map.of("kafka", new KafkaMessageBinding()))
                 .payloadType(AnotherExamplePayloadDto.class)
                 .headers(AsyncHeaders.NOT_USED)
                 .build();
 
-        mockProducers(ImmutableList.of(producerData1, producerData2));
+        mockProducers(List.of(producerData1, producerData2));
 
         // When scanning for producers
         Map<String, ChannelItem> producerChannels = scanner.scan();
@@ -145,14 +143,14 @@ class ProducerOperationDataScannerTest {
 
         String messageDescription1 = "Example Payload DTO Description";
         String messageDescription2 = "Another Example Payload DTO Description";
-        Set<Message> messages = ImmutableSet.of(
+        Set<Message> messages = Set.of(
                 Message.builder()
                         .name(ExamplePayloadDto.class.getName())
                         .description(messageDescription1)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                        .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                        .bindings(Map.of("kafka", new KafkaMessageBinding()))
                         .build(),
                 Message.builder()
                         .name(AnotherExamplePayloadDto.class.getName())
@@ -160,19 +158,19 @@ class ProducerOperationDataScannerTest {
                         .title(AnotherExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(AnotherExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_USED.getSchemaName()))
-                        .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                        .bindings(Map.of("kafka", new KafkaMessageBinding()))
                         .build()
         );
 
         Operation operation = Operation.builder()
                 .description(description1)
                 .operationId("example-producer-topic_subscribe")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .bindings(Map.of("kafka", new KafkaOperationBinding()))
                 .message(toMessageObjectOrComposition(messages))
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                .bindings(Map.of("kafka", new KafkaChannelBinding()))
                 .subscribe(operation)
                 .build();
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
@@ -2,8 +2,6 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata
 
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
@@ -86,7 +84,7 @@ class AsyncListenerAnnotationScannerTest {
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
+                .containsExactly(Map.entry("test-channel", expectedChannel));
     }
 
     @Test
@@ -110,7 +108,7 @@ class AsyncListenerAnnotationScannerTest {
         Operation operation = Operation.builder()
                 .description("description")
                 .operationId("test-channel_publish")
-                .bindings(ImmutableMap.of(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING))
+                .bindings(Map.of(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING))
                 .message(message)
                 .build();
 
@@ -120,7 +118,7 @@ class AsyncListenerAnnotationScannerTest {
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
+                .containsExactly(Map.entry("test-channel", expectedChannel));
     }
 
     @Test
@@ -164,8 +162,8 @@ class AsyncListenerAnnotationScannerTest {
                 .build();
 
         assertThat(actualChannels)
-                .containsExactlyEntriesOf(
-                        ImmutableMap.of(
+                .containsExactlyInAnyOrderEntriesOf(
+                        Map.of(
                                 "test-channel-1", expectedChannel1,
                                 "test-channel-2", expectedChannel2));
     }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
@@ -2,8 +2,6 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata
 
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
@@ -86,7 +84,7 @@ class AsyncPublisherAnnotationScannerTest {
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
+                .containsExactly(Map.entry("test-channel", expectedChannel));
     }
 
     @Test
@@ -111,7 +109,7 @@ class AsyncPublisherAnnotationScannerTest {
         Operation operation = Operation.builder()
                 .description("description")
                 .operationId("test-channel_subscribe")
-                .bindings(ImmutableMap.of(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING))
+                .bindings(Map.of(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING))
                 .message(message)
                 .build();
 
@@ -121,7 +119,7 @@ class AsyncPublisherAnnotationScannerTest {
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry("test-channel", expectedChannel));
+                .containsExactly(Map.entry("test-channel", expectedChannel));
     }
 
     @Test
@@ -168,8 +166,8 @@ class AsyncPublisherAnnotationScannerTest {
                 .build();
 
         assertThat(actualChannels)
-                .containsExactlyEntriesOf(
-                        ImmutableMap.of(
+                .containsExactlyInAnyOrderEntriesOf(
+                        Map.of(
                                 "test-channel-1", expectedChannel1,
                                 "test-channel-2", expectedChannel2));
     }

--- a/springwolf-examples/springwolf-amqp-example/build.gradle
+++ b/springwolf-examples/springwolf-amqp-example/build.gradle
@@ -20,7 +20,6 @@ dependencies {
 
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.amqp:spring-rabbit"
-    implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api"
     implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
 

--- a/springwolf-examples/springwolf-cloud-stream-example/build.gradle
+++ b/springwolf-examples/springwolf-cloud-stream-example/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.cloud:spring-cloud-stream"
     implementation "org.springframework.cloud:spring-cloud-stream-binder-kafka-streams"
-    implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api"
     implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
 

--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.kafka:spring-kafka"
     implementation "org.springframework.boot:spring-boot-starter-security"
-    implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api"
     implementation "org.javamoney:moneta:${javaMoneyMonetaVersion}"
     implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"

--- a/springwolf-plugins/springwolf-amqp-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-amqp-plugin/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation "org.springframework:spring-web"
     implementation "org.springframework.amqp:spring-rabbit"
 
-    implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api"
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/SpringWolfAmqpConfigProperties.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/SpringWolfAmqpConfigProperties.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.Nullable;
+import org.springframework.lang.Nullable;
 
 import static io.github.stavshamir.springwolf.SpringWolfAmqpConfigConstants.SPRINGWOLF_AMQP_CONFIG_PREFIX;
 

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScanner.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScanner.java
@@ -6,7 +6,6 @@ import com.asyncapi.v2.binding.operation.OperationBinding;
 import com.asyncapi.v2.binding.channel.amqp.AMQPChannelBinding;
 import com.asyncapi.v2.binding.message.amqp.AMQPMessageBinding;
 import com.asyncapi.v2.binding.operation.amqp.AMQPOperationBinding;
-import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import lombok.extern.slf4j.Slf4j;
@@ -89,7 +88,7 @@ public class MethodLevelRabbitListenerScanner extends AbstractMethodLevelListene
                 .is("routingKey")
                 .exchange(exchangeProperties)
                 .build();
-        return ImmutableMap.of("amqp", channelBinding);
+        return Map.of("amqp", channelBinding);
     }
 
     private String getExchangeName(RabbitListener annotation) {
@@ -110,13 +109,13 @@ public class MethodLevelRabbitListenerScanner extends AbstractMethodLevelListene
 
     @Override
     protected Map<String, ? extends OperationBinding> buildOperationBinding(RabbitListener annotation) {
-        return ImmutableMap.of("amqp", AMQPOperationBinding.builder().cc(getRoutingKeys(annotation)).build());
+        return Map.of("amqp", AMQPOperationBinding.builder().cc(getRoutingKeys(annotation)).build());
     }
 
     @Override
     protected Map<String, ? extends MessageBinding> buildMessageBinding(RabbitListener annotation) {
         // currently the feature to define amqp message binding is not implemented.
-        return ImmutableMap.of("amqp", new AMQPMessageBinding());
+        return Map.of("amqp", new AMQPMessageBinding());
     }
 
     private List<String> getRoutingKeys(RabbitListener annotation) {

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AmqpConsumerData.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AmqpConsumerData.java
@@ -3,11 +3,11 @@ package io.github.stavshamir.springwolf.asyncapi.types;
 import com.asyncapi.v2.binding.channel.amqp.AMQPChannelBinding;
 import com.asyncapi.v2.binding.message.amqp.AMQPMessageBinding;
 import com.asyncapi.v2.binding.operation.amqp.AMQPOperationBinding;
-import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import lombok.Builder;
 
 import java.util.Collections;
+import java.util.Map;
 
 public class AmqpConsumerData extends ConsumerData {
 
@@ -18,16 +18,16 @@ public class AmqpConsumerData extends ConsumerData {
 
         AMQPChannelBinding.ExchangeProperties exchangeProperties = new AMQPChannelBinding.ExchangeProperties();
         exchangeProperties.setName(exchangeName);
-        this.channelBinding = ImmutableMap.of("amqp", AMQPChannelBinding.builder()
+        this.channelBinding = Map.of("amqp", AMQPChannelBinding.builder()
                 .is("routingKey")
                 .exchange(exchangeProperties)
                 .build());
 
-        this.operationBinding = ImmutableMap.of("amqp", AMQPOperationBinding.builder()
+        this.operationBinding = Map.of("amqp", AMQPOperationBinding.builder()
                 .cc(Collections.singletonList(routingKey))
                 .build());
 
-        this.messageBinding = ImmutableMap.of("amqp", AMQPMessageBinding.builder()
+        this.messageBinding = Map.of("amqp", AMQPMessageBinding.builder()
                 .build());
 
         this.payloadType = payloadType;

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AmqpProducerData.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/AmqpProducerData.java
@@ -3,11 +3,11 @@ package io.github.stavshamir.springwolf.asyncapi.types;
 import com.asyncapi.v2.binding.channel.amqp.AMQPChannelBinding;
 import com.asyncapi.v2.binding.message.amqp.AMQPMessageBinding;
 import com.asyncapi.v2.binding.operation.amqp.AMQPOperationBinding;
-import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import lombok.Builder;
 
 import java.util.Collections;
+import java.util.Map;
 
 public class AmqpProducerData extends ProducerData {
 
@@ -18,16 +18,16 @@ public class AmqpProducerData extends ProducerData {
 
         AMQPChannelBinding.ExchangeProperties exchangeProperties = new AMQPChannelBinding.ExchangeProperties();
         exchangeProperties.setName(exchangeName);
-        this.channelBinding = ImmutableMap.of("amqp", AMQPChannelBinding.builder()
+        this.channelBinding = Map.of("amqp", AMQPChannelBinding.builder()
                 .is("routingKey")
                 .exchange(exchangeProperties)
                 .build());
 
-        this.operationBinding = ImmutableMap.of("amqp", AMQPOperationBinding.builder()
+        this.operationBinding = Map.of("amqp", AMQPOperationBinding.builder()
                 .cc(Collections.singletonList(routingKey))
                 .build());
 
-        this.messageBinding = ImmutableMap.of("amqp", AMQPMessageBinding.builder()
+        this.messageBinding = Map.of("amqp", AMQPMessageBinding.builder()
                 .build());
 
         this.payloadType = payloadType;

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScannerTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScannerTest.java
@@ -6,8 +6,6 @@ import com.asyncapi.v2.binding.message.amqp.AMQPMessageBinding;
 import com.asyncapi.v2.binding.operation.amqp.AMQPOperationBinding;
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
@@ -100,25 +98,25 @@ class MethodLevelRabbitListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("amqp", new AMQPMessageBinding()))
+                .bindings(Map.of("amqp", new AMQPMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("test-queue_publish_methodWithAnnotation")
-                .bindings(ImmutableMap.of("amqp", AMQPOperationBinding.builder()
+                .bindings(Map.of("amqp", AMQPOperationBinding.builder()
                         .cc(Collections.singletonList(QUEUE))
                         .build()))
                 .message(message)
                 .build();
 
         ChannelItem expectedChannelItem = ChannelItem.builder()
-                .bindings(ImmutableMap.of("amqp", channelBinding))
+                .bindings(Map.of("amqp", channelBinding))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannelItems)
-                .containsExactly(Maps.immutableEntry(QUEUE, expectedChannelItem));
+                .containsExactly(Map.entry(QUEUE, expectedChannelItem));
     }
 
     @Test
@@ -142,25 +140,25 @@ class MethodLevelRabbitListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("amqp", new AMQPMessageBinding()))
+                .bindings(Map.of("amqp", new AMQPMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("test-queue_publish_methodWithAnnotation1")
-                .bindings(ImmutableMap.of("amqp", AMQPOperationBinding.builder()
+                .bindings(Map.of("amqp", AMQPOperationBinding.builder()
                         .cc(Collections.singletonList(QUEUE))
                         .build()))
                 .message(message)
                 .build();
 
         ChannelItem expectedChannelItem = ChannelItem.builder()
-                .bindings(ImmutableMap.of("amqp", channelBinding))
+                .bindings(Map.of("amqp", channelBinding))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannelItems)
-                .containsExactly(Maps.immutableEntry(QUEUE, expectedChannelItem));
+                .containsExactly(Map.entry(QUEUE, expectedChannelItem));
     }
 
     @Test
@@ -181,25 +179,25 @@ class MethodLevelRabbitListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("amqp", new AMQPMessageBinding()))
+                .bindings(Map.of("amqp", new AMQPMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("test-queue_publish_methodWithAnnotation1")
-                .bindings(ImmutableMap.of("amqp", AMQPOperationBinding.builder()
+                .bindings(Map.of("amqp", AMQPOperationBinding.builder()
                         .cc(Collections.singletonList("key"))
                         .build()))
                 .message(message)
                 .build();
 
         ChannelItem expectedChannelItem = ChannelItem.builder()
-                .bindings(ImmutableMap.of("amqp", channelBinding))
+                .bindings(Map.of("amqp", channelBinding))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannelItems)
-                .containsExactly(Maps.immutableEntry(QUEUE, expectedChannelItem));
+                .containsExactly(Map.entry(QUEUE, expectedChannelItem));
     }
 
     @Test
@@ -220,25 +218,25 @@ class MethodLevelRabbitListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("amqp", new AMQPMessageBinding()))
+                .bindings(Map.of("amqp", new AMQPMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("binding-bean-queue_publish_methodWithAnnotation1")
-                .bindings(ImmutableMap.of("amqp", AMQPOperationBinding.builder()
+                .bindings(Map.of("amqp", AMQPOperationBinding.builder()
                         .cc(Collections.singletonList("binding-bean-key"))
                         .build()))
                 .message(message)
                 .build();
 
         ChannelItem expectedChannelItem = ChannelItem.builder()
-                .bindings(ImmutableMap.of("amqp", channelBinding))
+                .bindings(Map.of("amqp", channelBinding))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannelItems)
-                .containsExactly(Maps.immutableEntry("binding-bean-queue", expectedChannelItem));
+                .containsExactly(Map.entry("binding-bean-queue", expectedChannelItem));
     }
 
     @Test
@@ -276,25 +274,25 @@ class MethodLevelRabbitListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("amqp", new AMQPMessageBinding()))
+                .bindings(Map.of("amqp", new AMQPMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("test-queue_publish_methodWithAnnotation")
-                .bindings(ImmutableMap.of("amqp", AMQPOperationBinding.builder()
+                .bindings(Map.of("amqp", AMQPOperationBinding.builder()
                         .cc(Collections.singletonList(QUEUE))
                         .build()))
                 .message(message)
                 .build();
 
         ChannelItem expectedChannelItem = ChannelItem.builder()
-                .bindings(ImmutableMap.of("amqp", channelBinding))
+                .bindings(Map.of("amqp", channelBinding))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannelItems)
-                .containsExactly(Maps.immutableEntry(QUEUE, expectedChannelItem));
+                .containsExactly(Map.entry(QUEUE, expectedChannelItem));
     }
 
     private static class ClassWithoutRabbitListenerAnnotations {

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducerTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducerTest.java
@@ -4,7 +4,6 @@ import com.asyncapi.v2.binding.channel.amqp.AMQPChannelBinding;
 import com.asyncapi.v2.binding.operation.amqp.AMQPOperationBinding;
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
-import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.ChannelsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +33,7 @@ class SpringwolfAmqpProducerTest {
 
     @Test
     void send_defaultExchangeAndChannelNameAsRoutingKey() {
-        when(channelsService.getChannels()).thenReturn(ImmutableMap.of("channel-name", new ChannelItem()));
+        when(channelsService.getChannels()).thenReturn(Map.of("channel-name", new ChannelItem()));
 
         Map<String, Object> payload = new HashMap<>();
         springwolfAmqpProducer.send("channel-name", payload);
@@ -47,14 +46,14 @@ class SpringwolfAmqpProducerTest {
         AMQPChannelBinding.ExchangeProperties properties = new AMQPChannelBinding.ExchangeProperties();
         properties.setName("exchange-name");
         ChannelItem channelItem = ChannelItem.builder()
-                .bindings(ImmutableMap.of("amqp", AMQPChannelBinding.builder()
+                .bindings(Map.of("amqp", AMQPChannelBinding.builder()
                         .exchange(properties)
                         .build()))
                 .publish(Operation.builder()
-                        .bindings(ImmutableMap.of("amqp", new AMQPOperationBinding()))
+                        .bindings(Map.of("amqp", new AMQPOperationBinding()))
                         .build())
                 .build();
-        Map<String, ChannelItem> channels = ImmutableMap.of("channel-name", channelItem);
+        Map<String, ChannelItem> channels = Map.of("channel-name", channelItem);
         when(channelsService.getChannels()).thenReturn(channels);
 
         Map<String, Object> payload = new HashMap<>();
@@ -68,16 +67,16 @@ class SpringwolfAmqpProducerTest {
         AMQPChannelBinding.ExchangeProperties properties = new AMQPChannelBinding.ExchangeProperties();
         properties.setName("exchange-name");
         ChannelItem channelItem = ChannelItem.builder()
-                .bindings(ImmutableMap.of("amqp", AMQPChannelBinding.builder()
+                .bindings(Map.of("amqp", AMQPChannelBinding.builder()
                         .exchange(properties)
                         .build()))
                 .publish(Operation.builder()
-                        .bindings(ImmutableMap.of("amqp", AMQPOperationBinding.builder()
+                        .bindings(Map.of("amqp", AMQPOperationBinding.builder()
                                 .cc(Collections.singletonList("routing-key"))
                                 .build()))
                         .build())
                 .build();
-        Map<String, ChannelItem> channels = ImmutableMap.of("channel-name", channelItem);
+        Map<String, ChannelItem> channels = Map.of("channel-name", channelItem);
         when(channelsService.getChannels()).thenReturn(channels);
 
         Map<String, Object> payload = new HashMap<>();

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/build.gradle
@@ -27,7 +27,6 @@ dependencies {
 
     implementation "org.springframework.cloud:spring-cloud-stream"
 
-    implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api"
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScanner.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScanner.java
@@ -6,8 +6,6 @@ import com.asyncapi.v2._0_0.model.server.Server;
 import com.asyncapi.v2.binding.channel.ChannelBinding;
 import com.asyncapi.v2.binding.message.MessageBinding;
 import com.asyncapi.v2.binding.operation.OperationBinding;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import io.github.stavshamir.springwolf.asyncapi.scanners.beans.DefaultBeanMethodsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.bindings.EmptyChannelBinding;
@@ -68,7 +66,7 @@ public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
         String operationId = buildOperationId(beanData, channelName);
         ChannelItem channelItem = buildChannel(beanData, operationId);
 
-        return Maps.immutableEntry(channelName, channelItem);
+        return Map.entry(channelName, channelItem);
     }
 
     private ChannelItem buildChannel(FunctionalChannelBeanData beanData, String operationId) {
@@ -90,25 +88,25 @@ public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
                 .bindings(buildOperationBinding())
                 .build();
 
-        ImmutableMap<String, ? extends ChannelBinding> channelBinding = buildChannelBinding();
+        Map<String, ? extends ChannelBinding> channelBinding = buildChannelBinding();
         return beanData.getBeanType() == FunctionalChannelBeanData.BeanType.CONSUMER
                 ? ChannelItem.builder().bindings(channelBinding).publish(operation).build()
                 : ChannelItem.builder().bindings(channelBinding).subscribe(operation).build();
     }
 
-    private ImmutableMap<String, ? extends MessageBinding> buildMessageBinding() {
+    private Map<String, ? extends MessageBinding> buildMessageBinding() {
         String protocolName = getProtocolName();
-        return ImmutableMap.of(protocolName, new EmptyMessageBinding());
+        return Map.of(protocolName, new EmptyMessageBinding());
     }
 
-    private ImmutableMap<String, ? extends OperationBinding> buildOperationBinding() {
+    private Map<String, ? extends OperationBinding> buildOperationBinding() {
         String protocolName = getProtocolName();
-        return ImmutableMap.of(protocolName, new EmptyOperationBinding());
+        return Map.of(protocolName, new EmptyOperationBinding());
     }
 
-    private ImmutableMap<String, ? extends ChannelBinding> buildChannelBinding() {
+    private Map<String, ? extends ChannelBinding> buildChannelBinding() {
         String protocolName = getProtocolName();
-        return ImmutableMap.of(protocolName, new EmptyChannelBinding());
+        return Map.of(protocolName, new EmptyChannelBinding());
     }
 
     private String getProtocolName() {

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/FunctionalChannelBeanData.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/FunctionalChannelBeanData.java
@@ -1,6 +1,5 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.cloudstream;
 
-import com.google.common.collect.ImmutableSet;
 import lombok.Data;
 
 import java.lang.reflect.Method;
@@ -29,12 +28,12 @@ class FunctionalChannelBeanData {
 
         if (Consumer.class.isAssignableFrom(returnType)) {
             Class<?> payloadType = getReturnTypeGenerics(methodBean).get(0);
-            return ImmutableSet.of(ofConsumer(methodBean.getName(), payloadType));
+            return Set.of(ofConsumer(methodBean.getName(), payloadType));
         }
 
         if (Supplier.class.isAssignableFrom(returnType)) {
             Class<?> payloadType = getReturnTypeGenerics(methodBean).get(0);
-            return ImmutableSet.of(ofSupplier(methodBean.getName(), payloadType));
+            return Set.of(ofSupplier(methodBean.getName(), payloadType));
         }
 
         if (Function.class.isAssignableFrom(returnType)) {
@@ -52,13 +51,13 @@ class FunctionalChannelBeanData {
         return new FunctionalChannelBeanData(name, payloadType, BeanType.SUPPLIER, name + "-out-0");
     }
 
-    private static ImmutableSet<FunctionalChannelBeanData> fromFunctionBean(Method methodBean) {
+    private static Set<FunctionalChannelBeanData> fromFunctionBean(Method methodBean) {
         String name = methodBean.getName();
 
         Class<?> inputType = getReturnTypeGenerics(methodBean).get(0);
         Class<?> outputType = getReturnTypeGenerics(methodBean).get(1);
 
-        return ImmutableSet.of(
+        return Set.of(
                 ofConsumer(name, inputType),
                 ofSupplier(name, outputType)
         );

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScannerTest.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScannerTest.java
@@ -4,8 +4,6 @@ import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
 import com.asyncapi.v2._0_0.model.info.Info;
 import com.asyncapi.v2._0_0.model.server.Server;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import io.github.stavshamir.springwolf.asyncapi.scanners.beans.DefaultBeanMethodsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ConfigurationClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.bindings.EmptyChannelBinding;
@@ -70,7 +68,7 @@ class CloudStreamFunctionChannelsScannerTest {
         BindingProperties testConsumerInBinding = new BindingProperties();
         String topicName = "test-consumer-input-topic";
         testConsumerInBinding.setDestination(topicName);
-        when(bindingServiceProperties.getBindings()).thenReturn(ImmutableMap.of(
+        when(bindingServiceProperties.getBindings()).thenReturn(Map.of(
                 "testConsumer-in-0", testConsumerInBinding
         ));
 
@@ -83,23 +81,23 @@ class CloudStreamFunctionChannelsScannerTest {
                 .title(String.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(String.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("kafka", new EmptyMessageBinding()))
+                .bindings(Map.of("kafka", new EmptyMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
-                .bindings(ImmutableMap.of("kafka", new EmptyOperationBinding()))
+                .bindings(Map.of("kafka", new EmptyOperationBinding()))
                 .description("Auto-generated description")
                 .operationId("test-consumer-input-topic_publish_testConsumer")
                 .message(message)
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new EmptyChannelBinding()))
+                .bindings(Map.of("kafka", new EmptyChannelBinding()))
                 .publish(operation)
                 .build();
 
         assertThat(channels)
-                .containsExactly(Maps.immutableEntry(topicName, expectedChannel));
+                .containsExactly(Map.entry(topicName, expectedChannel));
     }
 
 
@@ -109,7 +107,7 @@ class CloudStreamFunctionChannelsScannerTest {
         BindingProperties testSupplierOutBinding = new BindingProperties();
         String topicName = "test-supplier-output-topic";
         testSupplierOutBinding.setDestination(topicName);
-        when(bindingServiceProperties.getBindings()).thenReturn(ImmutableMap.of(
+        when(bindingServiceProperties.getBindings()).thenReturn(Map.of(
                 "testSupplier-out-0", testSupplierOutBinding
         ));
 
@@ -122,23 +120,23 @@ class CloudStreamFunctionChannelsScannerTest {
                 .title(String.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(String.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("kafka", new EmptyMessageBinding()))
+                .bindings(Map.of("kafka", new EmptyMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
-                .bindings(ImmutableMap.of("kafka", new EmptyOperationBinding()))
+                .bindings(Map.of("kafka", new EmptyOperationBinding()))
                 .description("Auto-generated description")
                 .operationId("test-supplier-output-topic_subscribe_testSupplier")
                 .message(message)
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new EmptyChannelBinding()))
+                .bindings(Map.of("kafka", new EmptyChannelBinding()))
                 .subscribe(operation)
                 .build();
 
         assertThat(channels)
-                .containsExactly(Maps.immutableEntry(topicName, expectedChannel));
+                .containsExactly(Map.entry(topicName, expectedChannel));
     }
 
     @Test
@@ -153,7 +151,7 @@ class CloudStreamFunctionChannelsScannerTest {
         BindingProperties testFunctionOutBinding = new BindingProperties();
         testFunctionOutBinding.setDestination(outputTopicName)
         ;
-        when(bindingServiceProperties.getBindings()).thenReturn(ImmutableMap.of(
+        when(bindingServiceProperties.getBindings()).thenReturn(Map.of(
                 "testFunction-in-0", testFunctionInBinding,
                 "testFunction-out-0", testFunctionOutBinding
         ));
@@ -167,18 +165,18 @@ class CloudStreamFunctionChannelsScannerTest {
                 .title(Integer.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(Integer.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("kafka", new EmptyMessageBinding()))
+                .bindings(Map.of("kafka", new EmptyMessageBinding()))
                 .build();
 
         Operation subscribeOperation = Operation.builder()
-                .bindings(ImmutableMap.of("kafka", new EmptyOperationBinding()))
+                .bindings(Map.of("kafka", new EmptyOperationBinding()))
                 .description("Auto-generated description")
                 .operationId("test-out-topic_subscribe_testFunction")
                 .message(subscribeMessage)
                 .build();
 
         ChannelItem subscribeChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new EmptyChannelBinding()))
+                .bindings(Map.of("kafka", new EmptyChannelBinding()))
                 .subscribe(subscribeOperation)
                 .build();
 
@@ -188,24 +186,24 @@ class CloudStreamFunctionChannelsScannerTest {
                 .title(String.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(String.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("kafka", new EmptyMessageBinding()))
+                .bindings(Map.of("kafka", new EmptyMessageBinding()))
                 .build();
 
         Operation publishOperation = Operation.builder()
-                .bindings(ImmutableMap.of("kafka", new EmptyOperationBinding()))
+                .bindings(Map.of("kafka", new EmptyOperationBinding()))
                 .description("Auto-generated description")
                 .operationId("test-in-topic_publish_testFunction")
                 .message(publishMessage)
                 .build();
 
         ChannelItem publishChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new EmptyChannelBinding()))
+                .bindings(Map.of("kafka", new EmptyChannelBinding()))
                 .publish(publishOperation)
                 .build();
 
         assertThat(channels).contains(
-                Maps.immutableEntry(inputTopicName, publishChannel),
-                Maps.immutableEntry(outputTopicName, subscribeChannel)
+                Map.entry(inputTopicName, publishChannel),
+                Map.entry(outputTopicName, subscribeChannel)
         );
     }
 
@@ -221,7 +219,7 @@ class CloudStreamFunctionChannelsScannerTest {
         BindingProperties testFunctionOutBinding = new BindingProperties();
         testFunctionOutBinding.setDestination(outputTopicName)
         ;
-        when(bindingServiceProperties.getBindings()).thenReturn(ImmutableMap.of(
+        when(bindingServiceProperties.getBindings()).thenReturn(Map.of(
                 "kStreamTestFunction-in-0", testFunctionInBinding,
                 "kStreamTestFunction-out-0", testFunctionOutBinding
         ));
@@ -235,18 +233,18 @@ class CloudStreamFunctionChannelsScannerTest {
                 .title(Integer.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(Integer.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("kafka", new EmptyMessageBinding()))
+                .bindings(Map.of("kafka", new EmptyMessageBinding()))
                 .build();
 
         Operation subscribeOperation = Operation.builder()
-                .bindings(ImmutableMap.of("kafka", new EmptyOperationBinding()))
+                .bindings(Map.of("kafka", new EmptyOperationBinding()))
                 .description("Auto-generated description")
                 .operationId("test-out-topic_subscribe_kStreamTestFunction")
                 .message(subscribeMessage)
                 .build();
 
         ChannelItem subscribeChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new EmptyChannelBinding()))
+                .bindings(Map.of("kafka", new EmptyChannelBinding()))
                 .subscribe(subscribeOperation)
                 .build();
 
@@ -256,24 +254,24 @@ class CloudStreamFunctionChannelsScannerTest {
                 .title(String.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(String.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("kafka", new EmptyMessageBinding()))
+                .bindings(Map.of("kafka", new EmptyMessageBinding()))
                 .build();
 
         Operation publishOperation = Operation.builder()
-                .bindings(ImmutableMap.of("kafka", new EmptyOperationBinding()))
+                .bindings(Map.of("kafka", new EmptyOperationBinding()))
                 .description("Auto-generated description")
                 .operationId("test-in-topic_publish_kStreamTestFunction")
                 .message(publishMessage)
                 .build();
 
         ChannelItem publishChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new EmptyChannelBinding()))
+                .bindings(Map.of("kafka", new EmptyChannelBinding()))
                 .publish(publishOperation)
                 .build();
 
         assertThat(channels).contains(
-                Maps.immutableEntry(inputTopicName, publishChannel),
-                Maps.immutableEntry(outputTopicName, subscribeChannel)
+                Map.entry(inputTopicName, publishChannel),
+                Map.entry(outputTopicName, subscribeChannel)
         );
     }
 

--- a/springwolf-plugins/springwolf-kafka-plugin/README.md
+++ b/springwolf-plugins/springwolf-kafka-plugin/README.md
@@ -55,7 +55,7 @@ public class AsyncApiConfiguration {
         // you will need to build a ProducerData and register it in the docket (line 65)
         ProducerData exampleProducerData = ProducerData.builder()
                 .channelName("example-producer-topic")
-                .binding(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .binding(Map.of("kafka", new KafkaOperationBinding()))
                 .payloadType(ExamplePayloadDto.class)
                 .build();
 

--- a/springwolf-plugins/springwolf-kafka-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-kafka-plugin/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     implementation "org.springframework.kafka:spring-kafka"
     implementation "io.swagger.core.v3:swagger-models:${swaggerCoreVersion}"
 
-    implementation "com.google.guava:guava:${guavaVersion}"
     implementation "org.slf4j:slf4j-api"
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/SpringWolfKafkaConfigProperties.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/SpringWolfKafkaConfigProperties.java
@@ -8,7 +8,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.Nullable;
+import org.springframework.lang.Nullable;
 
 import static io.github.stavshamir.springwolf.SpringWolfKafkaConfigConstants.SPRINGWOLF_KAFKA_CONFIG_PREFIX;
 

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/KafkaListenerUtil.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/KafkaListenerUtil.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.util.StringValueResolver;
 
-import javax.annotation.Nullable;
+import org.springframework.lang.Nullable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/KafkaListenerUtil.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/KafkaListenerUtil.java
@@ -8,7 +8,6 @@ import com.asyncapi.v2.binding.operation.OperationBinding;
 import com.asyncapi.v2.binding.operation.kafka.KafkaOperationBinding;
 import com.asyncapi.v2.schema.Schema;
 import com.asyncapi.v2.schema.Type;
-import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.util.StringValueResolver;
@@ -33,7 +32,7 @@ public class KafkaListenerUtil {
     }
 
     public static Map<String, ? extends ChannelBinding> buildChannelBinding() {
-        return ImmutableMap.of("kafka", new KafkaChannelBinding());
+        return Map.of("kafka", new KafkaChannelBinding());
     }
 
     public static Map<String, ? extends OperationBinding> buildOperationBinding(KafkaListener annotation, StringValueResolver resolver) {
@@ -42,7 +41,7 @@ public class KafkaListenerUtil {
 
         KafkaOperationBinding binding = new KafkaOperationBinding();
         binding.setGroupId(groupIdSchema);
-        return ImmutableMap.of("kafka", binding);
+        return Map.of("kafka", binding);
     }
 
     @Nullable
@@ -82,6 +81,6 @@ public class KafkaListenerUtil {
     }
 
     public static Map<String, ? extends MessageBinding> buildMessageBinding() {
-        return ImmutableMap.of("kafka", new KafkaMessageBinding());
+        return Map.of("kafka", new KafkaMessageBinding());
     }
 }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/KafkaConsumerData.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/KafkaConsumerData.java
@@ -3,19 +3,20 @@ package io.github.stavshamir.springwolf.asyncapi.types;
 import com.asyncapi.v2.binding.channel.kafka.KafkaChannelBinding;
 import com.asyncapi.v2.binding.message.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.operation.kafka.KafkaOperationBinding;
-import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import lombok.Builder;
+
+import java.util.Map;
 
 public class KafkaConsumerData extends ConsumerData {
     @Builder(builderMethodName = "kafkaConsumerDataBuilder")
     public KafkaConsumerData(String topicName, Class<?> payloadType, String description, AsyncHeaders headers) {
         this.channelName = topicName;
         this.description = description;
-        this.channelBinding = ImmutableMap.of("kafka", new KafkaChannelBinding());
+        this.channelBinding = Map.of("kafka", new KafkaChannelBinding());
         this.payloadType = payloadType;
         this.headers = headers != null ? headers : this.headers;
-        this.operationBinding = ImmutableMap.of("kafka", new KafkaOperationBinding());
-        this.messageBinding = ImmutableMap.of("kafka", new KafkaMessageBinding());
+        this.operationBinding = Map.of("kafka", new KafkaOperationBinding());
+        this.messageBinding = Map.of("kafka", new KafkaMessageBinding());
     }
 }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/KafkaProducerData.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/KafkaProducerData.java
@@ -3,9 +3,10 @@ package io.github.stavshamir.springwolf.asyncapi.types;
 import com.asyncapi.v2.binding.channel.kafka.KafkaChannelBinding;
 import com.asyncapi.v2.binding.message.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.operation.kafka.KafkaOperationBinding;
-import com.google.common.collect.ImmutableMap;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import lombok.Builder;
+
+import java.util.Map;
 
 public class KafkaProducerData extends ProducerData {
 
@@ -13,11 +14,11 @@ public class KafkaProducerData extends ProducerData {
     public KafkaProducerData(String topicName, Class<?> payloadType, String description, AsyncHeaders headers) {
         this.channelName = topicName;
         this.description = description;
-        this.channelBinding = ImmutableMap.of("kafka", new KafkaChannelBinding());
+        this.channelBinding = Map.of("kafka", new KafkaChannelBinding());
         this.payloadType = payloadType;
         this.headers = headers != null ? headers : this.headers;
-        this.operationBinding = ImmutableMap.of("kafka", new KafkaOperationBinding());
-        this.messageBinding = ImmutableMap.of("kafka", new KafkaMessageBinding());
+        this.operationBinding = Map.of("kafka", new KafkaOperationBinding());
+        this.messageBinding = Map.of("kafka", new KafkaMessageBinding());
     }
 
 }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeadersForSpringKafkaBuilder.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeadersForSpringKafkaBuilder.java
@@ -4,8 +4,6 @@ import org.springframework.kafka.support.mapping.AbstractJavaTypeMapper;
 
 import java.util.List;
 
-import static com.google.common.collect.ImmutableList.of;
-
 public class AsyncHeadersForSpringKafkaBuilder {
     private final AsyncHeaders headers;
 
@@ -18,7 +16,7 @@ public class AsyncHeadersForSpringKafkaBuilder {
     }
 
     public AsyncHeadersForSpringKafkaBuilder withTypeIdHeader(String exampleTypeId) {
-        return withTypeIdHeader(exampleTypeId, of(exampleTypeId));
+        return withTypeIdHeader(exampleTypeId, List.of(exampleTypeId));
     }
 
     public AsyncHeadersForSpringKafkaBuilder withTypeIdHeader(String exampleTypeId, List<String> types) {

--- a/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScannerTest.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelKafkaListenerScannerTest.java
@@ -5,9 +5,6 @@ import com.asyncapi.v2.binding.message.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.operation.kafka.KafkaOperationBinding;
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
@@ -63,7 +60,7 @@ class ClassLevelKafkaListenerScannerTest {
     @Test
     void scan_componentWithMultipleKafkaListenersAndHandlers() {
         // Given multiple @KafkaListener annotated classes with method(s) annotated with @KafkaHandler
-        ImmutableSet<Class<?>> classesToScan = ImmutableSet.of(
+        Set<Class<?>> classesToScan = Set.of(
                 KafkaListenerClassWithOneKafkaHandler.class,
                 KafkaListenerClassWithMultipleKafkaHandler.class
         );
@@ -78,7 +75,7 @@ class ClassLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleFoo.class.getSimpleName()))
-                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .bindings(Map.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Message barMessage = Message.builder()
@@ -86,23 +83,23 @@ class ClassLevelKafkaListenerScannerTest {
                 .title(SimpleBar.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleBar.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleBar.class.getSimpleName()))
-                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .bindings(Map.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("KafkaListenerClassWithMultipleKafkaHandler_publish")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .message(toMessageObjectOrComposition(ImmutableSet.of(fooMessage, barMessage)))
+                .bindings(Map.of("kafka", new KafkaOperationBinding()))
+                .message(toMessageObjectOrComposition(Set.of(fooMessage, barMessage)))
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                .bindings(Map.of("kafka", new KafkaChannelBinding()))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry(TOPIC, expectedChannel));
+                .containsExactly(Map.entry(TOPIC, expectedChannel));
     }
 
     @Test
@@ -142,23 +139,23 @@ class ClassLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleFoo.class.getSimpleName()))
-                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .bindings(Map.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("KafkaListenerClassWithOneKafkaHandler_publish")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .bindings(Map.of("kafka", new KafkaOperationBinding()))
                 .message(message)
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                .bindings(Map.of("kafka", new KafkaChannelBinding()))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry(TOPIC, expectedChannel));
+                .containsExactly(Map.entry(TOPIC, expectedChannel));
     }
 
     @Test
@@ -175,7 +172,7 @@ class ClassLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleFoo.class.getSimpleName()))
-                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .bindings(Map.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Message barMessage = Message.builder()
@@ -183,23 +180,23 @@ class ClassLevelKafkaListenerScannerTest {
                 .title(SimpleBar.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleBar.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleBar.class.getSimpleName()))
-                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .bindings(Map.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("KafkaListenerClassWithMultipleKafkaHandler_publish")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
-                .message(toMessageObjectOrComposition(ImmutableSet.of(fooMessage, barMessage)))
+                .bindings(Map.of("kafka", new KafkaOperationBinding()))
+                .message(toMessageObjectOrComposition(Set.of(fooMessage, barMessage)))
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                .bindings(Map.of("kafka", new KafkaChannelBinding()))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry(TOPIC, expectedChannel));
+                .containsExactly(Map.entry(TOPIC, expectedChannel));
     }
 
     @Test
@@ -217,23 +214,23 @@ class ClassLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("SpringKafkaDefaultHeaders-" + SimpleFoo.class.getSimpleName()))
-                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .bindings(Map.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("KafkaListenerClassWithKafkaHandlerWithBatchPayload_publish")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .bindings(Map.of("kafka", new KafkaOperationBinding()))
                 .message(message)
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                .bindings(Map.of("kafka", new KafkaChannelBinding()))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry(TOPIC, expectedChannel));
+                .containsExactly(Map.entry(TOPIC, expectedChannel));
     }
 
 

--- a/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelKafkaListenerScannerTest.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelKafkaListenerScannerTest.java
@@ -6,8 +6,6 @@ import com.asyncapi.v2.binding.message.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.operation.kafka.KafkaOperationBinding;
 import com.asyncapi.v2._0_0.model.channel.ChannelItem;
 import com.asyncapi.v2._0_0.model.channel.operation.Operation;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
@@ -81,23 +79,23 @@ class MethodLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .bindings(Map.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("test-topic_publish_methodWithAnnotation")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .bindings(Map.of("kafka", new KafkaOperationBinding()))
                 .message(message)
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                .bindings(Map.of("kafka", new KafkaChannelBinding()))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry(TOPIC, expectedChannel));
+                .containsExactly(Map.entry(TOPIC, expectedChannel));
     }
 
     @Test
@@ -114,23 +112,23 @@ class MethodLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .bindings(Map.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("test-topic_publish_methodWithAnnotation1")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .bindings(Map.of("kafka", new KafkaOperationBinding()))
                 .message(message)
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                .bindings(Map.of("kafka", new KafkaChannelBinding()))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry(TOPIC, expectedChannel));
+                .containsExactly(Map.entry(TOPIC, expectedChannel));
     }
 
     @Test
@@ -182,23 +180,23 @@ class MethodLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .bindings(Map.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("test-topic_publish_methodWithAnnotation")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .bindings(Map.of("kafka", new KafkaOperationBinding()))
                 .message(message)
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                .bindings(Map.of("kafka", new KafkaChannelBinding()))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry(TOPIC, expectedChannel));
+                .containsExactly(Map.entry(TOPIC, expectedChannel));
     }
 
     @Test
@@ -215,23 +213,23 @@ class MethodLevelKafkaListenerScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
-                .bindings(ImmutableMap.of("kafka", new KafkaMessageBinding()))
+                .bindings(Map.of("kafka", new KafkaMessageBinding()))
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
                 .operationId("test-topic_publish_methodWithAnnotation")
-                .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
+                .bindings(Map.of("kafka", new KafkaOperationBinding()))
                 .message(message)
                 .build();
 
         ChannelItem expectedChannel = ChannelItem.builder()
-                .bindings(ImmutableMap.of("kafka", new KafkaChannelBinding()))
+                .bindings(Map.of("kafka", new KafkaChannelBinding()))
                 .publish(operation)
                 .build();
 
         assertThat(actualChannels)
-                .containsExactly(Maps.immutableEntry(TOPIC, expectedChannel));
+                .containsExactly(Map.entry(TOPIC, expectedChannel));
     }
 
     private static class ClassWithoutKafkaListenerAnnotations {


### PR DESCRIPTION
The Guava library is really convenient, but over time, most of its features became part
of the vanilla Java.

This PR removes the usage of Guava, replacing it by Java equivalents.