### PR TITLE
feat(core): add option to expose docs as part of spring actuator endp…

### DIFF
--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 
     implementation "org.springframework.boot:spring-boot"
+    implementation "org.springframework.boot:spring-boot-actuator"
     implementation "org.springframework:spring-web"
     implementation "org.springframework:spring-context"
     implementation "org.springframework:spring-messaging"

--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 
     implementation "org.springframework.boot:spring-boot"
-    implementation "org.springframework.boot:spring-boot-actuator"
+
     implementation "org.springframework:spring-web"
     implementation "org.springframework:spring-context"
     implementation "org.springframework:spring-messaging"
@@ -34,6 +34,7 @@ dependencies {
 
     implementation "org.apache.commons:commons-lang3:${commonsLang3Version}"
 
+    compileOnly "org.springframework.boot:spring-boot-actuator"
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
 
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/controller/ActuatorAsyncApiController.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/controller/ActuatorAsyncApiController.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.github.stavshamir.springwolf.asyncapi.AsyncApiSerializerService;
 import io.github.stavshamir.springwolf.asyncapi.AsyncApiService;
 import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
-import io.github.stavshamir.springwolf.configuration.properties.SpringwolfConfigConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
@@ -13,11 +12,13 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import static io.github.stavshamir.springwolf.configuration.properties.SpringwolfConfigConstants.SPRINGWOLF_ENDPOINT_ACTUATOR_ENABLED;
+
 @Component
 @Slf4j
 @RestControllerEndpoint(id = "springwolf")
 @RequiredArgsConstructor
-@ConditionalOnProperty(name = SpringwolfConfigConstants.SPRINGWOLF_USE_MANAGEMENT_PORT, havingValue = "true")
+@ConditionalOnProperty(name = SPRINGWOLF_ENDPOINT_ACTUATOR_ENABLED, havingValue = "true")
 public class ActuatorAsyncApiController {
 
     private final AsyncApiService asyncApiService;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/controller/ActuatorAsyncApiController.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/controller/ActuatorAsyncApiController.java
@@ -7,37 +7,32 @@ import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
 import io.github.stavshamir.springwolf.configuration.properties.SpringwolfConfigConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 
+@Component
 @Slf4j
-@RestController
+@RestControllerEndpoint(id = "springwolf")
 @RequiredArgsConstructor
-@ConditionalOnProperty(
-        name = SpringwolfConfigConstants.SPRINGWOLF_USE_MANAGEMENT_PORT,
-        havingValue = "false",
-        matchIfMissing = true)
-public class AsyncApiController {
+@ConditionalOnProperty(name = SpringwolfConfigConstants.SPRINGWOLF_USE_MANAGEMENT_PORT, havingValue = "true")
+public class ActuatorAsyncApiController {
 
     private final AsyncApiService asyncApiService;
     private final AsyncApiSerializerService serializer;
 
     @GetMapping(
-            path = {"${springwolf.paths.docs:/springwolf/docs}", "${springwolf.paths.docs:/springwolf/docs}.json"},
+            path = {"/docs", "/docs.json"},
             produces = MediaType.APPLICATION_JSON_VALUE)
     public String asyncApiJson() throws JsonProcessingException {
-        log.debug("Returning AsyncApi.json document");
-
         AsyncAPI asyncAPI = asyncApiService.getAsyncAPI();
         return serializer.toJsonString(asyncAPI);
     }
 
-    @GetMapping(path = "${springwolf.paths.docs:/springwolf/docs}.yaml", produces = "application/yaml")
+    @GetMapping(path = "/docs.yaml", produces = "application/yaml")
     public String asyncApiYaml() throws JsonProcessingException {
-        log.debug("Returning AsyncApi.yaml document");
-
         AsyncAPI asyncAPI = asyncApiService.getAsyncAPI();
         return serializer.toYaml(asyncAPI);
     }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/controller/AsyncApiController.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/controller/AsyncApiController.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.github.stavshamir.springwolf.asyncapi.AsyncApiSerializerService;
 import io.github.stavshamir.springwolf.asyncapi.AsyncApiService;
 import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
-import io.github.stavshamir.springwolf.configuration.properties.SpringwolfConfigConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -12,13 +11,12 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static io.github.stavshamir.springwolf.configuration.properties.SpringwolfConfigConstants.SPRINGWOLF_ENDPOINT_ACTUATOR_ENABLED;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@ConditionalOnProperty(
-        name = SpringwolfConfigConstants.SPRINGWOLF_USE_MANAGEMENT_PORT,
-        havingValue = "false",
-        matchIfMissing = true)
+@ConditionalOnProperty(name = SPRINGWOLF_ENDPOINT_ACTUATOR_ENABLED, havingValue = "false", matchIfMissing = true)
 public class AsyncApiController {
 
     private final AsyncApiService asyncApiService;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/properties/SpringwolfConfigConstants.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/properties/SpringwolfConfigConstants.java
@@ -3,15 +3,16 @@ package io.github.stavshamir.springwolf.configuration.properties;
 public class SpringwolfConfigConstants {
     public static final String ENABLED = ".enabled";
 
-    public static final String USE_MANAGEMENT_PORT = ".use-management-port";
-
     public static final String SCANNER = ".scanner";
 
     public static final String SPRINGWOLF_CONFIG_PREFIX = "springwolf";
 
     public static final String SPRINGWOLF_ENABLED = SPRINGWOLF_CONFIG_PREFIX + ENABLED;
 
-    public static final String SPRINGWOLF_USE_MANAGEMENT_PORT = SPRINGWOLF_CONFIG_PREFIX + USE_MANAGEMENT_PORT;
+    public static final String ENDPOINT_ACTUATOR = ".endpoint.actuator";
+
+    public static final String SPRINGWOLF_ENDPOINT_ACTUATOR_ENABLED =
+            SPRINGWOLF_CONFIG_PREFIX + ENDPOINT_ACTUATOR + ENABLED;
 
     public static final String SPRINGWOLF_PLUGIN_CONFIG_PREFIX = SPRINGWOLF_CONFIG_PREFIX + ".plugin";
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/properties/SpringwolfConfigConstants.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/properties/SpringwolfConfigConstants.java
@@ -3,11 +3,16 @@ package io.github.stavshamir.springwolf.configuration.properties;
 public class SpringwolfConfigConstants {
     public static final String ENABLED = ".enabled";
 
+    public static final String USE_MANAGEMENT_PORT = ".use-management-port";
+
     public static final String SCANNER = ".scanner";
 
     public static final String SPRINGWOLF_CONFIG_PREFIX = "springwolf";
 
     public static final String SPRINGWOLF_ENABLED = SPRINGWOLF_CONFIG_PREFIX + ENABLED;
+
+    public static final String SPRINGWOLF_USE_MANAGEMENT_PORT = SPRINGWOLF_CONFIG_PREFIX + USE_MANAGEMENT_PORT;
+
     public static final String SPRINGWOLF_PLUGIN_CONFIG_PREFIX = SPRINGWOLF_CONFIG_PREFIX + ".plugin";
 
     public static final String SPRINGWOLF_SCANNER_PREFIX = SPRINGWOLF_CONFIG_PREFIX + SCANNER;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/properties/SpringwolfConfigProperties.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/properties/SpringwolfConfigProperties.java
@@ -45,10 +45,8 @@ public class SpringwolfConfigProperties {
      */
     private InitMode initMode = InitMode.FAIL_FAST;
 
-    /**
-     * Flag to enable Springwolf on the actuator management port instead of the regular application port
-     */
-    private Boolean useManagementPort = false;
+    @Nullable
+    private Endpoint endpoint;
 
     @Nullable
     private ConfigDocket docket;
@@ -194,6 +192,24 @@ public class SpringwolfConfigProperties {
              * This mirrors the ConfigConstant {@see SpringwolfConfigConstants#SPRINGWOLF_SCANNER_RABBIT_LISTENER_ENABLED}
              */
             private boolean enabled = true;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class Endpoint {
+
+        @Nullable
+        private Actuator actuator;
+
+        @Getter
+        @Setter
+        private static class Actuator {
+
+            /**
+             * Flag to move the endpoint that exposes the AsyncAPI document beneath Spring Boot’s actuator endpoint.
+             */
+            private boolean enabled = false;
         }
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/properties/SpringwolfConfigProperties.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/configuration/properties/SpringwolfConfigProperties.java
@@ -45,6 +45,11 @@ public class SpringwolfConfigProperties {
      */
     private InitMode initMode = InitMode.FAIL_FAST;
 
+    /**
+     * Flag to enable Springwolf on the actuator management port instead of the regular application port
+     */
+    private Boolean useManagementPort = false;
+
     @Nullable
     private ConfigDocket docket;
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/SpringContextIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/SpringContextIntegrationTest.java
@@ -6,16 +6,15 @@ import io.github.stavshamir.springwolf.asyncapi.DefaultAsyncApiService;
 import io.github.stavshamir.springwolf.asyncapi.DefaultChannelsService;
 import io.github.stavshamir.springwolf.configuration.DefaultAsyncApiDocketService;
 import io.github.stavshamir.springwolf.configuration.properties.SpringwolfConfigProperties;
+import io.github.stavshamir.springwolf.fixtures.MinimalTestContextConfiguration;
 import io.github.stavshamir.springwolf.schemas.DefaultSchemasService;
 import io.github.stavshamir.springwolf.schemas.example.ExampleJsonGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,31 +56,7 @@ public class SpringContextIntegrationTest {
 
     @ExtendWith(SpringExtension.class)
     @Nested
-    @ContextConfiguration(
-            classes = {
-                DefaultAsyncApiDocketService.class,
-                DefaultAsyncApiService.class,
-                DefaultChannelsService.class,
-                DefaultSchemasService.class,
-                ExampleJsonGenerator.class,
-                DefaultAsyncApiService.class,
-                DefaultAsyncApiSerializerService.class,
-            })
-    @EnableConfigurationProperties(
-            value = {
-                SpringwolfConfigProperties.class,
-            })
-    @TestPropertySource(
-            properties = {
-                "springwolf.enabled=true",
-                "springwolf.docket.info.title=Info title was loaded from spring properties",
-                "springwolf.docket.info.version=1.0.0",
-                "springwolf.docket.id=urn:io:github:stavshamir:springwolf:example",
-                "springwolf.docket.default-content-type=application/yaml",
-                "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
-                "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
-            })
+    @MinimalTestContextConfiguration
     class ApplicationPropertiesConfigurationTest {
 
         @Autowired

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/SpringContextControllerIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/SpringContextControllerIntegrationTest.java
@@ -1,0 +1,74 @@
+package io.github.stavshamir.springwolf.asyncapi.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.github.stavshamir.springwolf.fixtures.MinimalTestContextConfiguration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class SpringContextControllerIntegrationTest {
+
+    @ExtendWith(SpringExtension.class)
+    @Nested
+    @Import(value = {AsyncApiController.class, ActuatorAsyncApiController.class})
+    @MinimalTestContextConfiguration
+    class SpringwolfOnApplicationPortConfigurationTest {
+
+        @Autowired
+        private ApplicationContext context;
+
+        @Autowired
+        private Optional<AsyncApiController> asyncApiController;
+
+        @Autowired
+        private Optional<ActuatorAsyncApiController> actuatorAsyncApiController;
+
+        @Test
+        void testContextWithApplicationProperties() throws JsonProcessingException {
+            assertNotNull(context);
+
+            assertThat(asyncApiController).isPresent();
+            assertThat(actuatorAsyncApiController).isNotPresent();
+
+            assertThat(asyncApiController.get().asyncApiJson()).isNotNull();
+        }
+    }
+
+    @Nested
+    @ExtendWith(SpringExtension.class)
+    @MinimalTestContextConfiguration
+    @Import(value = {AsyncApiController.class, ActuatorAsyncApiController.class})
+    @TestPropertySource(
+            properties = {"springwolf.use-management-port=true", "management.endpoints.web.exposure.include=*"})
+    class SpringwolfOnManagementPortConfigurationTest {
+
+        @Autowired
+        private ApplicationContext context;
+
+        @Autowired
+        private Optional<AsyncApiController> asyncApiController;
+
+        @Autowired
+        private Optional<ActuatorAsyncApiController> actuatorAsyncApiController;
+
+        @Test
+        void testContextWithApplicationProperties() throws JsonProcessingException {
+            assertNotNull(context);
+
+            assertThat(asyncApiController).isNotPresent();
+            assertThat(actuatorAsyncApiController).isPresent();
+
+            assertThat(actuatorAsyncApiController.get().asyncApiJson()).isNotNull();
+        }
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/SpringContextControllerIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/SpringContextControllerIntegrationTest.java
@@ -49,7 +49,7 @@ public class SpringContextControllerIntegrationTest {
     @MinimalTestContextConfiguration
     @Import(value = {AsyncApiController.class, ActuatorAsyncApiController.class})
     @TestPropertySource(
-            properties = {"springwolf.use-management-port=true", "management.endpoints.web.exposure.include=*"})
+            properties = {"springwolf.endpoint.actuator.enabled=true", "management.endpoints.web.exposure.include=*"})
     class SpringwolfOnManagementPortConfigurationTest {
 
         @Autowired

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/fixtures/MinimalTestContextConfiguration.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/fixtures/MinimalTestContextConfiguration.java
@@ -1,0 +1,41 @@
+package io.github.stavshamir.springwolf.fixtures;
+
+import io.github.stavshamir.springwolf.asyncapi.DefaultAsyncApiSerializerService;
+import io.github.stavshamir.springwolf.asyncapi.DefaultAsyncApiService;
+import io.github.stavshamir.springwolf.asyncapi.DefaultChannelsService;
+import io.github.stavshamir.springwolf.configuration.DefaultAsyncApiDocketService;
+import io.github.stavshamir.springwolf.configuration.properties.SpringwolfConfigProperties;
+import io.github.stavshamir.springwolf.schemas.DefaultSchemasService;
+import io.github.stavshamir.springwolf.schemas.example.ExampleJsonGenerator;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@ContextConfiguration(
+        classes = {
+            DefaultAsyncApiDocketService.class,
+            DefaultAsyncApiService.class,
+            DefaultChannelsService.class,
+            DefaultSchemasService.class,
+            ExampleJsonGenerator.class,
+            DefaultAsyncApiService.class,
+            DefaultAsyncApiSerializerService.class,
+        })
+@EnableConfigurationProperties(SpringwolfConfigProperties.class)
+@TestPropertySource(
+        properties = {
+            "springwolf.enabled=true",
+            "springwolf.docket.info.title=Info title",
+            "springwolf.docket.info.version=1.0.0",
+            "springwolf.docket.id=urn:io:github:stavshamir:springwolf:example",
+            "springwolf.docket.default-content-type=application/yaml",
+            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
+            "springwolf.docket.servers.test-protocol.protocol=test",
+            "springwolf.docket.servers.test-protocol.url=some-server:1234",
+        })
+public @interface MinimalTestContextConfiguration {}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/fixtures/MinimalTestContextConfiguration.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/fixtures/MinimalTestContextConfiguration.java
@@ -30,7 +30,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @TestPropertySource(
         properties = {
             "springwolf.enabled=true",
-            "springwolf.docket.info.title=Info title",
+            "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
             "springwolf.docket.id=urn:io:github:stavshamir:springwolf:example",
             "springwolf.docket.default-content-type=application/yaml",

--- a/springwolf-examples/springwolf-cloud-stream-example/build.gradle
+++ b/springwolf-examples/springwolf-cloud-stream-example/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     runtimeOnly project(":springwolf-ui")
     runtimeOnly "org.springframework.boot:spring-boot-starter-web"
+    runtimeOnly "org.springframework.boot:spring-boot-starter-actuator"
 
     implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
     implementation "org.apache.kafka:kafka-streams:${kafkaVersion}"
@@ -77,4 +78,3 @@ test {
         exceptionFormat = 'full'
     }
 }
-

--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -19,7 +19,6 @@ dependencies {
     annotationProcessor project(":springwolf-plugins:springwolf-kafka")
 
     runtimeOnly "org.springframework.boot:spring-boot-starter-web"
-    implementation "org.springframework.boot:spring-boot-starter-actuator"
 
     implementation "org.springframework:spring-beans"
     implementation "org.springframework:spring-context"
@@ -57,7 +56,11 @@ dependencies {
     testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
+
     permitTestUnusedDeclared "org.apache.kafka:kafka-clients:${kafkaVersion}:test@jar"
+
+    testImplementation("org.springframework.boot:spring-boot-starter-actuator")
+    permitTestUnusedDeclared("org.springframework.boot:spring-boot-starter-actuator")
 }
 
 docker {

--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     annotationProcessor project(":springwolf-plugins:springwolf-kafka")
 
     runtimeOnly "org.springframework.boot:spring-boot-starter-web"
+    implementation "org.springframework.boot:spring-boot-starter-actuator"
 
     implementation "org.springframework:spring-beans"
     implementation "org.springframework:spring-context"

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/configuration/CustomWebSecurityConfigurerAdapter.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/configuration/CustomWebSecurityConfigurerAdapter.java
@@ -20,6 +20,9 @@ public class CustomWebSecurityConfigurerAdapter {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http.authorizeHttpRequests(it -> it
+                        // allow anonymous access to all actuator endpoint
+                        .requestMatchers("/actuator/**")
+                        .anonymous()
                         // anyone can read the springwolf docs + ui
                         // also, anyone can publish messages (as enabled in application.properties)
                         .requestMatchers(DOCS_ENDPOINT, UI_RESOURCES, KAFKA_PUBLISH_ENDPOINT)

--- a/springwolf-examples/springwolf-kafka-example/src/main/resources/application.properties
+++ b/springwolf-examples/springwolf-kafka-example/src/main/resources/application.properties
@@ -50,6 +50,10 @@ springwolf.plugin.kafka.publishing.producer.security.protocol=SASL_PLAINTEXT
 springwolf.plugin.kafka.publishing.producer.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="broker" password="broker-secret";
 springwolf.plugin.kafka.publishing.producer.properties.sasl.mechanism=PLAIN
 
-
 # For debugging purposes
 logging.level.io.github.stavshamir.springwolf=DEBUG
+
+# Configure springwolf to publish the spec as part of springboot actuator
+springwolf.use-management-port=true
+management.server.port=8081
+management.endpoints.web.exposure.include=springwolf

--- a/springwolf-examples/springwolf-kafka-example/src/main/resources/application.properties
+++ b/springwolf-examples/springwolf-kafka-example/src/main/resources/application.properties
@@ -52,8 +52,3 @@ springwolf.plugin.kafka.publishing.producer.properties.sasl.mechanism=PLAIN
 
 # For debugging purposes
 logging.level.io.github.stavshamir.springwolf=DEBUG
-
-# Configure springwolf to publish the spec as part of springboot actuator
-springwolf.use-management-port=true
-management.server.port=8081
-management.endpoints.web.exposure.include=springwolf

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ApiIntegrationWithActuatorTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ApiIntegrationWithActuatorTest.java
@@ -18,7 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SpringBootTest(
         classes = {SpringwolfKafkaExampleApplication.class},
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = {"springwolf.use-management-port=true", "management.endpoints.web.exposure.include=springwolf"})
+        properties = {
+            "springwolf.endpoint.actuator.enabled=true",
+            "management.endpoints.web.exposure.include=springwolf"
+        })
 @EmbeddedKafka(
         partitions = 1,
         brokerProperties = {

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ApiIntegrationWithActuatorTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ApiIntegrationWithActuatorTest.java
@@ -1,0 +1,50 @@
+package io.github.stavshamir.springwolf.example.kafka;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(
+        classes = {SpringwolfKafkaExampleApplication.class},
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {"springwolf.use-management-port=true", "management.endpoints.web.exposure.include=springwolf"})
+@EmbeddedKafka(
+        partitions = 1,
+        brokerProperties = {
+            "listeners=PLAINTEXT://localhost:9092",
+            "port=9092",
+        })
+@DirtiesContext
+public class ApiIntegrationWithActuatorTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @LocalServerPort
+    private int managementPort;
+
+    @Test
+    void asyncApiResourceArtifactTest() throws JSONException, IOException {
+        String url = "http://localhost:" + managementPort + "/actuator/springwolf/docs";
+        String actual = restTemplate.getForObject(url, String.class);
+        System.out.println("Got: " + actual);
+
+        InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
+        String expectedWithoutServersKafkaUrlPatch = new String(s.readAllBytes(), StandardCharsets.UTF_8);
+        // When running with EmbeddedKafka, localhost is used as hostname
+        String expected = expectedWithoutServersKafkaUrlPatch.replace("kafka:29092", "127.0.0.1:9092");
+
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
We wanted to add the possibility to expose the springwolf docs as part of spring actuator endpoints.
The docs are either exposed by the actuator endpoint or by the application endpoint.

@ctasada This is inspired by your idea/request, what do you think? 
