### PR TITLE
feat: Added support for Message description

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
@@ -11,6 +11,7 @@ import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.HeaderReference;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
 
@@ -94,10 +95,13 @@ public abstract class AbstractOperationDataScanner implements ChannelsScanner {
         String modelName = this.getSchemaService().register(payloadType);
         String headerModelName = this.getSchemaService().register(operationData.getHeaders());
 
+        Schema schema = payloadType.getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+        String description = schema != null ? schema.description() : null;
+
         return Message.builder()
                 .name(payloadType.getName())
                 .title(modelName)
-                // FIXME: Add support for Message Description
+                .description(description)
                 .payload(PayloadReference.fromModelName(modelName))
                 .headers(HeaderReference.fromModelName(headerModelName))
                 .bindings(operationData.getMessageBinding())

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
@@ -109,7 +109,6 @@ class DefaultAsyncApiServiceTest {
         final ChannelItem channel = actualChannels.get("producer-topic");
         assertThat(channel.getSubscribe()).isNotNull();
         final Message message = (Message) channel.getSubscribe().getMessage();
-        // Message description is not supported yet
         assertThat(message.getDescription()).isNull();
         assertThat(message.getBindings()).isEqualTo(ImmutableMap.of("kafka", new KafkaMessageBinding()));
     }
@@ -125,7 +124,6 @@ class DefaultAsyncApiServiceTest {
         final ChannelItem channel = actualChannels.get("consumer-topic");
         assertThat(channel.getPublish()).isNotNull();
         final Message message = (Message) channel.getPublish().getMessage();
-        // Message description is not supported yet
         assertThat(message.getDescription()).isNull();
         assertThat(message.getBindings()).isEqualTo(ImmutableMap.of("kafka", new KafkaMessageBinding()));
     }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerTest.java
@@ -17,6 +17,7 @@ import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.schemas.DefaultSchemasService;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,14 +66,14 @@ class ConsumerOperationDataScannerTest {
         assertThat(consumerChannels)
                 .containsKey(channelName);
 
+        String messageDescription = "Example Payload DTO Description";
         Operation operation = Operation.builder()
                 .description(description)
                 .operationId("example-consumer-topic-foo1_publish")
                 .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .message(Message.builder()
                         .name(ExamplePayloadDto.class.getName())
-                        // Message description is not supported yet
-//                        .description(description)
+                        .description(messageDescription)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
@@ -142,11 +143,12 @@ class ConsumerOperationDataScannerTest {
                 .hasSize(1)
                 .containsKey(channelName);
 
+        String messageDescription1 = "Example Payload DTO Description";
+        String messageDescription2 = "Another Example Payload DTO Description";
         Set<Message> messages = ImmutableSet.of(
                 Message.builder()
                         .name(ExamplePayloadDto.class.getName())
-                        // Message description is not supported yet
-//                        .description(description1)
+                        .description(messageDescription1)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
@@ -154,8 +156,7 @@ class ConsumerOperationDataScannerTest {
                         .build(),
                 Message.builder()
                         .name(AnotherExamplePayloadDto.class.getName())
-                        // Message description is not supported yet
-//                        .description(description2)
+                        .description(messageDescription2)
                         .title(AnotherExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(AnotherExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_USED.getSchemaName()))
@@ -190,10 +191,12 @@ class ConsumerOperationDataScannerTest {
         when(asyncApiDocketService.getAsyncApiDocket()).thenReturn(asyncApiDocket);
     }
 
+    @Schema(description = "Example Payload DTO Description")
     static class ExamplePayloadDto {
         private String foo;
     }
 
+    @Schema(description = "Another Example Payload DTO Description")
     static class AnotherExamplePayloadDto {
         private String bar;
     }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerTest.java
@@ -17,6 +17,7 @@ import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.schemas.DefaultSchemasService;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,14 +66,14 @@ class ProducerOperationDataScannerTest {
         assertThat(producerChannels)
                 .containsKey(channelName);
 
+        String messageDescription1 = "Example Payload DTO Description";
         Operation operation = Operation.builder()
                 .description(description)
                 .operationId("example-producer-topic-foo1_subscribe")
                 .bindings(ImmutableMap.of("kafka", new KafkaOperationBinding()))
                 .message(Message.builder()
                         .name(ExamplePayloadDto.class.getName())
-                        // Message description is not supported yet
-//                        .description(description)
+                        .description(messageDescription1)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
@@ -142,11 +143,12 @@ class ProducerOperationDataScannerTest {
                 .hasSize(1)
                 .containsKey(channelName);
 
+        String messageDescription1 = "Example Payload DTO Description";
+        String messageDescription2 = "Another Example Payload DTO Description";
         Set<Message> messages = ImmutableSet.of(
                 Message.builder()
                         .name(ExamplePayloadDto.class.getName())
-                        // Message description is not supported yet
-//                        .description(description1)
+                        .description(messageDescription1)
                         .title(ExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(ExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
@@ -154,8 +156,7 @@ class ProducerOperationDataScannerTest {
                         .build(),
                 Message.builder()
                         .name(AnotherExamplePayloadDto.class.getName())
-                        // Message description is not supported yet
-//                        .description(description2)
+                        .description(messageDescription2)
                         .title(AnotherExamplePayloadDto.class.getSimpleName())
                         .payload(PayloadReference.fromModelName(AnotherExamplePayloadDto.class.getSimpleName()))
                         .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_USED.getSchemaName()))
@@ -189,12 +190,13 @@ class ProducerOperationDataScannerTest {
         when(asyncApiDocketService.getAsyncApiDocket()).thenReturn(asyncApiDocket);
     }
 
+    @Schema(description = "Example Payload DTO Description")
     static class ExamplePayloadDto {
         private String foo;
     }
 
+    @Schema(description = "Another Example Payload DTO Description")
     static class AnotherExamplePayloadDto {
         private String bar;
     }
-
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
@@ -10,6 +10,7 @@ import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.HeaderReference;
 import io.github.stavshamir.springwolf.schemas.DefaultSchemasService;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Test;
@@ -66,8 +67,7 @@ class AsyncListenerAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                // Message description is not supported yet
-//                .description("test channel operation description")
+                .description("SimpleFoo Message Description")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName(AsyncHeaders.NOT_DOCUMENTED.getSchemaName()))
                 .bindings(EMPTY_MAP)
@@ -101,8 +101,7 @@ class AsyncListenerAnnotationScannerTest {
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                // Message description is not supported yet
-//                .description("description")
+                .description("SimpleFoo Message Description")
                 .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
                 .headers(HeaderReference.fromModelName("TestSchema"))
                 .bindings(EMPTY_MAP)
@@ -144,8 +143,7 @@ class AsyncListenerAnnotationScannerTest {
                 .description("test-channel-1-description")
                 .operationId("test-channel-1_publish")
                 .bindings(EMPTY_MAP)
-                // Message description is not supported yet
-                .message(builder/*.description("test-channel-1-description")*/.build())
+                .message(builder.description("SimpleFoo Message Description").build())
                 .build();
 
         ChannelItem expectedChannel1 = ChannelItem.builder()
@@ -157,8 +155,7 @@ class AsyncListenerAnnotationScannerTest {
                 .description("test-channel-2-description")
                 .operationId("test-channel-2_publish")
                 .bindings(EMPTY_MAP)
-                // Message description is not supported yet
-                .message(builder/*.description("test-channel-2-description")*/.build())
+                .message(builder.description("SimpleFoo Message Description").build())
                 .build();
 
         ChannelItem expectedChannel2 = ChannelItem.builder()
@@ -228,6 +225,7 @@ class AsyncListenerAnnotationScannerTest {
 
     @Data
     @NoArgsConstructor
+    @Schema(description = "SimpleFoo Message Description")
     private static class SimpleFoo {
         private String s;
         private boolean b;

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -111,6 +111,7 @@
           "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
           "name" : "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
           "title" : "AnotherPayloadDto",
+          "description" : "Another payload model",
           "payload" : {
             "$ref" : "#/components/schemas/AnotherPayloadDto"
           },
@@ -149,6 +150,7 @@
           "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
           "name" : "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
           "title" : "AnotherPayloadDto",
+          "description" : "Another payload model",
           "payload" : {
             "$ref" : "#/components/schemas/AnotherPayloadDto"
           },
@@ -193,6 +195,7 @@
           "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
           "name" : "io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto",
           "title" : "ExamplePayloadDto",
+          "description" : "Example payload model",
           "payload" : {
             "$ref" : "#/components/schemas/ExamplePayloadDto"
           },

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -70,6 +70,7 @@
           "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
           "name" : "io.github.stavshamir.springwolf.example.kafka.dtos.ExamplePayloadDto",
           "title" : "ExamplePayloadDto",
+          "description" : "Example payload model",
           "payload" : {
             "$ref" : "#/components/schemas/ExamplePayloadDto"
           },
@@ -102,6 +103,7 @@
           "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
           "name" : "io.github.stavshamir.springwolf.example.kafka.dtos.AnotherPayloadDto",
           "title" : "AnotherPayloadDto",
+          "description" : "Another payload model",
           "payload" : {
             "$ref" : "#/components/schemas/AnotherPayloadDto"
           },
@@ -242,6 +244,7 @@
           "schemaFormat" : "application/vnd.oai.openapi+json;version=3.0.0",
           "name" : "io.github.stavshamir.springwolf.example.kafka.dtos.NestedPayloadDto",
           "title" : "NestedPayloadDto",
+          "description" : "Payload model with nested complex types",
           "payload" : {
             "$ref" : "#/components/schemas/NestedPayloadDto"
           },


### PR DESCRIPTION
While working at https://github.com/springwolf/springwolf-core/pull/189 we found out that the provided Message description was, in fact, the one associated to the Operation. As a result we decided to fully remove the description until we could fix it.

This PR adds support for Message description.

Any `Message` object, annotated with `@Schema` will use the annotation `description` value, as the Message description.

The https://www.springwolf.dev/docs/configuration/documenting-schemas documentation is already stating this scenario, so I don't think we need further documentation updates.