### PR TITLE
feat: Added @AsyncMessage

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AbstractOperationDataScanner.java
@@ -138,12 +138,12 @@ public abstract class AbstractOperationDataScanner implements ChannelsScanner {
 
             var name = annotationMessage.getName();
             if (StringUtils.hasText(name)) {
-                builder.name(annotationMessage.getName());
+                builder.name(name);
             }
 
             var title = annotationMessage.getTitle();
             if (StringUtils.hasText(title)) {
-                builder.title(annotationMessage.getTitle());
+                builder.title(title);
             }
         }
     }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtil.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtil.java
@@ -85,17 +85,36 @@ class AsyncAnnotationScannerUtil {
     public static Message processMessageFromAnnotation(Method method) {
         var messageBuilder = Message.builder();
 
-        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
-        for (Annotation[] annotations : parameterAnnotations) {
-            for (Annotation annotation : annotations) {
-                if (annotation instanceof AsyncMessage asyncMessage) {
-                    messageBuilder.description(asyncMessage.description());
-                    messageBuilder.messageId(asyncMessage.messageId());
-                    messageBuilder.name(asyncMessage.name());
-                    messageBuilder.schemaFormat(asyncMessage.schemaFormat());
-                    messageBuilder.title(asyncMessage.title());
-                }
+        Annotation[] annotations = method.getAnnotations();
+        for (Annotation annotation : annotations) {
+            if (annotation instanceof AsyncListener asyncListener) {
+                return parseMessage(asyncListener.operation());
+            } else if (annotation instanceof AsyncPublisher asyncPublisher) {
+                return parseMessage(asyncPublisher.operation());
             }
+        }
+
+        return messageBuilder.build();
+    }
+
+    private static Message parseMessage(AsyncOperation asyncOperation) {
+        var messageBuilder = Message.builder();
+
+        var asyncMessage = asyncOperation.message();
+        if (StringUtils.hasText(asyncMessage.description())) {
+            messageBuilder.description(asyncMessage.description());
+        }
+        if (StringUtils.hasText(asyncMessage.messageId())) {
+            messageBuilder.messageId(asyncMessage.messageId());
+        }
+        if (StringUtils.hasText(asyncMessage.name())) {
+            messageBuilder.name(asyncMessage.name());
+        }
+        if (StringUtils.hasText(asyncMessage.schemaFormat())) {
+            messageBuilder.schemaFormat(asyncMessage.schemaFormat());
+        }
+        if (StringUtils.hasText(asyncMessage.title())) {
+            messageBuilder.title(asyncMessage.title());
         }
 
         return messageBuilder.build();

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtil.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtil.java
@@ -4,11 +4,13 @@ import com.asyncapi.v2.binding.message.MessageBinding;
 import com.asyncapi.v2.binding.operation.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProcessedMessageBinding;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProcessedOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaderSchema;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import org.springframework.util.StringUtils;
 import org.springframework.util.StringValueResolver;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -78,5 +80,24 @@ class AsyncAnnotationScannerUtil {
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toMap(ProcessedMessageBinding::getType, ProcessedMessageBinding::getBinding));
+    }
+
+    public static Message processMessageFromAnnotation(Method method) {
+        var messageBuilder = Message.builder();
+
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        for (Annotation[] annotations : parameterAnnotations) {
+            for (Annotation annotation : annotations) {
+                if (annotation instanceof AsyncMessage asyncMessage) {
+                    messageBuilder.description(asyncMessage.description());
+                    messageBuilder.messageId(asyncMessage.messageId());
+                    messageBuilder.name(asyncMessage.name());
+                    messageBuilder.schemaFormat(asyncMessage.schemaFormat());
+                    messageBuilder.title(asyncMessage.title());
+                }
+            }
+        }
+
+        return messageBuilder.build();
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScanner.java
@@ -8,6 +8,7 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.ConsumerData;
 import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,14 +72,15 @@ public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner
 
         Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processOperationBindingFromAnnotation(method, operationBindingProcessors);
         Map<String, MessageBinding> messageBindings = AsyncAnnotationScannerUtil.processMessageBindingFromAnnotation(method, messageBindingProcessors);
+        Message message = AsyncAnnotationScannerUtil.processMessageFromAnnotation(method);
 
         Class<AsyncListener> annotationClass = AsyncListener.class;
         return Arrays
                 .stream(method.getAnnotationsByType(annotationClass))
-                .map(annotation -> toConsumerData(method, operationBindings, messageBindings, annotation));
+                .map(annotation -> toConsumerData(method, operationBindings, messageBindings, message, annotation));
     }
 
-    private ConsumerData toConsumerData(Method method, Map<String, OperationBinding> operationBindings, Map<String, MessageBinding> messageBindings, AsyncListener annotation) {
+    private ConsumerData toConsumerData(Method method, Map<String, OperationBinding> operationBindings, Map<String, MessageBinding> messageBindings, Message message, AsyncListener annotation) {
         AsyncOperation op = annotation.operation();
         Class<?> payloadType = op.payloadType() != Object.class ? op.payloadType() :
                 SpringPayloadAnnotationTypeExtractor.getPayloadType(method);
@@ -89,6 +91,7 @@ public class AsyncListenerAnnotationScanner extends AbstractOperationDataScanner
                 .payloadType(payloadType)
                 .operationBinding(operationBindings)
                 .messageBinding(messageBindings)
+                .message(message)
                 .build();
     }
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncMessage.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncMessage.java
@@ -1,0 +1,42 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message.DEFAULT_SCHEMA_FORMAT;
+
+/**
+ * Annotation is mapped to {@link Message}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface AsyncMessage {
+    /**
+     * Mapped to {@link Message#getDescription()}
+     */
+    String description() default "";
+
+    /**
+     * Mapped to {@link Message#getMessageId()}
+     */
+    String messageId() default "";
+
+    /**
+     * Mapped to {@link Message#getName()}
+     */
+    String name() default "";
+
+    /**
+     * Mapped to {@link Message#getSchemaFormat()}
+     */
+    String schemaFormat() default DEFAULT_SCHEMA_FORMAT;
+
+    /**
+     * Mapped to {@link Message#getTitle()}
+     */
+    String title() default "";
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncOperation.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncOperation.java
@@ -26,6 +26,11 @@ public @interface AsyncOperation {
     String description() default "";
 
     /**
+     * Mapped to {@link OperationData#getMessage()}
+     */
+    AsyncMessage message() default @AsyncMessage();
+
+    /**
      * Mapped to {@link OperationData#getPayloadType()}
      */
     Class<?> payloadType() default Object.class;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
@@ -8,6 +8,7 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
 import io.github.stavshamir.springwolf.asyncapi.types.ProducerData;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,14 +72,15 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
 
         Map<String, OperationBinding> operationBindings = AsyncAnnotationScannerUtil.processOperationBindingFromAnnotation(method, operationBindingProcessors);
         Map<String, MessageBinding> messageBindings = AsyncAnnotationScannerUtil.processMessageBindingFromAnnotation(method, messageBindingProcessors);
+        Message message = AsyncAnnotationScannerUtil.processMessageFromAnnotation(method);
 
         Class<AsyncPublisher> annotationClass = AsyncPublisher.class;
         return Arrays
                 .stream(method.getAnnotationsByType(annotationClass))
-                .map(annotation -> toConsumerData(method, operationBindings, messageBindings, annotation));
+                .map(annotation -> toConsumerData(method, operationBindings, messageBindings, message, annotation));
     }
 
-    private ProducerData toConsumerData(Method method, Map<String, OperationBinding> operationBindings, Map<String, MessageBinding> messageBindings, AsyncPublisher annotation) {
+    private ProducerData toConsumerData(Method method, Map<String, OperationBinding> operationBindings, Map<String, MessageBinding> messageBindings, Message message, AsyncPublisher annotation) {
         AsyncOperation op = annotation.operation();
         Class<?> payloadType = op.payloadType() != Object.class ? op.payloadType() :
                 SpringPayloadAnnotationTypeExtractor.getPayloadType(method);
@@ -89,6 +91,7 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
                 .payloadType(payloadType)
                 .operationBinding(operationBindings)
                 .messageBinding(messageBindings)
+                .message(message)
                 .build();
     }
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ConsumerData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ConsumerData.java
@@ -3,6 +3,7 @@ package io.github.stavshamir.springwolf.asyncapi.types;
 import com.asyncapi.v2.binding.channel.ChannelBinding;
 import com.asyncapi.v2.binding.message.MessageBinding;
 import com.asyncapi.v2.binding.operation.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -71,4 +72,9 @@ public class ConsumerData implements OperationData {
      * </code>
      */
     protected Map<String, ? extends MessageBinding> messageBinding;
+
+    /**
+     * Operation message.
+     */
+    protected Message message;
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/OperationData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/OperationData.java
@@ -3,6 +3,7 @@ package io.github.stavshamir.springwolf.asyncapi.types;
 import com.asyncapi.v2.binding.channel.ChannelBinding;
 import com.asyncapi.v2.binding.message.MessageBinding;
 import com.asyncapi.v2.binding.operation.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 
 import java.util.Map;
@@ -45,6 +46,8 @@ public interface OperationData {
      * The message binding.
      */
     Map<String, ? extends MessageBinding> getMessageBinding();
+
+    Message getMessage();
 
     enum OperationType {
         PUBLISH("publish"), SUBSCRIBE("subscribe");

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ProducerData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/ProducerData.java
@@ -3,6 +3,7 @@ package io.github.stavshamir.springwolf.asyncapi.types;
 import com.asyncapi.v2.binding.channel.ChannelBinding;
 import com.asyncapi.v2.binding.message.MessageBinding;
 import com.asyncapi.v2.binding.operation.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -72,4 +73,8 @@ public class ProducerData implements OperationData {
      */
     protected Map<String, ? extends MessageBinding> messageBinding;
 
+    /**
+     * Operation message.
+     */
+    protected Message message;
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/Message.java
@@ -20,8 +20,19 @@ import java.util.Map;
 @AllArgsConstructor
 public class Message {
 
+    public static final String DEFAULT_SCHEMA_FORMAT = "application/vnd.oai.openapi+json;version=3.0.0";
+
     @Builder.Default
-    private String schemaFormat = "application/vnd.oai.openapi+json;version=3.0.0";
+    private String schemaFormat = DEFAULT_SCHEMA_FORMAT;
+
+    /**
+     * Unique string used to identify the message.
+     * <p>
+     * The id MUST be unique among all messages described in the API. The messageId value is case-sensitive.
+     * Tools and libraries MAY use the messageId to uniquely identify a message, therefore, it is RECOMMENDED to
+     * follow common programming naming conventions.
+     */
+    private String messageId;
 
     /**
      * A machine-friendly name for the message.
@@ -43,4 +54,14 @@ public class Message {
     private HeaderReference headers;
 
     private Map<String, ? extends MessageBinding> bindings;
+
+    // Why do we add this empty class if Lombok @Builder is doing this job? Because this class is used as an argument
+    // in one method. Since Lombok works as an annotation Processor, the JavaDoc tool cannot find the generated class
+    // and fails.
+    // The alternative to define this class would be to use `delombok` during the Javadoc generation. This is really easy
+    // in Maven, but with Gradle seems to be more complicated. Creating an empty class that Lombok overrides and expands
+    // is much cleaner.
+    public static class MessageBuilder {
+        MessageBuilder() {}
+    }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtilTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtilTest.java
@@ -115,18 +115,17 @@ class AsyncAnnotationScannerUtilTest {
                 headers = @AsyncOperation.Headers(
                         schemaName = "TestSchema",
                         values = {@AsyncOperation.Headers.Header(name = "header", value = "value", description = "description")}
-                )
-        ))
-        @TestOperationBindingProcessor.TestOperationBinding()
-        private void methodWithAsyncMessageAnnotation(
-                @AsyncMessage(
+                ),
+                message = @AsyncMessage(
                         description = "Message description",
                         messageId = "simpleFoo",
                         name = "SimpleFooPayLoad",
                         schemaFormat = "application/schema+json;version=draft-07",
                         title = "Message Title"
                 )
-                String payload) {
+        ))
+        @TestOperationBindingProcessor.TestOperationBinding()
+        private void methodWithAsyncMessageAnnotation(String payload) {
         }
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtilTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncAnnotationScannerUtilTest.java
@@ -1,6 +1,8 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
 
+import com.asyncapi.v2.binding.message.MessageBinding;
 import com.asyncapi.v2.binding.operation.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.Test;
@@ -50,6 +52,50 @@ class AsyncAnnotationScannerUtilTest {
         assertEquals(Maps.newHashMap(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING), bindings);
     }
 
+    @Test
+    void processMessageBindingFromAnnotation() throws NoSuchMethodException {
+        // given
+        Method m = ClassWithOperationBindingProcessor.class.getDeclaredMethod("methodWithAnnotation", String.class);
+
+        // when
+        Map<String, MessageBinding> bindings = AsyncAnnotationScannerUtil.processMessageBindingFromAnnotation(m, Collections.singletonList(new TestMessageBindingProcessor()));
+
+        // then
+        assertEquals(Maps.newHashMap(TestMessageBindingProcessor.TYPE, TestMessageBindingProcessor.BINDING), bindings);
+    }
+
+    @Test
+    void processMessageFromAnnotationWithoutAsyncMessage() throws NoSuchMethodException {
+        // given
+        Method method = ClassWithOperationBindingProcessor.class.getDeclaredMethod("methodWithAnnotation", String.class);
+
+        // when
+        Message message = AsyncAnnotationScannerUtil.processMessageFromAnnotation(method);
+
+        // then
+        var expectedMessage = Message.builder().build();
+        assertEquals(expectedMessage, message);
+    }
+
+    @Test
+    void processMessageFromAnnotationWithAsyncMessage() throws NoSuchMethodException {
+        // given
+        Method method = ClassWithOperationBindingProcessor.class.getDeclaredMethod("methodWithAsyncMessageAnnotation", String.class);
+
+        // when
+        Message message = AsyncAnnotationScannerUtil.processMessageFromAnnotation(method);
+
+        // then
+        var expectedMessage = Message.builder()
+                .description("Message description")
+                .messageId("simpleFoo")
+                .name("SimpleFooPayLoad")
+                .schemaFormat("application/schema+json;version=draft-07")
+                .title("Message Title")
+                .build();
+        assertEquals(expectedMessage, message);
+    }
+
     private static class ClassWithOperationBindingProcessor {
         @AsyncListener(operation = @AsyncOperation(
                 channelName = "${test.property.test-channel}",
@@ -61,6 +107,26 @@ class AsyncAnnotationScannerUtilTest {
         ))
         @TestOperationBindingProcessor.TestOperationBinding()
         private void methodWithAnnotation(String payload) {
+        }
+
+        @AsyncListener(operation = @AsyncOperation(
+                channelName = "${test.property.test-channel}",
+                description = "${test.property.description}",
+                headers = @AsyncOperation.Headers(
+                        schemaName = "TestSchema",
+                        values = {@AsyncOperation.Headers.Header(name = "header", value = "value", description = "description")}
+                )
+        ))
+        @TestOperationBindingProcessor.TestOperationBinding()
+        private void methodWithAsyncMessageAnnotation(
+                @AsyncMessage(
+                        description = "Message description",
+                        messageId = "simpleFoo",
+                        name = "SimpleFooPayLoad",
+                        schemaFormat = "application/schema+json;version=draft-07",
+                        title = "Message Title"
+                )
+                String payload) {
         }
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerTest.java
@@ -263,16 +263,16 @@ class AsyncListenerAnnotationScannerTest {
 
         @AsyncListener(operation = @AsyncOperation(
                 channelName = "test-channel",
-                description = "test channel operation description"
-        ))
-        private void methodWithAnnotation(
-                @AsyncMessage(
+                description = "test channel operation description",
+                message = @AsyncMessage(
                         description = "Message description",
                         messageId = "simpleFoo",
                         name = "SimpleFooPayLoad",
                         schemaFormat = "application/schema+json;version=draft-07",
                         title = "Message Title"
-                ) SimpleFoo payload) {
+                )
+        ))
+        private void methodWithAnnotation(SimpleFoo payload) {
         }
 
         private void methodWithoutAnnotation() {

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerTest.java
@@ -266,16 +266,16 @@ class AsyncPublisherAnnotationScannerTest {
     private static class ClassWithMessageAnnotation {
 
         @AsyncPublisher(operation = @AsyncOperation(
-                channelName = "test-channel"
-        ))
-        private void methodWithAnnotation(
-                @AsyncMessage(
+                channelName = "test-channel",
+                message = @AsyncMessage(
                         description = "Message description",
                         messageId = "simpleFoo",
                         name = "SimpleFooPayLoad",
                         schemaFormat = "application/schema+json;version=draft-07",
                         title = "Message Title"
-                ) SimpleFoo payload) {
+                )
+        ))
+        private void methodWithAnnotation(SimpleFoo payload) {
         }
 
         private void methodWithoutAnnotation() {

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/TestMessageBindingProcessor.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/TestMessageBindingProcessor.java
@@ -1,0 +1,35 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import com.asyncapi.v2.binding.message.MessageBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProcessedMessageBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
+
+public class TestMessageBindingProcessor implements MessageBindingProcessor {
+
+    public final static String TYPE = "testType";
+    public final static MessageBinding BINDING = new MessageBinding();
+    @Override
+    public Optional<ProcessedMessageBinding> process(Method method) {
+        return Arrays.stream(method.getAnnotations())
+                .filter(annotation -> annotation instanceof TestOperationBindingProcessor.TestOperationBinding)
+                .map(annotation -> (TestOperationBindingProcessor.TestOperationBinding) annotation)
+                .findAny()
+                .map(this::mapToMessageBinding);
+    }
+
+    private ProcessedMessageBinding mapToMessageBinding(TestOperationBindingProcessor.TestOperationBinding bindingAnnotation) {
+        return new ProcessedMessageBinding(TYPE, BINDING);
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(value = {ElementType.METHOD})
+    public @interface TestMessageBinding {
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/TestOperationBindingProcessor.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/TestOperationBindingProcessor.java
@@ -25,5 +25,6 @@ public class TestOperationBindingProcessor implements OperationBindingProcessor 
     @Retention(RetentionPolicy.RUNTIME)
     @Target(value = {ElementType.METHOD})
     public @interface TestOperationBinding {
+        TestMessageBindingProcessor.TestMessageBinding messageBinding() default @TestMessageBindingProcessor.TestMessageBinding();
     }
 }


### PR DESCRIPTION
Added support for a new `@AsyncMessage` annotation. This annotation can be used as a method parameter annotation on the same method the `@AsyncPublisher` or `@AsyncListener` annotations are used.

This new `@AsyncMessage` annotation allows to enrich the AsyncAPI Operation Message with all the supported fields.

The Message payload documentation stays in the Swagger `@Schema` annotation. This new `@AsyncMessage` annotation is intended to enrich the missing values.

A special case is the description, which is available in both. Any value defined in `@AsyncMessage` has higher priority than any other default value.