### PR TITLE
feat: Added an `@AsyncOperationBinding` annotation to simplify the creation of new operation bindings

### DIFF
--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
+    testImplementation("org.junit.jupiter:junit-jupiter-params:${junitJupiterVersion}")
     testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
     testImplementation "com.vaadin.external.google:android-json:${androidJsonVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoCoreVersion}"

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/AbstractOperationBindingProcessor.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/AbstractOperationBindingProcessor.java
@@ -1,0 +1,44 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.AsyncOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProcessedOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.OperationBindingProcessor;
+import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.util.StringUtils;
+import org.springframework.util.StringValueResolver;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
+import java.util.Optional;
+
+public abstract class AbstractOperationBindingProcessor<A>
+        implements OperationBindingProcessor, EmbeddedValueResolverAware {
+    private StringValueResolver resolver;
+
+    @Override
+    public void setEmbeddedValueResolver(StringValueResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public Optional<ProcessedOperationBinding> process(Method method) {
+        final Class<A> clazz = getGenericAnnotationClass();
+
+        return Arrays.stream(method.getAnnotations())
+                .filter(annotation -> annotation.annotationType().isAnnotationPresent(AsyncOperationBinding.class))
+                .map(clazz::cast)
+                .findAny()
+                .map(this::mapToOperationBinding);
+    }
+
+    private Class<A> getGenericAnnotationClass() {
+        return (Class<A>) ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0];
+    }
+
+    protected abstract ProcessedOperationBinding mapToOperationBinding(A bindingAnnotation);
+
+    protected String resolveOrNull(String stringValue) {
+        return StringUtils.hasText(stringValue) ? resolver.resolveStringValue(stringValue) : null;
+    }
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncOperationBinding.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncOperationBinding.java
@@ -1,0 +1,19 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code @AsyncOperationBinding} is a meta-annotation used to identify Operation Binding annotations.
+ * </p>
+ * The annotations annotated with {@code @AsyncOperationBinding} are intended to provide the Operation Bindings
+ * Object documentation. Those implementations are usually available in its own plugin, like {@code springwolf-kafka-plugin}
+ * or {@code springwolf-amqp-plugin}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.ANNOTATION_TYPE})
+@Inherited
+public @interface AsyncOperationBinding {}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/TestAbstractOperationBindingProcessor.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/TestAbstractOperationBindingProcessor.java
@@ -1,0 +1,30 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
+
+import com.asyncapi.v2.binding.operation.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.AbstractOperationBindingProcessor;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.AsyncOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProcessedOperationBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+public class TestAbstractOperationBindingProcessor
+        extends AbstractOperationBindingProcessor<TestAbstractOperationBindingProcessor.TestOperationBinding> {
+    public static final String TYPE = "testType";
+    public static final OperationBinding BINDING = new OperationBinding();
+
+    @Override
+    protected ProcessedOperationBinding mapToOperationBinding(TestOperationBinding bindingAnnotation) {
+        return new ProcessedOperationBinding(TYPE, BINDING);
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(value = {ElementType.METHOD})
+    @AsyncOperationBinding
+    public @interface TestOperationBinding {
+        TestMessageBindingProcessor.TestMessageBinding messageBinding() default
+                @TestMessageBindingProcessor.TestMessageBinding();
+    }
+}

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AmqpOperationBindingProcessor.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/AmqpOperationBindingProcessor.java
@@ -1,42 +1,21 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata;
 
 import com.asyncapi.v2.binding.operation.amqp.AMQPOperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.AbstractOperationBindingProcessor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AmqpAsyncOperationBinding;
-import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.OperationBindingProcessor;
-import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
-import org.springframework.util.StringValueResolver;
 
-import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Component
-public class AmqpOperationBindingProcessor implements OperationBindingProcessor, EmbeddedValueResolverAware {
-    private StringValueResolver resolver;
-
+public class AmqpOperationBindingProcessor extends AbstractOperationBindingProcessor<AmqpAsyncOperationBinding> {
     @Override
-    public void setEmbeddedValueResolver(StringValueResolver resolver) {
-        this.resolver = resolver;
-    }
-
-    @Override
-    public Optional<ProcessedOperationBinding> process(Method method) {
-        return Arrays.stream(method.getAnnotations())
-                .filter(annotation -> annotation instanceof AmqpAsyncOperationBinding)
-                .map(annotation -> (AmqpAsyncOperationBinding) annotation)
-                .findAny()
-                .map(this::mapToOperationBinding);
-    }
-
-    private ProcessedOperationBinding mapToOperationBinding(AmqpAsyncOperationBinding bindingAnnotation) {
+    protected ProcessedOperationBinding mapToOperationBinding(AmqpAsyncOperationBinding bindingAnnotation) {
         AMQPOperationBinding amqpOperationBinding = AMQPOperationBinding.builder()
                 .expiration(bindingAnnotation.expiration())
                 .cc(Arrays.stream(bindingAnnotation.cc())
                         .map(this::resolveOrNull)
-                        .collect(Collectors.toList()))
+                        .toList())
                 .priority(bindingAnnotation.priority())
                 .deliveryMode(bindingAnnotation.deliveryMode())
                 .mandatory(bindingAnnotation.mandatory())
@@ -45,9 +24,5 @@ public class AmqpOperationBindingProcessor implements OperationBindingProcessor,
                 .build();
 
         return new ProcessedOperationBinding(bindingAnnotation.type(), amqpOperationBinding);
-    }
-
-    private String resolveOrNull(String stringValue) {
-        return StringUtils.hasText(stringValue) ? resolver.resolveStringValue(stringValue) : null;
     }
 }

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AmqpAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AmqpAsyncOperationBinding.java
@@ -1,5 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
 
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.AsyncOperationBinding;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -11,6 +13,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})
+@AsyncOperationBinding
 public @interface AmqpAsyncOperationBinding {
 
     String type() default "amqp";

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/KafkaOperationBindingProcessor.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/KafkaOperationBindingProcessor.java
@@ -2,37 +2,16 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata
 
 import com.asyncapi.v2.binding.operation.kafka.KafkaOperationBinding;
 import com.asyncapi.v2.schema.Schema;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.AbstractOperationBindingProcessor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.KafkaListenerUtil;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.KafkaAsyncOperationBinding;
-import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.OperationBindingProcessor;
-import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-import org.springframework.util.StringValueResolver;
-
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Optional;
 
 @Component
-public class KafkaOperationBindingProcessor implements OperationBindingProcessor, EmbeddedValueResolverAware {
-    private StringValueResolver resolver;
-
+public class KafkaOperationBindingProcessor extends AbstractOperationBindingProcessor<KafkaAsyncOperationBinding> {
     @Override
-    public void setEmbeddedValueResolver(StringValueResolver resolver) {
-        this.resolver = resolver;
-    }
-
-    @Override
-    public Optional<ProcessedOperationBinding> process(Method method) {
-        return Arrays.stream(method.getAnnotations())
-                .filter(annotation -> annotation instanceof KafkaAsyncOperationBinding)
-                .map(annotation -> (KafkaAsyncOperationBinding) annotation)
-                .findAny()
-                .map(this::mapToOperationBinding);
-    }
-
-    private ProcessedOperationBinding mapToOperationBinding(KafkaAsyncOperationBinding bindingAnnotation) {
+    protected ProcessedOperationBinding mapToOperationBinding(KafkaAsyncOperationBinding bindingAnnotation) {
         String clientId = resolveOrNull(bindingAnnotation.clientId());
         Schema clientIdSchema = KafkaListenerUtil.buildKafkaClientIdSchema(clientId);
         String groupId = resolveOrNull(bindingAnnotation.groupId());
@@ -47,9 +26,5 @@ public class KafkaOperationBindingProcessor implements OperationBindingProcessor
         }
 
         return new ProcessedOperationBinding(bindingAnnotation.type(), kafkaOperationBindingBuilder.build());
-    }
-
-    private String resolveOrNull(String stringValue) {
-        return StringUtils.hasText(stringValue) ? resolver.resolveStringValue(stringValue) : null;
     }
 }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/KafkaAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/KafkaAsyncOperationBinding.java
@@ -1,5 +1,7 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
 
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.AsyncOperationBinding;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -11,6 +13,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD})
+@AsyncOperationBinding
 public @interface KafkaAsyncOperationBinding {
 
     String type() default "kafka";


### PR DESCRIPTION
So far we had 2 Operation Binding implementations: `springwolf-kafka-plugin` and `springwolf-amqp-plugin`. Now we have a new annotation that can be used to simplify the implementation of new bindings, reducing code duplicities.

Any new `OperationBindingProcessor` can extend from the new `AbstractOperationBindingProcessor`.

This PR is created as a first draft to follow up from the https://github.com/springwolf/springwolf-core/issues/288#issuecomment-1636082284 comment.

@timonback @sam0r040 What do you think of this approach? Would make sense to do something similar with the `MessageBindingProcessor`? My next step would be to create a new `GooglePubSubBinding` implementation, probably as its own plugin, using this approach.