### PR TITLE
chore: set and specify versions of all dependencies 

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -19,13 +19,20 @@
  */
 ext {
     androidJsonVersion = '0.0.20131108.vaadin1'
-    assertjVersion = '3.24.2'
+    assertjCoreVersion = '3.24.2'
     asyncapiCoreVersion = '1.0.0-EAP-2'
     awaitilityVersion = '4.2.0'
     commonsIoVersion = '2.13.0'
 
     kafkaClientsVersion = '3.4.0'
     kafkaStreamsVersion = '3.4.0'
+
+    jacksonAnnotationsVersion = '2.15.0'
+    jacksonCoreVersion = '2.15.0'
+    jacksonDatabindVersion = '2.15.0'
+    jacksonDataformatYamlVersion = '2.15.0'
+
+    jakartaAnnotationApiVersion = '2.1.1'
 
     mockitoCoreVersion = '4.8.1'
     mockitoJunitJupiterVersion = '4.5.1'
@@ -40,9 +47,12 @@ ext {
 
     lombokVersion = '1.18.28'
 
+    slf4jApiVersion = '2.0.7'
+
     swaggerCoreJakartaVersion = '2.2.11'
     swaggerModelsJakartaVersion = '2.2.11'
 
+    swaggerAnnotationsJakartaVersion = '2.2.11'
     swaggerAnnotationsVersion = '2.2.12'
     swaggerInflectorVersion = '2.0.9'
     swaggerModelsVersion = '2.2.11'

--- a/springwolf-add-ons/springwolf-common-model-converters/build.gradle
+++ b/springwolf-add-ons/springwolf-common-model-converters/build.gradle
@@ -16,17 +16,17 @@ version '0.1.2' + (isSnapshot ? '-SNAPSHOT' : '')
 dependencies {
     implementation "org.springframework:spring-context"
 
-    implementation "com.fasterxml.jackson.core:jackson-annotations"
-    implementation "com.fasterxml.jackson.core:jackson-databind"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
 
-    implementation "io.swagger.core.v3:swagger-annotations-jakarta"
+    implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerAnnotationsJakartaVersion}"
     implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreJakartaVersion}"
     implementation "io.swagger.core.v3:swagger-models-jakarta:${swaggerModelsJakartaVersion}"
 
-    implementation "javax.money:money-api"
+    implementation "javax.money:money-api:${moneyApiVersion}"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
 }
 
 jar {

--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -27,20 +27,20 @@ dependencies {
         // the 'old' javax.validation groupId.
 
         exclude group: "io.swagger.core.v3"
-//        exclude group: "io.swagger"  // not possible
         exclude group: "javax.validation"
     }
 
     implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerAnnotationsVersion}@jar"
     implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreJakartaVersion}"
 
-    implementation "com.fasterxml.jackson.core:jackson-annotations"
-    implementation "com.fasterxml.jackson.core:jackson-core"
-    implementation "com.fasterxml.jackson.core:jackson-databind"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${jacksonCoreVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonDataformatYamlVersion}"
 
-    implementation "org.slf4j:slf4j-api"
+    implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 
+    implementation "org.springframework.boot:spring-boot"
     implementation "org.springframework:spring-web"
     implementation "org.springframework:spring-context"
     implementation "org.springframework:spring-messaging"
