### PR TITLE
chore: dependency management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+    // include dependency versions from explicit dependencies.gradle file
+    apply from: 'dependencies.gradle'
+}
+
+plugins {
+    id 'ca.cutterslade.analyze' version '1.9.1'
+
+    id 'io.spring.dependency-management' version '1.1.0'  apply(false)
+    id 'org.springframework.boot' version '3.1.0'  apply(false)
+}
+
 allprojects {
     apply plugin: 'java'
 
@@ -16,30 +28,4 @@ allprojects {
 
         mavenCentral()
     }
-}
-
-ext {
-    // dependencies sorted alphabetically
-    assertjVersion = '3.24.2'
-
-    asyncApiCoreVersion = '1.0.0-EAP-2'
-
-    awaitabilityVersion = '4.2.0'
-
-    commonsIoVersion = '2.12.0'
-
-    javaMoneyMonetaVersion = '1.4.2'
-
-    jsonAssertVersion = '1.5.1'
-
-    junitJupiterVersion = '5.9.3'
-    junitPlatformVersion = '1.9.3'
-
-    lombokVersion = '1.18.28'
-
-    swaggerInflectorVersion = '2.0.9'
-    swaggerCoreVersion = '2.2.11'
-    swaggerParserVersion = '2.1.15'
-
-    testcontainersVersion = '1.18.3'
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,53 @@
+/**
+ * Explicit dependencies file to share artifact versions between subprojects.
+ * This approach is compatible with dependabot.
+ * (see: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#gradle)
+ *
+ * Naming strategy.
+ * There is no fixed rule for variable naming but there is a recommendation (which is not always appropriate).
+ * For most cases the following naming rule applies:
+ *  - use the artifactId
+ *  - split the artifactId by hyphens
+ *  - keep the first part of the splitted artifactId lowerCase
+ *  - add the remaining parts upperCase
+ *  - add a 'Version' suffix
+ *
+ *  e.g.: com.asyncapi:asyncapi-core' will be 'asyncapiCoreVersion'
+ *  e.g.: 'io.swagger.core.v3:swagger-core-jakarta' will be 'swaggerCoreJakartaVersion'
+ *
+ * The dependencies are sorted alphabetically.
+ */
+ext {
+    androidJsonVersion = '0.0.20131108.vaadin1'
+    assertjVersion = '3.24.2'
+    asyncapiCoreVersion = '1.0.0-EAP-2'
+    awaitilityVersion = '4.2.0'
+    commonsIoVersion = '2.12.0'
+
+    kafkaClientsVersion = '3.4.0'
+    kafkaStreamsVersion = '3.4.0'
+
+    mockitoCoreVersion = '4.8.1'
+    mockitoJunitJupiterVersion = '4.5.1'
+
+    monetaVersion = '1.4.2'
+    monetaCoreVersion = '1.4.2'
+
+    moneyApiVersion = '1.1'
+    jsonassertVersion = '1.5.1'
+
+    junitJupiterVersion = '5.9.3'
+    junitPlatformVersion = '1.9.3'
+
+    lombokVersion = '1.18.28'
+
+    swaggerCoreJakartaVersion = '2.2.11'
+    swaggerModelsJakartaVersion = '2.2.11'
+
+    swaggerAnnotationsVersion = '2.2.11'
+    swaggerInflectorVersion = '2.0.9'
+    swaggerModelsVersion = '2.2.11'
+    swaggerParserCoreVersion = '2.1.15'
+
+    testcontainersVersion = '1.18.3'
+}

--- a/springwolf-add-ons/springwolf-common-model-converters/build.gradle
+++ b/springwolf-add-ons/springwolf-common-model-converters/build.gradle
@@ -3,8 +3,9 @@ plugins {
     id 'signing'
     id 'maven-publish'
 
-    id 'org.springframework.boot' version '3.1.0'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+    id 'ca.cutterslade.analyze'
 }
 
 def isSnapshot = Boolean.valueOf(project.findProperty('SNAPSHOT'))
@@ -13,15 +14,19 @@ group 'io.github.springwolf'
 version '0.1.2' + (isSnapshot ? '-SNAPSHOT' : '')
 
 dependencies {
-    implementation "org.javamoney.moneta:moneta-core:${javaMoneyMonetaVersion}"
-    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
-
     implementation "org.springframework:spring-context"
 
-    testImplementation "org.junit.platform:junit-platform-engine:${junitPlatformVersion}"
-    testImplementation "org.junit.platform:junit-platform-commons:${junitPlatformVersion}"
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations"
+    implementation "com.fasterxml.jackson.core:jackson-databind"
+
+    implementation "io.swagger.core.v3:swagger-annotations-jakarta"
+    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreJakartaVersion}"
+    implementation "io.swagger.core.v3:swagger-models-jakarta:${swaggerModelsJakartaVersion}"
+
+    implementation "javax.money:money-api"
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
 }
 
 jar {

--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -4,8 +4,9 @@ plugins {
     id 'signing'
     id 'maven-publish'
 
-    id 'org.springframework.boot' version '3.1.0'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+    id 'ca.cutterslade.analyze'
 }
 
 def isSnapshot = Boolean.valueOf(project.findProperty('SNAPSHOT'))
@@ -14,43 +15,60 @@ group = 'io.github.springwolf'
 version = '0.10.0' + (isSnapshot ? '-SNAPSHOT' : '')
 
 dependencies {
-    api "com.asyncapi:asyncapi-core:${asyncApiCoreVersion}"
+    api "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
 
     implementation("io.swagger:swagger-inflector:${swaggerInflectorVersion}") {
         // swagger-inflector (2.0.9) transiently pulls two swagger-core dependencies:
         // - io.swagger.core.v3:swagger-core  2.x
         // - io.swagger:swagger-core  1.6.9
-        // these deps should be excluded because we need 'io.swagger.core.v3:swagger-core-jakarkta 2.x'
-        // Unfortunatly, io.swagger.swagger-core is still used in one place in swagger-inflector (io.swagger.util.Json)
-        // so we cannot exclude the old 'io.swagger:swagger-core 1.6.9' dependeny. Instead, we exclude explicitly
-        // the 'old' javax.validation groupid.
+        // these deps should be excluded because we need 'io.swagger.core.v3:swagger-core-jakarta 2.x'
+        // Unfortunately, io.swagger.swagger-core is still used in one place in swagger-inflector (io.swagger.util.Json)
+        // so we cannot exclude the old 'io.swagger:swagger-core 1.6.9' dependency. Instead, we exclude explicitly
+        // the 'old' javax.validation groupId.
 
         exclude group: "io.swagger.core.v3"
 //        exclude group: "io.swagger"  // not possible
         exclude group: "javax.validation"
     }
 
-    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
-    implementation "io.swagger.parser.v3:swagger-parser-core:${swaggerParserVersion}"
+    implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerAnnotationsVersion}@jar"
+    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreJakartaVersion}"
+
+    implementation "com.fasterxml.jackson.core:jackson-annotations"
+    implementation "com.fasterxml.jackson.core:jackson-core"
+    implementation "com.fasterxml.jackson.core:jackson-databind"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+
+    implementation "org.slf4j:slf4j-api"
 
     implementation "org.springframework:spring-web"
     implementation "org.springframework:spring-context"
     implementation "org.springframework:spring-messaging"
