### PR TITLE
Revert "chore(deps): Bump snakeyaml and kafka"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -37,7 +37,8 @@ ext {
 
     jsr305Version = '3.0.2'
 
-    kafkaVersion = '3.5.1'
+    kafkaClientsVersion = '3.5.1'
+    kafkaStreamsVersion = '3.5.1'
 
     jacksonVersion = '2.15.2'
     jakartaAnnotationApiVersion = '2.1.1'
@@ -57,10 +58,4 @@ ext {
     swaggerVersion = '2.2.16'
 
     testcontainersVersion = '1.19.0'
-}
-
-// spring boot managed dependency versions
-ext {
-    set('kafka.version', ext.kafkaVersion)
-    set('snakeyaml.version', '2.2')
 }

--- a/springwolf-examples/springwolf-cloud-stream-example/build.gradle
+++ b/springwolf-examples/springwolf-cloud-stream-example/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     runtimeOnly "org.springframework.boot:spring-boot-starter-actuator"
 
     implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
-    implementation "org.apache.kafka:kafka-streams:${kafkaVersion}"
+    implementation "org.apache.kafka:kafka-streams:${kafkaStreamsVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
     implementation "io.swagger.core.v3:swagger-annotations:${swaggerVersion}"
 

--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 
     testImplementation "com.vaadin.external.google:android-json:${androidJsonVersion}"
 
-    testImplementation "org.apache.kafka:kafka-clients:${kafkaVersion}@jar"
+    testImplementation "org.apache.kafka:kafka-clients:${kafkaClientsVersion}@jar"
     testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
     testImplementation "org.awaitility:awaitility:${awaitilityVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoCoreVersion}"
@@ -57,7 +57,7 @@ dependencies {
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
 
-    permitTestUnusedDeclared "org.apache.kafka:kafka-clients:${kafkaVersion}:test@jar"
+    permitTestUnusedDeclared "org.apache.kafka:kafka-clients:${kafkaClientsVersion}:test@jar"
 
     testImplementation("org.springframework.boot:spring-boot-starter-actuator")
     permitTestUnusedDeclared("org.springframework.boot:spring-boot-starter-actuator")

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
 
     testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
-    testImplementation "org.apache.kafka:kafka-streams:${kafkaVersion}"
+    testImplementation "org.apache.kafka:kafka-streams:${kafkaStreamsVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoCoreVersion}"
 

--- a/springwolf-plugins/springwolf-kafka-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-kafka-plugin/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     implementation "com.asyncapi:asyncapi-core:${asyncapiCoreVersion}"
     implementation "io.swagger.core.v3:swagger-models:${swaggerVersion}"
-    implementation "org.apache.kafka:kafka-clients:${kafkaVersion}"
+    implementation "org.apache.kafka:kafka-clients:${kafkaClientsVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 
     implementation "org.springframework:spring-beans"


### PR DESCRIPTION
This reverts commit 8cf45d4b

Reason:
- These dependency should be upgraded by the spring (in their versions file) or by the user
  - Source: https://docs.spring.io/spring-boot/docs/current/reference/html/dependency-versions.html
- The versions appear in our pom.xml, which might not be ideal for a library to enfore this on our users