### PR TITLE
build: fixed compile warning

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,7 +13,7 @@
  *  - add a 'Version' suffix
  *
  *  e.g.: com.asyncapi:asyncapi-core' will be 'asyncapiCoreVersion'
- *  e.g.: 'io.swagger.core.v3:swagger-core-jakarta' will be 'swaggerCoreJakartaVersion'
+ *  e.g.: 'io.swagger.core.v3:swagger-core-jakarta' will be 'swaggerCoreVersion'
  *
  * The dependencies are sorted alphabetically.
  */
@@ -51,10 +51,9 @@ ext {
 
     slf4jApiVersion = '2.0.7'
 
-    swaggerCoreJakartaVersion = '2.2.13'
+    swaggerCoreVersion = '2.2.13'
 
     swaggerInflectorVersion = '2.0.9'
-    swaggerModelsVersion = '2.2.12'
     swaggerParserCoreVersion = '2.1.15'
 
     testcontainersVersion = '1.18.3'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,6 +24,8 @@ ext {
     awaitilityVersion = '4.2.0'
     commonsIoVersion = '2.13.0'
 
+    findbugsJSR305Version = '3.0.2'
+
     kafkaClientsVersion = '3.4.0'
     kafkaStreamsVersion = '3.4.0'
 

--- a/springwolf-add-ons/springwolf-common-model-converters/build.gradle
+++ b/springwolf-add-ons/springwolf-common-model-converters/build.gradle
@@ -19,9 +19,9 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
 
-    implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerCoreJakartaVersion}"
-    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreJakartaVersion}"
-    implementation "io.swagger.core.v3:swagger-models-jakarta:${swaggerCoreJakartaVersion}"
+    implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerCoreVersion}"
+    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
+    implementation "io.swagger.core.v3:swagger-models-jakarta:${swaggerCoreVersion}"
 
     implementation "javax.money:money-api:${moneyApiVersion}"
 

--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -30,8 +30,8 @@ dependencies {
         exclude group: "javax.validation"
     }
 
-    implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerCoreJakartaVersion}@jar"
-    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreJakartaVersion}"
+    implementation "io.swagger.core.v3:swagger-annotations-jakarta:${swaggerCoreVersion}@jar"
+    implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerCoreVersion}"
 
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}"
     implementation "com.fasterxml.jackson.core:jackson-core:${jacksonCoreVersion}"
@@ -48,7 +48,7 @@ dependencies {
     implementation "org.springframework:spring-core"
     implementation "org.springframework.boot:spring-boot-autoconfigure"
 
-    implementation "io.swagger.core.v3:swagger-models-jakarta:${swaggerCoreJakartaVersion}"
+    implementation "io.swagger.core.v3:swagger-models-jakarta:${swaggerCoreVersion}"
     implementation "jakarta.annotation:jakarta.annotation-api:${jakartaAnnotationApiVersion}"
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"

--- a/springwolf-examples/springwolf-amqp-example/build.gradle
+++ b/springwolf-examples/springwolf-amqp-example/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     implementation "org.springframework.amqp:spring-rabbit"
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
-    implementation "io.swagger.core.v3:swagger-annotations:${swaggerCoreJakartaVersion}"
+    implementation "io.swagger.core.v3:swagger-annotations:${swaggerCoreVersion}"
     implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
 
     implementation "org.springframework.amqp:spring-amqp"

--- a/springwolf-examples/springwolf-cloud-stream-example/build.gradle
+++ b/springwolf-examples/springwolf-cloud-stream-example/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
     implementation "org.apache.kafka:kafka-streams:${kafkaStreamsVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
-    implementation "io.swagger.core.v3:swagger-annotations:${swaggerCoreJakartaVersion}"
+    implementation "io.swagger.core.v3:swagger-annotations:${swaggerCoreVersion}"
 
     implementation "org.springframework.boot:spring-boot-autoconfigure"
     implementation "org.springframework.boot:spring-boot"

--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation "org.springframework.security:spring-security-web"
 
     implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
-    implementation "io.swagger.core.v3:swagger-annotations:${swaggerCoreJakartaVersion}"
+    implementation "io.swagger.core.v3:swagger-annotations:${swaggerCoreVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 
     implementation "javax.money:money-api:${moneyApiVersion}"

--- a/springwolf-plugins/springwolf-amqp-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-amqp-plugin/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation "org.springframework.amqp:spring-amqp"
     implementation "org.springframework.amqp:spring-rabbit"
 
+    compileOnly "com.google.code.findbugs:jsr305:${findbugsJSR305Version}"
+
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"

--- a/springwolf-plugins/springwolf-kafka-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-kafka-plugin/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 
     implementation "org.springframework.kafka:spring-kafka"
 
+    compileOnly "com.google.code.findbugs:jsr305:${findbugsJSR305Version}"
+
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"

--- a/springwolf-plugins/springwolf-kafka-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-kafka-plugin/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     api project(":springwolf-core")
 
     implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
-    implementation "io.swagger.core.v3:swagger-models:${swaggerModelsVersion}"
+    implementation "io.swagger.core.v3:swagger-models:${swaggerCoreVersion}"
     implementation "org.apache.kafka:kafka-clients:${kafkaClientsVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 


### PR DESCRIPTION
When doing any `compileJava` task, Gradle was showing a warning

```
warning: unknown enum constant When.MAYBE
  reason: class file for javax.annotation.meta.When not found
```

This issue was caused by the `javax.annotation.meta.When` enum not being available to your projects runtime (`org.springframework.lang.Nullable` references this enum, but it is not made available automatically)

Also, renamed `swaggerCoreJakartaVersion` to `swaggerCoreVersion`

The groupId is `io.swagger.core` the fact that an artifact is suffixed `-jakarta` or not doesn't change the versioning.

Also, aligned a previously missing `swagger-models` dependency.