### PR TITLE
chore: Only publish actual artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,9 @@ allprojects {
 
     var publishedEnabled = (
             project.name == 'springwolf-core' ||
-            project.name == 'springwolf-amqp-plugin' ||
-            project.name == 'springwolf-cloud-stream-plugin' ||
-            project.name == 'springwolf-kafka-plugin' ||
+            project.name == 'springwolf-amqp' ||
+            project.name == 'springwolf-cloud-stream' ||
+            project.name == 'springwolf-kafka' ||
             project.name == 'springwolf-ui' ||
             project.name == 'springwolf-common-model-converters')
     tasks.withType(PublishToMavenRepository).configureEach { it.enabled = publishedEnabled }

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,15 @@ allprojects {
         mavenCentral()
     }
 
+    var publishedEnabled = (
+            project.name == 'springwolf-core' ||
+            project.name == 'springwolf-amqp-plugin' ||
+            project.name == 'springwolf-cloud-stream-plugin' ||
+            project.name == 'springwolf-kafka-plugin' ||
+            project.name == 'springwolf-ui' ||
+            project.name == 'springwolf-common-model-converters')
+    tasks.withType(PublishToMavenRepository).configureEach { it.enabled = publishedEnabled }
+    tasks.withType(PublishToMavenLocal).configureEach { it.enabled = publishedEnabled }
     publishing {
         publications {
             mavenJava(MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -46,15 +46,15 @@ allprojects {
         mavenCentral()
     }
 
-    var publishedEnabled = (
+    var publishingEnabled = (
             project.name == 'springwolf-core' ||
             project.name == 'springwolf-amqp' ||
             project.name == 'springwolf-cloud-stream' ||
             project.name == 'springwolf-kafka' ||
             project.name == 'springwolf-ui' ||
             project.name == 'springwolf-common-model-converters')
-    tasks.withType(PublishToMavenRepository).configureEach { it.enabled = publishedEnabled }
-    tasks.withType(PublishToMavenLocal).configureEach { it.enabled = publishedEnabled }
+    tasks.withType(PublishToMavenRepository).configureEach { it.enabled = publishingEnabled }
+    tasks.withType(PublishToMavenLocal).configureEach { it.enabled = publishingEnabled }
     publishing {
         publications {
             mavenJava(MavenPublication) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,3 +12,7 @@ include(
         'springwolf-add-ons:springwolf-common-model-converters'
 )
 
+project(':springwolf-plugins:springwolf-amqp-plugin').name = 'springwolf-amqp'
+project(':springwolf-plugins:springwolf-cloud-stream-plugin').name = 'springwolf-cloud-stream'
+project(':springwolf-plugins:springwolf-kafka-plugin').name = 'springwolf-kafka'
+

--- a/springwolf-examples/springwolf-amqp-example/build.gradle
+++ b/springwolf-examples/springwolf-amqp-example/build.gradle
@@ -43,10 +43,6 @@ dependencies {
     testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
 }
 
-// We don't want to publish the examples
-tasks.withType(PublishToMavenRepository).configureEach { it.enabled = false }
-tasks.withType(PublishToMavenLocal).configureEach { it.enabled = false }
-
 docker {
     springBootApplication {
         maintainer = 'shamir.stav@gmail.com'

--- a/springwolf-examples/springwolf-amqp-example/build.gradle
+++ b/springwolf-examples/springwolf-amqp-example/build.gradle
@@ -10,9 +10,9 @@ plugins {
 
 dependencies {
     implementation project(":springwolf-core")
-    implementation project(":springwolf-plugins:springwolf-amqp-plugin")
+    implementation project(":springwolf-plugins:springwolf-amqp")
 
-    annotationProcessor project(":springwolf-plugins:springwolf-amqp-plugin")
+    annotationProcessor project(":springwolf-plugins:springwolf-amqp")
     runtimeOnly project(":springwolf-ui")
 
     runtimeOnly "org.springframework.boot:spring-boot-starter-web"

--- a/springwolf-examples/springwolf-cloud-stream-example/build.gradle
+++ b/springwolf-examples/springwolf-cloud-stream-example/build.gradle
@@ -50,10 +50,6 @@ dependencies {
     testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
 }
 
-// We don't want to publish the examples
-tasks.withType(PublishToMavenRepository).configureEach { it.enabled = false }
-tasks.withType(PublishToMavenLocal).configureEach { it.enabled = false }
-
 docker {
     springBootApplication {
         maintainer = 'shamir.stav@gmail.com'

--- a/springwolf-examples/springwolf-cloud-stream-example/build.gradle
+++ b/springwolf-examples/springwolf-cloud-stream-example/build.gradle
@@ -20,8 +20,8 @@ dependencyManagement {
 dependencies {
     implementation project(":springwolf-core")
 
-    runtimeOnly project(":springwolf-plugins:springwolf-cloud-stream-plugin")
-    annotationProcessor project(":springwolf-plugins:springwolf-cloud-stream-plugin")
+    runtimeOnly project(":springwolf-plugins:springwolf-cloud-stream")
+    annotationProcessor project(":springwolf-plugins:springwolf-cloud-stream")
 
     runtimeOnly project(":springwolf-ui")
     runtimeOnly "org.springframework.boot:spring-boot-starter-web"

--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -59,10 +59,6 @@ dependencies {
     permitTestUnusedDeclared "org.apache.kafka:kafka-clients:${kafkaClientsVersion}:test@jar"
 }
 
-// We don't want to publish the examples
-tasks.withType(PublishToMavenRepository).configureEach { it.enabled = false }
-tasks.withType(PublishToMavenLocal).configureEach { it.enabled = false }
-
 docker {
     springBootApplication {
         maintainer = 'shamir.stav@gmail.com'

--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -11,12 +11,12 @@ plugins {
 
 dependencies {
     implementation project(":springwolf-core")
-    implementation project(":springwolf-plugins:springwolf-kafka-plugin")
+    implementation project(":springwolf-plugins:springwolf-kafka")
 
     runtimeOnly project(":springwolf-add-ons:springwolf-common-model-converters")
     runtimeOnly project(":springwolf-ui")
 
-    annotationProcessor project(":springwolf-plugins:springwolf-kafka-plugin")
+    annotationProcessor project(":springwolf-plugins:springwolf-kafka")
 
     runtimeOnly "org.springframework.boot:spring-boot-starter-web"
 


### PR DESCRIPTION
The current configuration also tries to publish `springwolf-add-ons`, `springwolf-examples`, `springwolf-plugins`