@@ -48,9 +48,8 @@ dependencies {
     implementation "org.springframework:spring-core"
     implementation "org.springframework.boot:spring-boot-autoconfigure"
 
-    implementation "io.swagger.core.v3:swagger-models-jakarta"
-    implementation "jakarta.annotation:jakarta.annotation-api"
-    implementation "org.springframework.boot:spring-boot"
+    implementation "io.swagger.core.v3:swagger-models-jakarta:${swaggerModelsJakartaVersion}"
+    implementation "jakarta.annotation:jakarta.annotation-api:${jakartaAnnotationApiVersion}"
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
 
@@ -60,14 +59,14 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api"
-    testImplementation "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
+    testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
     testImplementation "com.vaadin.external.google:android-json:${androidJsonVersion}"
-    testImplementation "org.mockito:mockito-core"
+    testImplementation "org.mockito:mockito-core:${mockitoCoreVersion}"
     testImplementation "org.springframework.boot:spring-boot-test"
     testImplementation "org.springframework:spring-test"
 
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
 }
 
 jar {

--- a/springwolf-examples/springwolf-amqp-example/build.gradle
+++ b/springwolf-examples/springwolf-amqp-example/build.gradle
@@ -23,9 +23,9 @@ dependencies {
     runtimeOnly "org.springframework.boot:spring-boot-starter-web"
 
     implementation "org.springframework.amqp:spring-rabbit"
-    implementation "org.slf4j:slf4j-api"
+    implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
     implementation "io.swagger.core.v3:swagger-annotations:${swaggerAnnotationsVersion}"
-    implementation "com.asyncapi:asyncapi-core"
+    implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
 
     implementation "org.springframework.amqp:spring-amqp"
     implementation "org.springframework.boot:spring-boot-autoconfigure"
@@ -33,13 +33,13 @@ dependencies {
     implementation "org.springframework:spring-beans"
     implementation "org.springframework:spring-context"
 
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
 
     testImplementation "commons-io:commons-io:${commonsIoVersion}"
     testImplementation "com.vaadin.external.google:android-json:${androidJsonVersion}"
 
-    testImplementation "org.assertj:assertj-core"
-    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
 
     testImplementation "org.springframework.boot:spring-boot-test"
     testImplementation "org.springframework:spring-web"

--- a/springwolf-examples/springwolf-cloud-stream-example/build.gradle
+++ b/springwolf-examples/springwolf-cloud-stream-example/build.gradle
@@ -32,9 +32,9 @@ dependencies {
     runtimeOnly project(":springwolf-ui")
     runtimeOnly "org.springframework.boot:spring-boot-starter-web"
 
-    implementation "com.asyncapi:asyncapi-core"
-    implementation "org.apache.kafka:kafka-streams"
-    implementation "org.slf4j:slf4j-api"
+    implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
+    implementation "org.apache.kafka:kafka-streams:${kafkaStreamsVersion}"
+    implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
     implementation "io.swagger.core.v3:swagger-annotations:${swaggerAnnotationsVersion}"
 
     implementation "org.springframework.boot:spring-boot-autoconfigure"
@@ -42,11 +42,11 @@ dependencies {
     implementation "org.springframework:spring-beans"
     implementation "org.springframework:spring-context"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
 
     testImplementation "com.vaadin.external.google:android-json:${androidJsonVersion}"
-    testImplementation "org.assertj:assertj-core"
+    testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
     testImplementation "org.springframework.boot:spring-boot-test"
     testImplementation "org.springframework:spring-test"
 

--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -37,22 +37,22 @@ dependencies {
     implementation "org.springframework.security:spring-security-config"
     implementation "org.springframework.security:spring-security-web"
 
-    implementation "com.asyncapi:asyncapi-core"
+    implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
     implementation "io.swagger.core.v3:swagger-annotations:${swaggerAnnotationsVersion}"
-    implementation "org.slf4j:slf4j-api"
+    implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 
     implementation "javax.money:money-api:${moneyApiVersion}"
     implementation "org.javamoney:moneta:${monetaVersion}"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
 
     testImplementation "commons-io:commons-io:${commonsIoVersion}"
     testImplementation "com.vaadin.external.google:android-json:${androidJsonVersion}"
 
     testImplementation "org.apache.kafka:kafka-clients:${kafkaClientsVersion}@jar"
-    testImplementation "org.assertj:assertj-core"
+    testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
     testImplementation "org.awaitility:awaitility:${awaitilityVersion}"
-    testImplementation "org.mockito:mockito-core"
+    testImplementation "org.mockito:mockito-core:${mockitoCoreVersion}"
 
     testImplementation "org.springframework.boot:spring-boot-test"
     testImplementation "org.springframework.kafka:spring-kafka-test"
@@ -61,7 +61,7 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"
     testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
 
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
     permitTestUnusedDeclared "org.apache.kafka:kafka-clients:${kafkaClientsVersion}:test@jar"
 }
 

--- a/springwolf-plugins/springwolf-amqp-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-amqp-plugin/build.gradle
@@ -16,8 +16,8 @@ version '0.8.0' + (isSnapshot ? '-SNAPSHOT' : '')
 dependencies {
     api project(":springwolf-core")
 
-    implementation "com.asyncapi:asyncapi-core"
-    implementation "org.slf4j:slf4j-api"
+    implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
+    implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 
     implementation "org.springframework:spring-context"
     implementation "org.springframework:spring-core"
@@ -31,15 +31,15 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
-    testImplementation "org.assertj:assertj-core:${assertjVersion}"
-    testImplementation "org.junit.jupiter:junit-jupiter-api"
-    testImplementation "org.mockito:mockito-core"
+    testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
+    testImplementation "org.mockito:mockito-core:${mockitoCoreVersion}"
 
     testImplementation "org.springframework.boot:spring-boot-test"
     testImplementation "org.springframework:spring-beans"
     testImplementation "org.springframework:spring-test"
 
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 }
 

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/build.gradle
@@ -26,8 +26,8 @@ dependencyManagement {
 dependencies {
     api project(":springwolf-core")
 
-    implementation "com.asyncapi:asyncapi-core"
-    implementation "org.slf4j:slf4j-api"
+    implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
+    implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 
     implementation "org.springframework:spring-context"
     implementation "org.springframework.cloud:spring-cloud-stream"
@@ -37,12 +37,12 @@ dependencies {
 
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
 
-    testImplementation "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
     testImplementation "org.apache.kafka:kafka-streams:${kafkaStreamsVersion}"
-    testImplementation "org.junit.jupiter:junit-jupiter-api"
-    testImplementation "org.mockito:mockito-core"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
+    testImplementation "org.mockito:mockito-core:${mockitoCoreVersion}"
 
     testImplementation "org.springframework.boot:spring-boot-test"
     testImplementation "org.springframework:spring-beans"

--- a/springwolf-plugins/springwolf-kafka-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-kafka-plugin/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
     implementation "io.swagger.core.v3:swagger-models:${swaggerModelsVersion}"
     implementation "org.apache.kafka:kafka-clients:${kafkaClientsVersion}"
-    implementation "org.slf4j:slf4j-api"
+    implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 
     implementation "org.springframework:spring-beans"
     implementation "org.springframework:spring-context"
@@ -35,10 +35,10 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
     testRuntimeOnly "org.springframework.boot:spring-boot-starter-web"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
 
     testImplementation "org.mockito:mockito-core:${mockitoCoreVersion}"
     testImplementation "org.mockito:mockito-junit-jupiter:${mockitoJunitJupiterVersion}"
@@ -48,7 +48,7 @@ dependencies {
 
     testImplementation "org.springframework:spring-test"
 
-    testImplementation "org.assertj:assertj-core"
+    testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
 }
 
 jar {


### PR DESCRIPTION
that are not managed by spring in dependencies.gradle

Otherwise the pom file is generated without a version, which leads to errors for all projects consuming springwolf-core, ...

Addressing: https://github.com/springwolf/springwolf-core/issues/232