### PR TITLE
GH-242: chore: Reduce jackson dependency to single one

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,10 +27,7 @@ ext {
     kafkaClientsVersion = '3.4.0'
     kafkaStreamsVersion = '3.4.0'
 
-    jacksonAnnotationsVersion = '2.15.0'
     jacksonCoreVersion = '2.15.0'
-    jacksonDatabindVersion = '2.15.0'
-    jacksonDataformatYamlVersion = '2.15.0'
 
     jakartaAnnotationApiVersion = '2.1.1'
 
@@ -38,7 +35,6 @@ ext {
     mockitoJunitJupiterVersion = '5.4.0'
 
     monetaVersion = '1.4.2'
-    monetaCoreVersion = '1.4.2'
 
     moneyApiVersion = '1.1'
 

--- a/springwolf-add-ons/springwolf-common-model-converters/build.gradle
+++ b/springwolf-add-ons/springwolf-common-model-converters/build.gradle
@@ -16,8 +16,8 @@ version '0.1.2' + (isSnapshot ? '-SNAPSHOT' : '')
 dependencies {
     implementation "org.springframework:spring-context"
 
-    implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonCoreVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonCoreVersion}"
 
     implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerCoreJakartaVersion}"
     implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreJakartaVersion}"

--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -33,10 +33,10 @@ dependencies {
     implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerCoreJakartaVersion}@jar"
     implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreJakartaVersion}"
 
-    implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonCoreVersion}"
     implementation "com.fasterxml.jackson.core:jackson-core:${jacksonCoreVersion}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonDataformatYamlVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonCoreVersion}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonCoreVersion}"
 
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 


### PR DESCRIPTION
com.fasterxml.jackson is also released together, so each artifact has the same version