### PR TITLE
Feat/amqp handle routing key

### DIFF
--- a/springwolf-examples/springwolf-amqp-example/README.md
+++ b/springwolf-examples/springwolf-amqp-example/README.md
@@ -4,3 +4,4 @@
 1. Copy the `docker-compose.yml` file to your machine.
 2. Run `$ docker-compose up`.
 3. Visit `localhost:8080/springwolf/asyncapi-ui.html` or try the API: `$ curl localhost:8080/springwolf/docs`.
+4. RabbitMQ Management: `http://localhost:15672` using `guest:guest` as login

--- a/springwolf-examples/springwolf-amqp-example/build.gradle
+++ b/springwolf-examples/springwolf-amqp-example/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     testImplementation "com.vaadin.external.google:android-json:${androidJsonVersion}"
 
     testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
+    testImplementation "org.awaitility:awaitility:${awaitilityVersion}"
+    testImplementation "org.mockito:mockito-core:${mockitoCoreVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
 
     testImplementation "org.springframework.boot:spring-boot-test"

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/configuration/RabbitConfiguration.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/configuration/RabbitConfiguration.java
@@ -32,7 +32,7 @@ public class RabbitConfiguration {
 
     @Bean
     public Queue exampleBindingsQueue() {
-        return new Queue("example-bindings-queue", false);
+        return new Queue("example-bindings-queue", false, true, true);
     }
 
     @Bean

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/consumers/ExampleConsumer.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/consumers/ExampleConsumer.java
@@ -2,6 +2,8 @@ package io.github.stavshamir.springwolf.example.amqp.consumers;
 
 import io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto;
 import io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto;
+import io.github.stavshamir.springwolf.example.amqp.producers.ExampleProducer;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.ExchangeTypes;
 import org.springframework.amqp.rabbit.annotation.Exchange;
@@ -12,11 +14,15 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class ExampleConsumer {
+
+    private final ExampleProducer exampleProducer;
 
     @RabbitListener(queues = "example-queue")
     public void receiveExamplePayload(ExamplePayloadDto payload) {
         log.info("Received new message in example-queue: {}", payload.toString());
+        exampleProducer.sendMessage(payload);
     }
 
     @RabbitListener(queues = "another-queue")
@@ -28,7 +34,8 @@ public class ExampleConsumer {
             bindings = {
                 @QueueBinding(
                         exchange = @Exchange(name = "name", type = ExchangeTypes.TOPIC),
-                        value = @Queue(name = "example-bindings-queue"))
+                        value = @Queue(name = "example-bindings-queue", durable = "false"),
+                        key = "example-topic-routing-key")
             })
     public void bindingsExample(AnotherPayloadDto payload) {
         log.info("Received new message in example-bindings-queue: {}", payload.toString());

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/consumers/ExampleConsumer.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/consumers/ExampleConsumer.java
@@ -33,8 +33,13 @@ public class ExampleConsumer {
     @RabbitListener(
             bindings = {
                 @QueueBinding(
-                        exchange = @Exchange(name = "name", type = ExchangeTypes.TOPIC),
-                        value = @Queue(name = "example-bindings-queue", durable = "false"),
+                        exchange = @Exchange(name = "example-bindings-exchange-name", type = ExchangeTypes.TOPIC),
+                        value =
+                                @Queue(
+                                        name = "example-bindings-queue",
+                                        durable = "false",
+                                        exclusive = "true",
+                                        autoDelete = "true"),
                         key = "example-topic-routing-key")
             })
     public void bindingsExample(AnotherPayloadDto payload) {

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/dtos/AnotherPayloadDto.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/dtos/AnotherPayloadDto.java
@@ -1,11 +1,23 @@
 package io.github.stavshamir.springwolf.example.amqp.dtos;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Schema(description = "Another payload model")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
 public class AnotherPayloadDto {
 
     @Schema(description = "Foo field", example = "bar", requiredMode = NOT_REQUIRED)
@@ -13,25 +25,4 @@ public class AnotherPayloadDto {
 
     @Schema(description = "Example field", requiredMode = REQUIRED)
     private ExamplePayloadDto example;
-
-    public String getFoo() {
-        return foo;
-    }
-
-    public void setFoo(String foo) {
-        this.foo = foo;
-    }
-
-    public ExamplePayloadDto getExample() {
-        return example;
-    }
-
-    public void setExample(ExamplePayloadDto example) {
-        this.example = example;
-    }
-
-    @Override
-    public String toString() {
-        return "AnotherPayloadDto{" + "foo='" + foo + '\'' + ", example=" + example + '}';
-    }
 }

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/dtos/AnotherPayloadDto.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/dtos/AnotherPayloadDto.java
@@ -2,22 +2,16 @@ package io.github.stavshamir.springwolf.example.amqp.dtos;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Schema(description = "Another payload model")
+@Data
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
-@Setter
-@EqualsAndHashCode
-@ToString
 public class AnotherPayloadDto {
 
     @Schema(description = "Foo field", example = "bar", requiredMode = NOT_REQUIRED)

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/dtos/ExamplePayloadDto.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/dtos/ExamplePayloadDto.java
@@ -1,10 +1,16 @@
 package io.github.stavshamir.springwolf.example.amqp.dtos;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Schema(description = "Example payload model")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ExamplePayloadDto {
     @Schema(description = "Some string field", example = "some string value", requiredMode = REQUIRED)
     private String someString;
@@ -15,41 +21,9 @@ public class ExamplePayloadDto {
     @Schema(description = "Some enum field", example = "FOO2", requiredMode = REQUIRED)
     private ExampleEnum someEnum;
 
-    public String getSomeString() {
-        return someString;
-    }
-
-    public void setSomeString(String someString) {
-        this.someString = someString;
-    }
-
-    public long getSomeLong() {
-        return someLong;
-    }
-
-    public void setSomeLong(long someLong) {
-        this.someLong = someLong;
-    }
-
-    public ExampleEnum getSomeEnum() {
-        return someEnum;
-    }
-
-    public void setSomeEnum(ExampleEnum someEnum) {
-        this.someEnum = someEnum;
-    }
-
     enum ExampleEnum {
         FOO1,
         FOO2,
         FOO3
-    }
-
-    @Override
-    public String toString() {
-        return "ExamplePayloadDto{" + "someString='"
-                + someString + '\'' + ", someLong="
-                + someLong + ", someEnum="
-                + someEnum + '}';
     }
 }

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/dtos/ExamplePayloadDto.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/dtos/ExamplePayloadDto.java
@@ -21,7 +21,7 @@ public class ExamplePayloadDto {
     @Schema(description = "Some enum field", example = "FOO2", requiredMode = REQUIRED)
     private ExampleEnum someEnum;
 
-    enum ExampleEnum {
+    public enum ExampleEnum {
         FOO1,
         FOO2,
         FOO3

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/producers/ExampleProducer.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/producers/ExampleProducer.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class ExampleProducer {
-private final RabbitTemplate rabbitTemplate;
+    private final RabbitTemplate rabbitTemplate;
 
     @AsyncPublisher(
             operation =

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/producers/ExampleProducer.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/stavshamir/springwolf/example/amqp/producers/ExampleProducer.java
@@ -3,11 +3,16 @@ package io.github.stavshamir.springwolf.example.amqp.producers;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AmqpAsyncOperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
+import io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto;
 import io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class ExampleProducer {
+private final RabbitTemplate rabbitTemplate;
 
     @AsyncPublisher(
             operation =
@@ -17,5 +22,7 @@ public class ExampleProducer {
     @AmqpAsyncOperationBinding()
     public void sendMessage(ExamplePayloadDto msg) {
         // send
+        AnotherPayloadDto dto = new AnotherPayloadDto("fooValue", msg);
+        rabbitTemplate.convertAndSend("example-topic-exchange", "example-topic-routing-key", dto);
     }
 }

--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/amqp/ProducerIntegrationWithDockerIntegrationTest.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/amqp/ProducerIntegrationWithDockerIntegrationTest.java
@@ -1,0 +1,80 @@
+package io.github.stavshamir.springwolf.example.amqp;
+
+import io.github.stavshamir.springwolf.example.amqp.consumers.ExampleConsumer;
+import io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto;
+import io.github.stavshamir.springwolf.producer.SpringwolfAmqpProducer;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.amqp.AmqpIOException;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.File;
+
+import static io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto.ExampleEnum.FOO1;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+/**
+ * While the assertion of this test is identical to ApiIntegrationTests,
+ * the setup uses a full docker-compose context with a real sqs instance.
+ */
+@SpringBootTest(
+        classes = {SpringwolfAmqpExampleApplication.class},
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@DirtiesContext
+@TestMethodOrder(OrderAnnotation.class)
+@TestPropertySource(properties = {"spring.rabbitmq.host=localhost"})
+// @Ignore("Uncomment this line if you have issues running this test on your local machine.")
+public class ProducerIntegrationWithDockerIntegrationTest {
+
+    @Autowired
+    SpringwolfAmqpProducer springwolfAmqpProducer;
+
+    @SpyBean
+    ExampleConsumer exampleConsumer;
+
+    @Container
+    public static DockerComposeContainer<?> environment =
+            new DockerComposeContainer<>(new File("docker-compose.yml")).withServices("amqp");
+
+    @Test
+    @Order(1)
+    void verifyAmqpIsAvailable() {
+        ConnectionFactory factory = new CachingConnectionFactory("localhost");
+
+        await().atMost(60, SECONDS).ignoreException(AmqpIOException.class).untilAsserted(() -> assertThat(
+                        factory.createConnection().isOpen())
+                .isTrue());
+    }
+
+    @Test
+    @Order(2)
+    void producerCanUseSpringwolfConfigurationToSendMessage() {
+        // given
+        ExamplePayloadDto payload = new ExamplePayloadDto();
+        payload.setSomeString("foo");
+        payload.setSomeLong(5);
+        payload.setSomeEnum(FOO1);
+
+        // when
+        springwolfAmqpProducer.send("example-queue", payload);
+
+        // then
+        verify(exampleConsumer, timeout(10000)).receiveExamplePayload(payload);
+    }
+}

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -62,7 +62,7 @@
           },
           "queue": {
             "name": "another-queue",
-            "durable": true,
+            "durable": false,
             "exclusive": false,
             "autoDelete": false,
             "vhost": "/"
@@ -229,7 +229,7 @@
           },
           "queue": {
             "name": "example-queue",
-            "durable": true,
+            "durable": false,
             "exclusive": false,
             "autoDelete": false,
             "vhost": "/"
@@ -272,7 +272,7 @@
           "is": "routingKey",
           "exchange": {
             "name": "example-topic-exchange",
-            "type": "direct",
+            "type": "topic",
             "durable": true,
             "autoDelete": false,
             "vhost": "/"

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -53,51 +53,18 @@
       "bindings": {
         "amqp": {
           "is": "queue",
-          "queue": {
-            "name": "another-queue"
-          },
           "exchange": {
             "name": "",
+            "type": "direct",
+            "durable": true,
+            "autoDelete": false,
             "vhost": "/"
           },
-          "bindingVersion": "0.2.0"
-        }
-      }
-    },
-    "example-bindings-queue": {
-      "publish": {
-        "operationId": "example-bindings-queue_publish_bindingsExample",
-        "description": "Auto-generated description",
-        "bindings": {
-          "amqp": {
-            "cc": [
-              ""
-            ],
-            "bindingVersion": "0.2.0"
-          }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
-          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
-          "title": "AnotherPayloadDto",
-          "payload": {
-            "$ref": "#/components/schemas/AnotherPayloadDto"
-          },
-          "headers": {
-            "$ref": "#/components/schemas/HeadersNotDocumented"
-          },
-          "bindings": {
-            "amqp": {
-              "bindingVersion": "0.2.0"
-            }
-          }
-        }
-      },
-      "bindings": {
-        "amqp": {
-          "is": "routingKey",
-          "exchange": {
-            "name": "name",
+          "queue": {
+            "name": "another-queue",
+            "durable": true,
+            "exclusive": false,
+            "autoDelete": false,
             "vhost": "/"
           },
           "bindingVersion": "0.2.0"
@@ -252,16 +219,26 @@
       },
       "bindings": {
         "amqp": {
-          "is": "routingKey",
+          "is": "queue",
           "exchange": {
             "name": "",
+            "type": "direct",
+            "durable": true,
+            "autoDelete": false,
+            "vhost": "/"
+          },
+          "queue": {
+            "name": "example-queue",
+            "durable": true,
+            "exclusive": false,
+            "autoDelete": false,
             "vhost": "/"
           },
           "bindingVersion": "0.2.0"
         }
       }
     },
-    "example-topic-routing-key": {
+    "example-topic-queue": {
       "publish": {
         "operationId": "example-topic-queue_publish_bindingsBeanExample",
         "description": "Auto-generated description",
@@ -295,17 +272,67 @@
           "is": "routingKey",
           "exchange": {
             "name": "example-topic-exchange",
-            "vhost": "/",
+            "type": "direct",
             "durable": true,
-            "type": "topic",
-            "autoDelete": false
+            "autoDelete": false,
+            "vhost": "/"
           },
           "queue": {
             "name": "example-topic-queue",
-            "vhost": "/",
             "durable": true,
-            "exclusive": "true",
-            "autoDelete": false
+            "exclusive": false,
+            "autoDelete": false,
+            "vhost": "/"
+          },
+          "bindingVersion": "0.2.0"
+        }
+      }
+    },
+    "example-topic-routing-key": {
+      "publish": {
+        "operationId": "example-topic-routing-key_publish_bindingsExample",
+        "description": "Auto-generated description",
+        "bindings": {
+          "amqp": {
+            "cc": [
+              "example-topic-routing-key"
+            ],
+            "bindingVersion": "0.2.0"
+          }
+        },
+        "message": {
+          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
+          "payload": {
+            "$ref": "#/components/schemas/AnotherPayloadDto"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
+          "bindings": {
+            "amqp": {
+              "bindingVersion": "0.2.0"
+            }
+          }
+        }
+      },
+      "bindings": {
+        "amqp": {
+          "is": "routingKey",
+          "exchange": {
+            "name": "example-bindings-exchange-name",
+            "type": "topic",
+            "durable": true,
+            "autoDelete": false,
+            "vhost": "/"
+          },
+          "queue": {
+            "name": "example-bindings-queue",
+            "durable": false,
+            "exclusive": true,
+            "autoDelete": true,
+            "vhost": "/"
           },
           "bindingVersion": "0.2.0"
         }

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -52,7 +52,10 @@
       },
       "bindings": {
         "amqp": {
-          "is": "routingKey",
+          "is": "queue",
+          "queue": {
+            "name": "another-queue"
+          },
           "exchange": {
             "name": "",
             "vhost": "/"
@@ -258,7 +261,7 @@
         }
       }
     },
-    "example-topic-queue": {
+    "example-topic-routing-key": {
       "publish": {
         "operationId": "example-topic-queue_publish_bindingsBeanExample",
         "description": "Auto-generated description",
@@ -292,7 +295,17 @@
           "is": "routingKey",
           "exchange": {
             "name": "example-topic-exchange",
-            "vhost": "/"
+            "vhost": "/",
+            "durable": true,
+            "type": "topic",
+            "autoDelete": false
+          },
+          "queue": {
+            "name": "example-topic-queue",
+            "vhost": "/",
+            "durable": true,
+            "exclusive": "true",
+            "autoDelete": false
           },
           "bindingVersion": "0.2.0"
         }

--- a/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/stavshamir/springwolf/example/cloudstream/payload/ConsumerPayload.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/stavshamir/springwolf/example/cloudstream/payload/ConsumerPayload.java
@@ -1,23 +1,13 @@
 package io.github.stavshamir.springwolf.example.cloudstream.payload;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ConsumerPayload {
 
     private String payloadString;
-
-    public ConsumerPayload(String payloadString) {
-        this.payloadString = payloadString;
-    }
-
-    public String getPayloadString() {
-        return payloadString;
-    }
-
-    public void setPayloadString(String payloadString) {
-        this.payloadString = payloadString;
-    }
-
-    @Override
-    public String toString() {
-        return "ConsumerPayload{" + "payloadString='" + payloadString + '\'' + '}';
-    }
 }

--- a/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/stavshamir/springwolf/example/cloudstream/payload/InputPayload.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/stavshamir/springwolf/example/cloudstream/payload/InputPayload.java
@@ -1,33 +1,18 @@
 package io.github.stavshamir.springwolf.example.cloudstream.payload;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Schema(description = "Input payload model")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class InputPayload {
 
     private List<String> foo;
     private int bar;
-
-    public List<String> getFoo() {
-        return foo;
-    }
-
-    public void setFoo(List<String> foo) {
-        this.foo = foo;
-    }
-
-    public int getBar() {
-        return bar;
-    }
-
-    public void setBar(int bar) {
-        this.bar = bar;
-    }
-
-    @Override
-    public String toString() {
-        return "InputPayload{" + "foo=" + foo + ", bar=" + bar + '}';
-    }
 }

--- a/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/stavshamir/springwolf/example/cloudstream/payload/OutputPayload.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/stavshamir/springwolf/example/cloudstream/payload/OutputPayload.java
@@ -1,16 +1,15 @@
 package io.github.stavshamir.springwolf.example.cloudstream.payload;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Schema(description = "Output payload model")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class OutputPayload {
-
-    public OutputPayload() {}
-
-    public OutputPayload(String someString, long someLong) {
-        this.someString = someString;
-        this.someLong = someLong;
-    }
 
     @Schema(
             description = "Some string field",
@@ -20,25 +19,4 @@ public class OutputPayload {
 
     @Schema(description = "Some long field", example = "5")
     private long someLong;
-
-    public String getSomeString() {
-        return someString;
-    }
-
-    public void setSomeString(String someString) {
-        this.someString = someString;
-    }
-
-    public long getSomeLong() {
-        return someLong;
-    }
-
-    public void setSomeLong(long someLong) {
-        this.someLong = someLong;
-    }
-
-    @Override
-    public String toString() {
-        return "OutputPayload{" + "someString='" + someString + '\'' + ", someLong=" + someLong + '}';
-    }
 }

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/dtos/AnotherPayloadDto.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/dtos/AnotherPayloadDto.java
@@ -1,11 +1,23 @@
 package io.github.stavshamir.springwolf.example.kafka.dtos;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Schema(description = "Another payload model")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
 public class AnotherPayloadDto {
 
     @Schema(description = "Foo field", example = "bar", requiredMode = NOT_REQUIRED)
@@ -13,25 +25,4 @@ public class AnotherPayloadDto {
 
     @Schema(description = "Example field", requiredMode = REQUIRED)
     private ExamplePayloadDto example;
-
-    public String getFoo() {
-        return foo;
-    }
-
-    public void setFoo(String foo) {
-        this.foo = foo;
-    }
-
-    public ExamplePayloadDto getExample() {
-        return example;
-    }
-
-    public void setExample(ExamplePayloadDto example) {
-        this.example = example;
-    }
-
-    @Override
-    public String toString() {
-        return "AnotherPayloadDto{" + "foo='" + foo + '\'' + ", example=" + example + '}';
-    }
 }

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/dtos/AnotherPayloadDto.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/dtos/AnotherPayloadDto.java
@@ -2,22 +2,16 @@ package io.github.stavshamir.springwolf.example.kafka.dtos;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Schema(description = "Another payload model")
+@Data
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
-@Setter
-@EqualsAndHashCode
-@ToString
 public class AnotherPayloadDto {
 
     @Schema(description = "Foo field", example = "bar", requiredMode = NOT_REQUIRED)

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/dtos/ExamplePayloadDto.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/dtos/ExamplePayloadDto.java
@@ -1,16 +1,16 @@
 package io.github.stavshamir.springwolf.example.kafka.dtos;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Schema(description = "Example payload model")
-@Getter
-@Setter
-@EqualsAndHashCode
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ExamplePayloadDto {
     @Schema(description = "Some string field", example = "some string value", requiredMode = REQUIRED)
     private String someString;
@@ -25,13 +25,5 @@ public class ExamplePayloadDto {
         FOO1,
         FOO2,
         FOO3
-    }
-
-    @Override
-    public String toString() {
-        return "ExamplePayloadDto{" + "someString='"
-                + someString + '\'' + ", someLong="
-                + someLong + ", someEnum="
-                + someEnum + '}';
     }
 }

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/dtos/NestedPayloadDto.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/dtos/NestedPayloadDto.java
@@ -2,36 +2,21 @@ package io.github.stavshamir.springwolf.example.kafka.dtos;
 
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.Set;
 
 @Schema(description = "Payload model with nested complex types")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class NestedPayloadDto {
     @ArraySchema(schema = @Schema(description = "Some string field", example = "some string value"), uniqueItems = true)
     private Set<String> someStrings;
 
     @ArraySchema
     private List<ExamplePayloadDto> examplePayloads;
-
-    public Set<String> getSomeStrings() {
-        return someStrings;
-    }
-
-    public void setSomeStrings(Set<String> someStrings) {
-        this.someStrings = someStrings;
-    }
-
-    public List<ExamplePayloadDto> getExamplePayloads() {
-        return examplePayloads;
-    }
-
-    public void setExamplePayloads(List<ExamplePayloadDto> examplePayloads) {
-        this.examplePayloads = examplePayloads;
-    }
-
-    @Override
-    public String toString() {
-        return "NestedPayloadDto{" + "someStrings=" + someStrings + ", examplePayloads=" + examplePayloads + '}';
-    }
 }

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ProducerIntegrationWithDockerIntegrationTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ProducerIntegrationWithDockerIntegrationTest.java
@@ -71,10 +71,7 @@ public class ProducerIntegrationWithDockerIntegrationTest {
     void producerCanUseSpringwolfConfigurationToSendMessage() {
         Map<String, String> headers = new HashMap<>();
         headers.put("header-key", "header-value");
-        ExamplePayloadDto payload = new ExamplePayloadDto();
-        payload.setSomeString("foo");
-        payload.setSomeLong(5);
-        payload.setSomeEnum(FOO1);
+        ExamplePayloadDto payload = new ExamplePayloadDto("foo", 5, FOO1);
 
         springwolfKafkaProducer.send("example-topic", "key", headers, payload);
         verify(exampleService, timeout(10000)).doSomething(payload);

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelRabbitListenerScanner.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelRabbitListenerScanner.java
@@ -21,8 +21,6 @@ import org.springframework.util.StringValueResolver;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static io.github.stavshamir.springwolf.configuration.properties.SpringwolfAmqpConfigConstants.SPRINGWOLF_SCANNER_RABBIT_LISTENER_ENABLED;
 
@@ -37,14 +35,7 @@ public class ClassLevelRabbitListenerScanner extends AbstractClassLevelListenerS
     private StringValueResolver resolver;
 
     public ClassLevelRabbitListenerScanner(List<Queue> queues, List<Exchange> exchanges, List<Binding> bindings) {
-        Map<String, Queue> queueMap =
-                queues.stream().collect(Collectors.toMap(Queue::getName, Function.identity(), (e1, e2) -> e1));
-        Map<String, Exchange> exchangeMap =
-                exchanges.stream().collect(Collectors.toMap(Exchange::getName, Function.identity(), (e1, e2) -> e1));
-        Map<String, Binding> bindingMap = bindings.stream()
-                .filter(Binding::isDestinationQueue)
-                .collect(Collectors.toMap(Binding::getDestination, Function.identity(), (e1, e2) -> e1));
-        context = new RabbitListenerUtil.RabbitListenerUtilContext(queueMap, exchangeMap, bindingMap);
+        context = RabbitListenerUtil.RabbitListenerUtilContext.create(queues, exchanges, bindings);
     }
 
     @Override

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelRabbitListenerScanner.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelRabbitListenerScanner.java
@@ -8,6 +8,8 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanne
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.annotation.RabbitHandler;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -31,13 +33,18 @@ import static io.github.stavshamir.springwolf.configuration.properties.Springwol
 public class ClassLevelRabbitListenerScanner extends AbstractClassLevelListenerScanner<RabbitListener, RabbitHandler>
         implements ChannelsScanner, EmbeddedValueResolverAware {
 
-    private final Map<String, Binding> bindingsMap;
+    private final RabbitListenerUtil.RabbitListenerUtilContext context;
     private StringValueResolver resolver;
 
-    public ClassLevelRabbitListenerScanner(List<Binding> bindings) {
-        bindingsMap = bindings.stream()
+    public ClassLevelRabbitListenerScanner(List<Queue> queues, List<Exchange> exchanges, List<Binding> bindings) {
+        Map<String, Queue> queueMap =
+                queues.stream().collect(Collectors.toMap(Queue::getName, Function.identity(), (e1, e2) -> e1));
+        Map<String, Exchange> exchangeMap =
+                exchanges.stream().collect(Collectors.toMap(Exchange::getName, Function.identity(), (e1, e2) -> e1));
+        Map<String, Binding> bindingMap = bindings.stream()
                 .filter(Binding::isDestinationQueue)
-                .collect(Collectors.toMap(Binding::getDestination, Function.identity()));
+                .collect(Collectors.toMap(Binding::getDestination, Function.identity(), (e1, e2) -> e1));
+        context = new RabbitListenerUtil.RabbitListenerUtilContext(queueMap, exchangeMap, bindingMap);
     }
 
     @Override
@@ -62,12 +69,12 @@ public class ClassLevelRabbitListenerScanner extends AbstractClassLevelListenerS
 
     @Override
     protected Map<String, ? extends OperationBinding> buildOperationBinding(RabbitListener annotation) {
-        return RabbitListenerUtil.buildOperationBinding(annotation, resolver, bindingsMap);
+        return RabbitListenerUtil.buildOperationBinding(annotation, resolver, context);
     }
 
     @Override
     protected Map<String, ? extends ChannelBinding> buildChannelBinding(RabbitListener annotation) {
-        return RabbitListenerUtil.buildChannelBinding(annotation, resolver, bindingsMap);
+        return RabbitListenerUtil.buildChannelBinding(annotation, resolver, context);
     }
 
     @Override

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScanner.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScanner.java
@@ -19,8 +19,6 @@ import org.springframework.util.StringValueResolver;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static io.github.stavshamir.springwolf.configuration.properties.SpringwolfAmqpConfigConstants.SPRINGWOLF_SCANNER_RABBIT_LISTENER_ENABLED;
 
@@ -35,14 +33,7 @@ public class MethodLevelRabbitListenerScanner extends AbstractMethodLevelListene
     private StringValueResolver resolver;
 
     public MethodLevelRabbitListenerScanner(List<Queue> queues, List<Exchange> exchanges, List<Binding> bindings) {
-        Map<String, Queue> queueMap =
-                queues.stream().collect(Collectors.toMap(Queue::getName, Function.identity(), (e1, e2) -> e1));
-        Map<String, Exchange> exchangeMap =
-                exchanges.stream().collect(Collectors.toMap(Exchange::getName, Function.identity(), (e1, e2) -> e1));
-        Map<String, Binding> bindingMap = bindings.stream()
-                .filter(Binding::isDestinationQueue)
-                .collect(Collectors.toMap(Binding::getDestination, Function.identity(), (e1, e2) -> e1));
-        context = new RabbitListenerUtil.RabbitListenerUtilContext(queueMap, exchangeMap, bindingMap);
+        context = RabbitListenerUtil.RabbitListenerUtilContext.create(queues, exchanges, bindings);
     }
 
     @Override

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/RabbitListenerUtil.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/RabbitListenerUtil.java
@@ -89,6 +89,9 @@ public class RabbitListenerUtil {
 
     private static List<String> getRoutingKeys(
             RabbitListener annotation, StringValueResolver resolver, Map<String, Binding> bindingsMap) {
+
+        // exchange name = "" -> exchange name = queue name
+
         /*
            The routing key is taken from the binding. As the key field in the @QueueBinding can be an empty array,
            it is set as an empty String in that case.

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducer.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducer.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static io.github.stavshamir.springwolf.configuration.properties.SpringwolfAmqpConfigConstants.SPRINGWOLF_AMQP_CONFIG_PREFIX;
@@ -36,7 +35,7 @@ public class SpringwolfAmqpProducer {
         this.rabbitTemplate = rabbitTemplates.isEmpty() ? Optional.empty() : Optional.of(rabbitTemplates.get(0));
     }
 
-    public void send(String channelName, Map<String, ?> payload) {
+    public void send(String channelName, Object payload) {
         AsyncAPI asyncAPI = asyncApiService.getAsyncAPI();
         ChannelItem channelItem = asyncAPI.getChannels().get(channelName);
 

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelRabbitListenerScannerIntegrationTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelRabbitListenerScannerIntegrationTest.java
@@ -17,6 +17,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.amqp.core.ExchangeTypes;
 import org.springframework.amqp.rabbit.annotation.RabbitHandler;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,9 +56,20 @@ class ClassLevelRabbitListenerScannerIntegrationTest {
     private static final Map<String, Object> defaultChannelBinding = Map.of(
             "amqp",
             AMQPChannelBinding.builder()
-                    .is("routingKey")
+                    .is("queue")
                     .exchange(AMQPChannelBinding.ExchangeProperties.builder()
                             .name("")
+                            .durable(true)
+                            .autoDelete(false)
+                            .type(ExchangeTypes.DIRECT)
+                            .vhost("/")
+                            .build())
+                    .queue(AMQPChannelBinding.QueueProperties.builder()
+                            .name(QUEUE)
+                            .durable(true)
+                            .autoDelete(false)
+                            .exclusive(false)
+                            .vhost("/")
                             .build())
                     .build());
 

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScannerIntegrationTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelRabbitListenerScannerIntegrationTest.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.ExchangeTypes;
 import org.springframework.amqp.rabbit.annotation.Exchange;
 import org.springframework.amqp.rabbit.annotation.Queue;
 import org.springframework.amqp.rabbit.annotation.QueueBinding;
@@ -71,9 +72,20 @@ class MethodLevelRabbitListenerScannerIntegrationTest {
     private static final Map<String, Object> defaultChannelBinding = Map.of(
             "amqp",
             AMQPChannelBinding.builder()
-                    .is("routingKey")
+                    .is("queue")
                     .exchange(AMQPChannelBinding.ExchangeProperties.builder()
                             .name("")
+                            .durable(true)
+                            .autoDelete(false)
+                            .type(ExchangeTypes.DIRECT)
+                            .vhost("/")
+                            .build())
+                    .queue(AMQPChannelBinding.QueueProperties.builder()
+                            .name(QUEUE)
+                            .durable(true)
+                            .autoDelete(false)
+                            .exclusive(false)
+                            .vhost("/")
                             .build())
                     .build());
 
@@ -102,10 +114,9 @@ class MethodLevelRabbitListenerScannerIntegrationTest {
         // Then the returned collection contains the channel
         AMQPChannelBinding.ExchangeProperties properties = new AMQPChannelBinding.ExchangeProperties();
         properties.setName("");
-        ChannelBinding channelBinding = AMQPChannelBinding.builder()
-                .is("routingKey")
-                .exchange(properties)
-                .build();
+        properties.setType(ExchangeTypes.DIRECT);
+        properties.setAutoDelete(false);
+        properties.setDurable(true);
 
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())
@@ -141,9 +152,19 @@ class MethodLevelRabbitListenerScannerIntegrationTest {
         // Then the returned collection contains the channel
         AMQPChannelBinding.ExchangeProperties properties = new AMQPChannelBinding.ExchangeProperties();
         properties.setName("");
+        properties.setType(ExchangeTypes.DIRECT);
+        properties.setAutoDelete(false);
+        properties.setDurable(true);
         ChannelBinding channelBinding = AMQPChannelBinding.builder()
-                .is("routingKey")
+                .is("queue")
                 .exchange(properties)
+                .queue(AMQPChannelBinding.QueueProperties.builder()
+                        .name(QUEUE)
+                        .durable(true)
+                        .autoDelete(false)
+                        .exclusive(false)
+                        .vhost("/")
+                        .build())
                 .build();
 
         Message message = Message.builder()
@@ -177,9 +198,19 @@ class MethodLevelRabbitListenerScannerIntegrationTest {
 
         AMQPChannelBinding.ExchangeProperties properties = new AMQPChannelBinding.ExchangeProperties();
         properties.setName("name");
+        properties.setType(ExchangeTypes.TOPIC);
+        properties.setAutoDelete(false);
+        properties.setDurable(true);
         ChannelBinding channelBinding = AMQPChannelBinding.builder()
                 .is("routingKey")
                 .exchange(properties)
+                .queue(AMQPChannelBinding.QueueProperties.builder()
+                        .name(QUEUE)
+                        .durable(true)
+                        .autoDelete(false)
+                        .exclusive(false)
+                        .vhost("/")
+                        .build())
                 .build();
 
         Message message = Message.builder()
@@ -192,7 +223,7 @@ class MethodLevelRabbitListenerScannerIntegrationTest {
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
-                .operationId("test-queue_publish_methodWithAnnotation1")
+                .operationId("key_publish_methodWithAnnotation1")
                 .bindings(Map.of(
                         "amqp",
                         AMQPOperationBinding.builder()
@@ -206,7 +237,7 @@ class MethodLevelRabbitListenerScannerIntegrationTest {
                 .publish(operation)
                 .build();
 
-        assertThat(actualChannelItems).containsExactly(Map.entry(QUEUE, expectedChannelItem));
+        assertThat(actualChannelItems).containsExactly(Map.entry("key", expectedChannelItem));
     }
 
     @Test
@@ -217,9 +248,19 @@ class MethodLevelRabbitListenerScannerIntegrationTest {
 
         AMQPChannelBinding.ExchangeProperties properties = new AMQPChannelBinding.ExchangeProperties();
         properties.setName("binding-bean-exchange");
+        properties.setType(ExchangeTypes.DIRECT);
+        properties.setAutoDelete(false);
+        properties.setDurable(true);
         ChannelBinding channelBinding = AMQPChannelBinding.builder()
                 .is("routingKey")
                 .exchange(properties)
+                .queue(AMQPChannelBinding.QueueProperties.builder()
+                        .name("binding-bean-queue")
+                        .durable(true)
+                        .autoDelete(false)
+                        .exclusive(false)
+                        .vhost("/")
+                        .build())
                 .build();
 
         Message message = Message.builder()
@@ -274,10 +315,9 @@ class MethodLevelRabbitListenerScannerIntegrationTest {
         // @Payload
         AMQPChannelBinding.ExchangeProperties properties = new AMQPChannelBinding.ExchangeProperties();
         properties.setName("");
-        ChannelBinding channelBinding = AMQPChannelBinding.builder()
-                .is("routingKey")
-                .exchange(properties)
-                .build();
+        properties.setType(ExchangeTypes.DIRECT);
+        properties.setAutoDelete(false);
+        properties.setDurable(true);
 
         Message message = Message.builder()
                 .name(SimpleFoo.class.getName())

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/RabbitListenerUtilTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/RabbitListenerUtilTest.java
@@ -304,6 +304,7 @@ class RabbitListenerUtilTest {
     class QueueBindingsWithBeansConfiguration {
         private final RabbitListenerUtil.RabbitListenerUtilContext context;
 
+        // Simulate a RabbitListenerUtilContext that has already been populated by exising spring beans
         {
             org.springframework.amqp.core.Queue queue =
                     new org.springframework.amqp.core.Queue("queue-1", false, true, true);

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/RabbitListenerUtilTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/RabbitListenerUtilTest.java
@@ -9,8 +9,9 @@ import com.asyncapi.v2.binding.operation.amqp.AMQPOperationBinding;
 import org.assertj.core.util.Sets;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.ExchangeTypes;
+import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.annotation.Exchange;
 import org.springframework.amqp.rabbit.annotation.Queue;
 import org.springframework.amqp.rabbit.annotation.QueueBinding;
@@ -26,6 +27,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class RabbitListenerUtilTest {
+
+    private final RabbitListenerUtil.RabbitListenerUtilContext emptyContext =
+            new RabbitListenerUtil.RabbitListenerUtilContext(emptyMap(), emptyMap(), emptyMap());
 
     @Nested
     public class QueuesConfiguration {
@@ -50,12 +54,10 @@ class RabbitListenerUtilTest {
             RabbitListener annotation = getAnnotation(ClassWithQueuesConfiguration.class);
             StringValueResolver resolver = mock(StringValueResolver.class);
             when(resolver.resolveStringValue("${queue-1}")).thenReturn("queue-1");
-            ;
-            Map<String, Binding> bindingsMap = emptyMap();
 
             // when
             Map<String, ? extends ChannelBinding> channelBinding =
-                    RabbitListenerUtil.buildChannelBinding(annotation, resolver, bindingsMap);
+                    RabbitListenerUtil.buildChannelBinding(annotation, resolver, emptyContext);
 
             // then
             assertEquals(1, channelBinding.size());
@@ -87,11 +89,10 @@ class RabbitListenerUtilTest {
             RabbitListener annotation = getAnnotation(ClassWithQueuesConfiguration.class);
             StringValueResolver resolver = mock(StringValueResolver.class);
             when(resolver.resolveStringValue("${queue-1}")).thenReturn("queue-1");
-            Map<String, Binding> bindingsMap = emptyMap();
 
             // when
             Map<String, ? extends OperationBinding> operationBinding =
-                    RabbitListenerUtil.buildOperationBinding(annotation, resolver, bindingsMap);
+                    RabbitListenerUtil.buildOperationBinding(annotation, resolver, emptyContext);
 
             // then
             assertEquals(1, operationBinding.size());
@@ -118,7 +119,7 @@ class RabbitListenerUtilTest {
     }
 
     @Nested
-    class BindingsConfiguration {
+    class QueueBindingsConfiguration {
         @Test
         void getChannelName() {
             // given
@@ -139,11 +140,10 @@ class RabbitListenerUtilTest {
             RabbitListener annotation = getAnnotation(ClassWithBindingsConfiguration.class);
             StringValueResolver resolver = mock(StringValueResolver.class);
             when(resolver.resolveStringValue("${queue-1}")).thenReturn("queue-1");
-            Map<String, Binding> bindingsMap = emptyMap();
 
             // when
             Map<String, ? extends ChannelBinding> channelBinding =
-                    RabbitListenerUtil.buildChannelBinding(annotation, resolver, bindingsMap);
+                    RabbitListenerUtil.buildChannelBinding(annotation, resolver, emptyContext);
 
             // then
             assertEquals(1, channelBinding.size());
@@ -173,11 +173,11 @@ class RabbitListenerUtilTest {
             // given
             RabbitListener annotation = getAnnotation(ClassWithBindingsConfiguration.class);
             StringValueResolver resolver = mock(StringValueResolver.class);
-            Map<String, Binding> bindingsMap = emptyMap();
+            when(resolver.resolveStringValue("${queue-1}")).thenReturn("queue-1");
 
             // when
             Map<String, ? extends OperationBinding> operationBinding =
-                    RabbitListenerUtil.buildOperationBinding(annotation, resolver, bindingsMap);
+                    RabbitListenerUtil.buildOperationBinding(annotation, resolver, emptyContext);
 
             // then
             assertEquals(1, operationBinding.size());
@@ -207,7 +207,7 @@ class RabbitListenerUtilTest {
     }
 
     @Nested
-    class BindingWithRoutingKeyConfiguration {
+    class QueueBindingWithRoutingKeyConfiguration {
         @Test
         void getChannelName() {
             // given
@@ -228,11 +228,10 @@ class RabbitListenerUtilTest {
             RabbitListener annotation = getAnnotation(ClassWithBindingsAndRoutingKeyConfiguration.class);
             StringValueResolver resolver = mock(StringValueResolver.class);
             when(resolver.resolveStringValue("${queue-1}")).thenReturn("queue-1");
-            Map<String, Binding> bindingsMap = emptyMap();
 
             // when
             Map<String, ? extends ChannelBinding> channelBinding =
-                    RabbitListenerUtil.buildChannelBinding(annotation, resolver, bindingsMap);
+                    RabbitListenerUtil.buildChannelBinding(annotation, resolver, emptyContext);
 
             // then
             assertEquals(1, channelBinding.size());
@@ -263,11 +262,10 @@ class RabbitListenerUtilTest {
             RabbitListener annotation = getAnnotation(ClassWithBindingsAndRoutingKeyConfiguration.class);
             StringValueResolver resolver = mock(StringValueResolver.class);
             when(resolver.resolveStringValue("${routing-key}")).thenReturn("routing-key");
-            Map<String, Binding> bindingsMap = emptyMap();
 
             // when
             Map<String, ? extends OperationBinding> operationBinding =
-                    RabbitListenerUtil.buildOperationBinding(annotation, resolver, bindingsMap);
+                    RabbitListenerUtil.buildOperationBinding(annotation, resolver, emptyContext);
 
             // then
             assertEquals(1, operationBinding.size());
@@ -295,6 +293,113 @@ class RabbitListenerUtilTest {
                                 exchange = @Exchange(name = "exchange-name"),
                                 key = "${routing-key}",
                                 value = @Queue(name = "${queue-1}"))
+                    })
+            private void methodWithAnnotation(String payload) {}
+        }
+    }
+
+    @Nested
+    class QueueBindingsWithBeansConfiguration {
+        private final RabbitListenerUtil.RabbitListenerUtilContext context;
+
+        {
+            org.springframework.amqp.core.Queue queue =
+                    new org.springframework.amqp.core.Queue("queue-1", false, true, true);
+            TopicExchange exchange = new TopicExchange("exchange-name", false, true);
+            context = new RabbitListenerUtil.RabbitListenerUtilContext(
+                    Map.of("queue-1", queue),
+                    Map.of("exchange-name", exchange),
+                    Map.of("queue-1", BindingBuilder.bind(queue).to(exchange).with("routing-key")));
+        }
+
+        @Test
+        void getChannelName() {
+            // given
+            RabbitListener annotation = getAnnotation(ClassWithBindingsConfiguration.class);
+            StringValueResolver resolver = mock(StringValueResolver.class);
+            when(resolver.resolveStringValue("${queue-1}")).thenReturn("queue-1");
+            when(resolver.resolveStringValue("${routing-key}")).thenReturn("routing-key");
+
+            // when
+            String channelName = RabbitListenerUtil.getChannelName(annotation, resolver);
+
+            // then
+            assertEquals("routing-key", channelName);
+        }
+
+        @Test
+        void buildChannelBinding() {
+            // given
+            RabbitListener annotation = getAnnotation(ClassWithBindingsConfiguration.class);
+            StringValueResolver resolver = mock(StringValueResolver.class);
+            when(resolver.resolveStringValue("${queue-1}")).thenReturn("queue-1");
+            when(resolver.resolveStringValue("${routing-key}")).thenReturn("routing-key");
+
+            // when
+            Map<String, ? extends ChannelBinding> channelBinding =
+                    RabbitListenerUtil.buildChannelBinding(annotation, resolver, context);
+
+            // then
+            assertEquals(1, channelBinding.size());
+            assertEquals(Sets.newTreeSet("amqp"), channelBinding.keySet());
+            assertEquals(
+                    AMQPChannelBinding.builder()
+                            .is("routingKey")
+                            .exchange(AMQPChannelBinding.ExchangeProperties.builder()
+                                    .name("exchange-name")
+                                    .type(ExchangeTypes.TOPIC)
+                                    .durable(false)
+                                    .autoDelete(true)
+                                    .build())
+                            .queue(AMQPChannelBinding.QueueProperties.builder()
+                                    .name("queue-1")
+                                    .durable(false)
+                                    .autoDelete(true)
+                                    .exclusive(true)
+                                    .vhost("/")
+                                    .build())
+                            .build(),
+                    channelBinding.get("amqp"));
+        }
+
+        @Test
+        void buildOperationBinding() {
+            // given
+            RabbitListener annotation = getAnnotation(ClassWithBindingsConfiguration.class);
+            StringValueResolver resolver = mock(StringValueResolver.class);
+            when(resolver.resolveStringValue("${queue-1}")).thenReturn("queue-1");
+            when(resolver.resolveStringValue("${routing-key}")).thenReturn("routing-key");
+
+            // when
+            Map<String, ? extends OperationBinding> operationBinding =
+                    RabbitListenerUtil.buildOperationBinding(annotation, resolver, context);
+
+            // then
+            assertEquals(1, operationBinding.size());
+            assertEquals(Sets.newTreeSet("amqp"), operationBinding.keySet());
+            assertEquals(
+                    AMQPOperationBinding.builder().cc(List.of("routing-key")).build(), operationBinding.get("amqp"));
+        }
+
+        @Test
+        void buildMessageBinding() {
+            // when
+            Map<String, ? extends MessageBinding> messageBinding = RabbitListenerUtil.buildMessageBinding();
+
+            // then
+            assertEquals(1, messageBinding.size());
+            assertEquals(Sets.newTreeSet("amqp"), messageBinding.keySet());
+            assertEquals(new AMQPMessageBinding(), messageBinding.get("amqp"));
+        }
+
+        private static class ClassWithBindingsConfiguration {
+
+            @RabbitListener(
+                    bindings = {
+                        @QueueBinding(
+                                exchange = @Exchange(name = "exchange-name"),
+                                value = @Queue(name = "${queue-1}"),
+                                key = "${routing-key}"),
                     })
             private void methodWithAnnotation(String payload) {}
         }

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/RabbitListenerUtilTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/RabbitListenerUtilTest.java
@@ -9,6 +9,7 @@ import com.asyncapi.v2.binding.operation.amqp.AMQPOperationBinding;
 import org.assertj.core.util.Sets;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.ExchangeTypes;
 import org.springframework.amqp.core.TopicExchange;
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -306,10 +308,10 @@ class RabbitListenerUtilTest {
             org.springframework.amqp.core.Queue queue =
                     new org.springframework.amqp.core.Queue("queue-1", false, true, true);
             TopicExchange exchange = new TopicExchange("exchange-name", false, true);
-            context = new RabbitListenerUtil.RabbitListenerUtilContext(
-                    Map.of("queue-1", queue),
-                    Map.of("exchange-name", exchange),
-                    Map.of("queue-1", BindingBuilder.bind(queue).to(exchange).with("routing-key")));
+            context = RabbitListenerUtil.RabbitListenerUtilContext.create(
+                    List.of(queue),
+                    List.of(exchange),
+                    List.of(BindingBuilder.bind(queue).to(exchange).with("routing-key")));
         }
 
         @Test
@@ -402,6 +404,69 @@ class RabbitListenerUtilTest {
                                 key = "${routing-key}"),
                     })
             private void methodWithAnnotation(String payload) {}
+        }
+    }
+
+    @Nested
+    public class RabbitListenerUtilContextTest {
+        @Test
+        void testEmptyContext() {
+            // when
+            RabbitListenerUtil.RabbitListenerUtilContext context =
+                    RabbitListenerUtil.RabbitListenerUtilContext.create(List.of(), List.of(), List.of());
+
+            // then
+            assertEquals(Map.of(), context.queueMap());
+            assertEquals(Map.of(), context.exchangeMap());
+            assertEquals(Map.of(), context.bindingMap());
+        }
+
+        @Test
+        void testWithSingleTopic() {
+            org.springframework.amqp.core.Queue queue =
+                    new org.springframework.amqp.core.Queue("queue-1", false, true, true);
+            TopicExchange exchange = new TopicExchange("exchange-name", false, true);
+            Binding binding = BindingBuilder.bind(queue).to(exchange).with("routing-key");
+
+            // when
+            RabbitListenerUtil.RabbitListenerUtilContext context = RabbitListenerUtil.RabbitListenerUtilContext.create(
+                    List.of(queue), List.of(exchange), List.of(binding));
+
+            // then
+            assertEquals(Map.of("queue-1", queue), context.queueMap());
+            assertEquals(Map.of("exchange-name", exchange), context.exchangeMap());
+            assertEquals(Map.of("queue-1", binding), context.bindingMap());
+        }
+
+        @Test
+        void testWithMultipleBeansForOneTopic() {
+            org.springframework.amqp.core.Queue queueBean =
+                    new org.springframework.amqp.core.Queue("queue-1", false, true, true);
+            TopicExchange exchangeBean = new TopicExchange("exchange-name", false, true);
+            Binding bindingBean =
+                    BindingBuilder.bind(queueBean).to(exchangeBean).with("routing-key");
+
+            // In this test, annotation values are different compared to the beans.
+            // This might happen due to ill user configuration, but like Spring AMQP Springwolf tries to handle it
+            org.springframework.amqp.core.Queue queueAnnotation =
+                    new org.springframework.amqp.core.Queue("queue-1", false, false, false);
+            TopicExchange exchangeAnnotation = new TopicExchange("exchange-name", true, false);
+            Binding bindingAnnotation =
+                    BindingBuilder.bind(queueAnnotation).to(exchangeAnnotation).with("routing-key");
+
+            // when
+            RabbitListenerUtil.RabbitListenerUtilContext context = RabbitListenerUtil.RabbitListenerUtilContext.create(
+                    List.of(queueBean, queueAnnotation),
+                    List.of(exchangeBean, exchangeAnnotation),
+                    List.of(bindingBean, bindingAnnotation));
+
+            // then
+            assertThat(context.queueMap()).hasSize(1);
+            assertThat(context.queueMap().get("queue-1")).isIn(queueBean, queueAnnotation);
+            assertThat(context.exchangeMap()).hasSize(1);
+            assertThat(context.exchangeMap().get("exchange-name")).isIn(exchangeBean, exchangeAnnotation);
+            assertThat(context.bindingMap()).hasSize(1);
+            assertThat(context.bindingMap().get("queue-1")).isIn(bindingBean, bindingAnnotation);
         }
     }
 


### PR DESCRIPTION
Addresses: https://github.com/springwolf/springwolf-core/issues/285

When a routingKey is presented, the routingKey becomes the channelName: https://github.com/asyncapi/bindings/issues/12#issuecomment-568731709

Also adds more RabbitListener properties.

Additionally the amqp example processes messages on `example-queue` and publishes them to the `example-topic-exchange` exchange.

~Out of scope:~ Included now: Analysing the `Queue` and `Exchange` beans to extract the correct durable, exclusive, autoDelete values (assuming default values).