+    implementation "org.springframework:spring-beans"
+    implementation "org.springframework:spring-core"
     implementation "org.springframework.boot:spring-boot-autoconfigure"
 
+    implementation "io.swagger.core.v3:swagger-models-jakarta"
+    implementation "jakarta.annotation:jakarta.annotation-api"
+    implementation "org.springframework.boot:spring-boot"
+
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
+
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
-
-    testImplementation "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
 
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "com.vaadin.external.google:android-json:${androidJsonVersion}"
+    testImplementation "org.mockito:mockito-core"
+    testImplementation "org.skyscreamer:jsonassert:${jsonassertVersion}"
+    testImplementation "org.springframework.boot:spring-boot-test"
+    testImplementation "org.springframework:spring-test"
 
-    testImplementation "org.springframework.boot:spring-boot-starter-test"
-    testImplementation "org.springframework.amqp:spring-rabbit"
-    testImplementation "org.springframework.kafka:spring-kafka"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
 }
 
 jar {

--- a/springwolf-examples/springwolf-amqp-example/build.gradle
+++ b/springwolf-examples/springwolf-amqp-example/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'java'
 
-    id 'org.springframework.boot' version '3.1.0'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+    id 'ca.cutterslade.analyze'
 
     id 'com.bmuschko.docker-spring-boot-application' version '8.1.0'
 }
