### PR TITLE
Support @Conditional: Add environment to AbstractAnnotatedClassScanner

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/AbstractAnnotatedClassScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/AbstractAnnotatedClassScanner.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.env.Environment;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.util.StringUtils;
 
@@ -20,6 +21,9 @@ public abstract class AbstractAnnotatedClassScanner<T extends Annotation> implem
     @Autowired
     private AsyncApiDocketService asyncApiDocketService;
 
+    @Autowired(required = false) // Handle missing bean gracefully
+    private Environment environment;
+
     /**
      * @return The class object of the annotation to scan.
      */
@@ -32,7 +36,14 @@ public abstract class AbstractAnnotatedClassScanner<T extends Annotation> implem
             throw new IllegalArgumentException("Base package must not be blank");
         }
 
-        ClassPathScanningCandidateComponentProvider provider = new ClassPathScanningCandidateComponentProvider(false);
+        ClassPathScanningCandidateComponentProvider provider;
+
+        if (environment != null) {
+            provider = new ClassPathScanningCandidateComponentProvider(false, environment);
+        } else {
+            provider = new ClassPathScanningCandidateComponentProvider(false);
+        }
+
         provider.addIncludeFilter(new AnnotationTypeFilter(getAnnotationClass()));
 
         log.debug("Scanning for {} classes in {}", getAnnotationClass().getSimpleName(), basePackage);

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/TestConditionalComponent.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/TestConditionalComponent.java
@@ -1,0 +1,8 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.classes;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty("include-conditional-component")
+public class TestConditionalComponent {}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/TestOtherConditionalComponent.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/classes/TestOtherConditionalComponent.java
@@ -1,0 +1,8 @@
+package io.github.stavshamir.springwolf.asyncapi.scanners.classes;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty("missing-property")
+public class TestOtherConditionalComponent {}


### PR DESCRIPTION
Added Environment to the AbstractAnnotatedClassScanner

Instantiate ClassPathScanningCandidateComponentProvider with environment, if available.

Updated tests to add scenario where Environment properties should trigger inclusion of @Conditional @Component.