### PR TITLE
replace commons.lang3.StringUtils with springframework.util.StringUtils

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtil.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtil.java
@@ -6,7 +6,7 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProcessedOperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaderSchema;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
-import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.util.StringValueResolver;
 
 import java.lang.reflect.Method;
@@ -58,7 +58,7 @@ class AsyncAnnotationScannerUtil {
                 .stream()
                 .map(AsyncOperation.Headers.Header::description)
                 .map(resolver::resolveStringValue)
-                .filter(StringUtils::isNotBlank)
+                .filter(StringUtils::hasText)
                 .sorted()
                 .findFirst()
                 .orElse(null);

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/AbstractAnnotatedClassScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/AbstractAnnotatedClassScanner.java
@@ -2,11 +2,11 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.classes;
 
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.util.StringUtils;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;
@@ -28,7 +28,7 @@ public abstract class AbstractAnnotatedClassScanner<T extends Annotation> implem
     @Override
     public Set<Class<?>> scan() {
         String basePackage = asyncApiDocketService.getAsyncApiDocket().getBasePackage();
-        if (StringUtils.isBlank(basePackage)) {
+        if (!StringUtils.hasText(basePackage)) {
             throw new IllegalArgumentException("Base package must not be blank");
         }
 


### PR DESCRIPTION
Replaces usage of `org.apache.commons.lang3.StringUtils` with `org.springframework.util.StringUtils`.   

`org.apache.commons:commons-lang3` is not needed anymore and could be removed from dependency management (currently not declared explicityl but picked up transiently)