@@ -13,22 +14,40 @@ group 'io.github.springwolf'
 version '0.7.0' + (isSnapshot ? '-SNAPSHOT' : '')
 
 dependencies {
+    implementation project(":springwolf-core")
     implementation project(":springwolf-plugins:springwolf-amqp-plugin")
-    compileOnly project(":springwolf-plugins:springwolf-amqp-plugin")
+
     annotationProcessor project(":springwolf-plugins:springwolf-amqp-plugin")
     runtimeOnly project(":springwolf-ui")
 
-    implementation "org.springframework.boot:spring-boot-starter-web"
+    runtimeOnly "org.springframework.boot:spring-boot-starter-web"
+
     implementation "org.springframework.amqp:spring-rabbit"
     implementation "org.slf4j:slf4j-api"
-    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
+    implementation "io.swagger.core.v3:swagger-annotations:${swaggerAnnotationsVersion}"
+    implementation "com.asyncapi:asyncapi-core"
 
-    testImplementation "org.springframework.boot:spring-boot-starter-test"
-    testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"
-    testImplementation "org.junit.platform:junit-platform-launcher:${junitPlatformVersion}"
-    testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
-    testImplementation "org.skyscreamer:jsonassert:${jsonAssertVersion}"
+    implementation "org.springframework.amqp:spring-amqp"
+    implementation "org.springframework.boot:spring-boot-autoconfigure"
+    implementation "org.springframework.boot:spring-boot"
+    implementation "org.springframework:spring-beans"
+    implementation "org.springframework:spring-context"
+
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+
     testImplementation "commons-io:commons-io:${commonsIoVersion}"
+    testImplementation "com.vaadin.external.google:android-json:${androidJsonVersion}"
+
+    testImplementation "org.assertj:assertj-core"
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testImplementation "org.skyscreamer:jsonassert"
+
+    testImplementation "org.springframework.boot:spring-boot-test"
+    testImplementation "org.springframework:spring-web"
+    testImplementation "org.springframework:spring-test"
+
+    testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"
+    testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
 }
 
 docker {

--- a/springwolf-examples/springwolf-cloud-stream-example/build.gradle
+++ b/springwolf-examples/springwolf-cloud-stream-example/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'java'
 
-    id 'org.springframework.boot' version '3.1.0'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+    id 'ca.cutterslade.analyze'
 
     id 'com.bmuschko.docker-spring-boot-application' version '8.1.0'
 }
@@ -23,23 +24,37 @@ group 'io.github.springwolf'
 version '0.2.0' + (isSnapshot ? '-SNAPSHOT' : '')
 
 dependencies {
-    implementation project(":springwolf-plugins:springwolf-cloud-stream-plugin")
-    compileOnly project(":springwolf-plugins:springwolf-cloud-stream-plugin")
+    implementation project(":springwolf-core")
+
+    runtimeOnly project(":springwolf-plugins:springwolf-cloud-stream-plugin")
     annotationProcessor project(":springwolf-plugins:springwolf-cloud-stream-plugin")
+
     runtimeOnly project(":springwolf-ui")
+    runtimeOnly "org.springframework.boot:spring-boot-starter-web"
 
-    implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "org.springframework.cloud:spring-cloud-stream"
-    implementation "org.springframework.cloud:spring-cloud-stream-binder-kafka-streams"
+    implementation "com.asyncapi:asyncapi-core"
+    implementation "org.apache.kafka:kafka-streams"
     implementation "org.slf4j:slf4j-api"
-    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
+    implementation "io.swagger.core.v3:swagger-annotations:${swaggerAnnotationsVersion}"
 
-    testImplementation "org.springframework.boot:spring-boot-starter-test"
+    implementation "org.springframework.boot:spring-boot-autoconfigure"
+    implementation "org.springframework.boot:spring-boot"
+    implementation "org.springframework:spring-beans"
+    implementation "org.springframework:spring-context"
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+
+    testImplementation "com.vaadin.external.google:android-json:${androidJsonVersion}"
+    testImplementation "org.assertj:assertj-core"
+    testImplementation "org.springframework.boot:spring-boot-test"
+    testImplementation "org.springframework:spring-test"
+
+    testImplementation "org.springframework:spring-web"
     testImplementation "org.springframework.kafka:spring-kafka-test"
-    testImplementation "org.junit.platform:junit-platform-launcher:${junitPlatformVersion}"
     testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"
     testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
-    testImplementation "org.skyscreamer:jsonassert:${jsonAssertVersion}"
+    testImplementation "org.skyscreamer:jsonassert"
     testImplementation "commons-io:commons-io:${commonsIoVersion}"
 }
 

