### PR TITLE
build: Fixed Swagger-Core dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,16 @@
+build/
+springwolf-add-ons/build/
 springwolf-core/build/
+springwolf-examples/build/
+springwolf-plugins/build/
 springwolf-ui/build/
+springwolf-add-ons/springwolf-common-model-converters/build/
 springwolf-examples/springwolf-amqp-example/build/
 springwolf-examples/springwolf-cloud-stream-example/build/
 springwolf-examples/springwolf-kafka-example/build/
 springwolf-plugins/springwolf-amqp-plugin/build/
 springwolf-plugins/springwolf-cloud-stream-plugin/build/
 springwolf-plugins/springwolf-kafka-plugin/build/
-springwolf-add-ons/springwolf-common-model-converters/build/
 
 .gradle/
 .idea/

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -50,10 +50,7 @@ ext {
     slf4jApiVersion = '2.0.7'
 
     swaggerCoreJakartaVersion = '2.2.13'
-    swaggerModelsJakartaVersion = '2.2.11'
 
-    swaggerAnnotationsJakartaVersion = '2.2.11'
-    swaggerAnnotationsVersion = '2.2.12'
     swaggerInflectorVersion = '2.0.9'
     swaggerModelsVersion = '2.2.12'
     swaggerParserCoreVersion = '2.1.15'

--- a/springwolf-add-ons/springwolf-common-model-converters/build.gradle
+++ b/springwolf-add-ons/springwolf-common-model-converters/build.gradle
@@ -19,9 +19,9 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
 
-    implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerAnnotationsJakartaVersion}"
+    implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerCoreJakartaVersion}"
     implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreJakartaVersion}"
-    implementation "io.swagger.core.v3:swagger-models-jakarta:${swaggerModelsJakartaVersion}"
+    implementation "io.swagger.core.v3:swagger-models-jakarta:${swaggerCoreJakartaVersion}"
 
     implementation "javax.money:money-api:${moneyApiVersion}"
 

--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -30,7 +30,7 @@ dependencies {
         exclude group: "javax.validation"
     }
 
-    implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerAnnotationsVersion}@jar"
+    implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerCoreJakartaVersion}@jar"
     implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreJakartaVersion}"
 
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}"
@@ -48,7 +48,7 @@ dependencies {
     implementation "org.springframework:spring-core"
     implementation "org.springframework.boot:spring-boot-autoconfigure"
 
-    implementation "io.swagger.core.v3:swagger-models-jakarta:${swaggerModelsJakartaVersion}"
+    implementation "io.swagger.core.v3:swagger-models-jakarta:${swaggerCoreJakartaVersion}"
     implementation "jakarta.annotation:jakarta.annotation-api:${jakartaAnnotationApiVersion}"
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"

--- a/springwolf-examples/springwolf-amqp-example/build.gradle
+++ b/springwolf-examples/springwolf-amqp-example/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     implementation "org.springframework.amqp:spring-rabbit"
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
-    implementation "io.swagger.core.v3:swagger-annotations:${swaggerAnnotationsVersion}"
+    implementation "io.swagger.core.v3:swagger-annotations:${swaggerCoreJakartaVersion}"
     implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
 
     implementation "org.springframework.amqp:spring-amqp"

--- a/springwolf-examples/springwolf-cloud-stream-example/build.gradle
+++ b/springwolf-examples/springwolf-cloud-stream-example/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
     implementation "org.apache.kafka:kafka-streams:${kafkaStreamsVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
-    implementation "io.swagger.core.v3:swagger-annotations:${swaggerAnnotationsVersion}"
+    implementation "io.swagger.core.v3:swagger-annotations:${swaggerCoreJakartaVersion}"
 
     implementation "org.springframework.boot:spring-boot-autoconfigure"
     implementation "org.springframework.boot:spring-boot"

--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation "org.springframework.security:spring-security-web"
 
     implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
-    implementation "io.swagger.core.v3:swagger-annotations:${swaggerAnnotationsVersion}"
+    implementation "io.swagger.core.v3:swagger-annotations:${swaggerCoreJakartaVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 
     implementation "javax.money:money-api:${moneyApiVersion}"


### PR DESCRIPTION
https://github.com/swagger-api/swagger-core is a monorepo and all the group dependencies are released together.

With the merge of https://github.com/springwolf/springwolf-core/pull/240 a breaking change was introduced and the code was not compiling anymore. Also, for some reason DependaBot was not identifying the need to update the rest of the dependencies.

Now we align all the Swagger-Core related dependencies.