--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -1,8 +1,9 @@
 plugins {
     id 'java'
 
-    id 'org.springframework.boot' version '3.1.0'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+    id 'ca.cutterslade.analyze'
 
     id 'com.bmuschko.docker-spring-boot-application' version '8.1.0'
     id 'org.springdoc.openapi-gradle-plugin' version '1.6.0'
@@ -14,27 +15,55 @@ group 'io.github.springwolf'
 version '0.11.0' + (isSnapshot ? '-SNAPSHOT' : '')
 
 dependencies {
+    implementation project(":springwolf-core")
     implementation project(":springwolf-plugins:springwolf-kafka-plugin")
-    compileOnly project(":springwolf-plugins:springwolf-kafka-plugin")
-    annotationProcessor project(":springwolf-plugins:springwolf-kafka-plugin")
-    implementation project(":springwolf-add-ons:springwolf-common-model-converters")
+
+    runtimeOnly project(":springwolf-add-ons:springwolf-common-model-converters")
     runtimeOnly project(":springwolf-ui")
 
-    implementation "org.springframework.boot:spring-boot-starter-web"
-    implementation "org.springframework.kafka:spring-kafka"
-    implementation "org.springframework.boot:spring-boot-starter-security"
-    implementation "org.slf4j:slf4j-api"
-    implementation "org.javamoney:moneta:${javaMoneyMonetaVersion}"
-    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
+    annotationProcessor project(":springwolf-plugins:springwolf-kafka-plugin")
 
-    testImplementation "org.springframework.boot:spring-boot-starter-test"
+    runtimeOnly "org.springframework.boot:spring-boot-starter-web"
+
+    implementation "org.springframework:spring-beans"
+    implementation "org.springframework:spring-context"
+    implementation "org.springframework:spring-web"
+
+    implementation "org.springframework.boot:spring-boot"
+    implementation "org.springframework.boot:spring-boot-autoconfigure"
+
+    implementation "org.springframework.kafka:spring-kafka"
+
+    implementation "org.springframework.security:spring-security-config"
+    implementation "org.springframework.security:spring-security-web"
+
+    implementation "com.asyncapi:asyncapi-core"
+    implementation "io.swagger.core.v3:swagger-annotations:${swaggerAnnotationsVersion}"
+    implementation "org.slf4j:slf4j-api"
+
+    implementation "javax.money:money-api:${moneyApiVersion}"
+    implementation "org.javamoney:moneta:${monetaVersion}"
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
+
+    testImplementation "commons-io:commons-io:${commonsIoVersion}"
+    testImplementation "com.vaadin.external.google:android-json:${androidJsonVersion}"
+
+    testImplementation "org.apache.kafka:kafka-clients:${kafkaClientsVersion}@jar"
+    testImplementation "org.assertj:assertj-core"
+    testImplementation "org.awaitility:awaitility:${awaitilityVersion}"
+    testImplementation "org.skyscreamer:jsonassert:${jsonassertVersion}"
+    testImplementation "org.mockito:mockito-core"
+
+    testImplementation "org.springframework.boot:spring-boot-test"
     testImplementation "org.springframework.kafka:spring-kafka-test"
-    testImplementation "org.junit.platform:junit-platform-launcher:${junitPlatformVersion}"
+    testImplementation "org.springframework:spring-test"
+
     testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"
     testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
-    testImplementation "org.skyscreamer:jsonassert:${jsonAssertVersion}"
-    testImplementation "commons-io:commons-io:${commonsIoVersion}"
-    testImplementation "org.awaitility:awaitility:${awaitabilityVersion}"
+
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+    permitTestUnusedDeclared "org.apache.kafka:kafka-clients:${kafkaClientsVersion}:test@jar"
 }
 
 docker {

--- a/springwolf-plugins/springwolf-amqp-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-amqp-plugin/build.gradle
@@ -3,8 +3,9 @@ plugins {
     id 'signing'
     id 'maven-publish'
 
-    id 'org.springframework.boot' version '3.1.0'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+    id 'ca.cutterslade.analyze'
 }
 
 def isSnapshot = Boolean.valueOf(project.findProperty('SNAPSHOT'))
@@ -15,23 +16,31 @@ version '0.7.0' + (isSnapshot ? '-SNAPSHOT' : '')
 dependencies {
     api project(":springwolf-core")
 
+    implementation "com.asyncapi:asyncapi-core"
+    implementation "org.slf4j:slf4j-api"
+
+    implementation "org.springframework:spring-context"
+    implementation "org.springframework:spring-core"
+    implementation "org.springframework:spring-web"
     implementation "org.springframework.boot:spring-boot"
     implementation "org.springframework.boot:spring-boot-autoconfigure"
-    implementation "org.springframework:spring-web"
+    implementation "org.springframework.amqp:spring-amqp"
     implementation "org.springframework.amqp:spring-rabbit"
-
-    implementation "org.slf4j:slf4j-api"
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
-
-    testImplementation "org.projectlombok:lombok:${lombokVersion}"
-    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
-
     testImplementation "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testImplementation "org.mockito:mockito-core"
+
+    testImplementation "org.springframework.boot:spring-boot-test"
+    testImplementation "org.springframework:spring-beans"
+    testImplementation "org.springframework:spring-test"
+
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 }
 
 jar {

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/build.gradle
@@ -3,8 +3,9 @@ plugins {
     id 'signing'
     id 'maven-publish'
 
-    id 'org.springframework.boot' version '3.1.0'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+    id 'ca.cutterslade.analyze'
 }
 
 def isSnapshot = Boolean.valueOf(project.findProperty('SNAPSHOT'))
@@ -25,18 +26,27 @@ dependencyManagement {
 dependencies {
     api project(":springwolf-core")
 
-    implementation "org.springframework.cloud:spring-cloud-stream"
-
+    implementation "com.asyncapi:asyncapi-core"
     implementation "org.slf4j:slf4j-api"
+
+    implementation "org.springframework:spring-context"
+    implementation "org.springframework.cloud:spring-cloud-stream"
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
-    testImplementation "org.projectlombok:lombok:${lombokVersion}"
-    testImplementation "org.springframework.boot:spring-boot-starter-test"
-    testImplementation "org.springframework.cloud:spring-cloud-stream-binder-kafka-streams"
+
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+
     testImplementation "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.apache.kafka:kafka-streams:${kafkaStreamsVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testImplementation "org.mockito:mockito-core"
+
+    testImplementation "org.springframework.boot:spring-boot-test"
+    testImplementation "org.springframework:spring-beans"
+    testImplementation "org.springframework:spring-test"
 }
 
 jar {

--- a/springwolf-plugins/springwolf-kafka-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-kafka-plugin/build.gradle
@@ -3,8 +3,9 @@ plugins {
     id 'signing'
     id 'maven-publish'
 
-    id 'org.springframework.boot' version '3.1.0'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+    id 'ca.cutterslade.analyze'
 }
 
 def isSnapshot = Boolean.valueOf(project.findProperty('SNAPSHOT'))
@@ -15,23 +16,39 @@ version '0.11.0' + (isSnapshot ? '-SNAPSHOT' : '')
 dependencies {
     api project(":springwolf-core")
 
-    implementation "org.springframework.boot:spring-boot"
-    implementation "org.springframework.boot:spring-boot-autoconfigure"
-    implementation "org.springframework:spring-web"
-    implementation "org.springframework.kafka:spring-kafka"
-    implementation "io.swagger.core.v3:swagger-models:${swaggerCoreVersion}"
-
+    implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
+    implementation "io.swagger.core.v3:swagger-models:${swaggerModelsVersion}"
+    implementation "org.apache.kafka:kafka-clients:${kafkaClientsVersion}"
     implementation "org.slf4j:slf4j-api"
 
-    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    implementation "org.springframework:spring-beans"
+    implementation "org.springframework:spring-context"
+    implementation "org.springframework:spring-core"
+    implementation "org.springframework:spring-web"
 
+    implementation "org.springframework.boot:spring-boot"
+    implementation "org.springframework.boot:spring-boot-autoconfigure"
+
+    implementation "org.springframework.kafka:spring-kafka"
+
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
-    testImplementation("org.springframework.boot:spring-boot-starter-web")
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+    testRuntimeOnly "org.springframework.boot:spring-boot-starter-web"
 
-    testImplementation "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
+
+    testImplementation "org.mockito:mockito-core:${mockitoCoreVersion}"
+    testImplementation "org.mockito:mockito-junit-jupiter:${mockitoJunitJupiterVersion}"
+
+    testImplementation "org.springframework.boot:spring-boot-test-autoconfigure"
+    testImplementation "org.springframework.boot:spring-boot-test"
+
+    testImplementation "org.springframework:spring-test"
+
+    testImplementation "org.assertj:assertj-core"
 }
 
 jar {


### PR DESCRIPTION
This pull request takes care of the dependency management. There are two changes.

First, introduce a gradle plugin called 'ca.cutterslade.analyze'. This plugin is a dependency management tool which scans for used but undeclared dependencies and vice versa unused but declared dependencies. This results in clear and reliable dependencies in the project.

Second, add a explicit _dependencies.gradle_ file containing versions for dependencies which are used in subprojects. This approach is compatible with dependabot (see: [dependabot-gradle](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#gradle))
