### PR TITLE
example of changing inheritance to composition

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringwolfScannerConfiguration.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringwolfScannerConfiguration.java
@@ -7,6 +7,7 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.MessageBinding
 import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.OperationBindingProcessor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ConsumerOperationDataScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.OperationDataScannerUtils;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProducerOperationDataScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncListenerAnnotationScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisherAnnotationScanner;
@@ -51,19 +52,24 @@ public class SpringwolfScannerConfiguration {
     }
 
     @Bean
+    public OperationDataScannerUtils operationDataScannerUtils(SchemasService schemasService) {
+        return new OperationDataScannerUtils(schemasService);
+    }
+
+    @Bean
     @ConditionalOnProperty(name = SPRINGWOLF_SCANNER_CONSUMER_DATA_ENABLED, havingValue = "true", matchIfMissing = true)
     @Order(value = ChannelPriority.MANUAL_DEFINED)
     public ConsumerOperationDataScanner consumerOperationDataScanner(
-            AsyncApiDocketService asyncApiDocketService, SchemasService schemasService) {
-        return new ConsumerOperationDataScanner(asyncApiDocketService, schemasService);
+            AsyncApiDocketService asyncApiDocketService, OperationDataScannerUtils operationDataScannerUtils) {
+        return new ConsumerOperationDataScanner(asyncApiDocketService, operationDataScannerUtils);
     }
 
     @Bean
     @ConditionalOnProperty(name = SPRINGWOLF_SCANNER_PRODUCER_DATA_ENABLED, havingValue = "true", matchIfMissing = true)
     @Order(value = ChannelPriority.MANUAL_DEFINED)
     public ProducerOperationDataScanner producerOperationDataScanner(
-            AsyncApiDocketService asyncApiDocketService, SchemasService schemasService) {
-        return new ProducerOperationDataScanner(asyncApiDocketService, schemasService);
+            AsyncApiDocketService asyncApiDocketService, OperationDataScannerUtils operationDataScannerUtils) {
+        return new ProducerOperationDataScanner(asyncApiDocketService, operationDataScannerUtils);
     }
 
     @Bean
@@ -74,11 +80,11 @@ public class SpringwolfScannerConfiguration {
     @Order(value = ChannelPriority.ASYNC_ANNOTATION)
     public AsyncListenerAnnotationScanner asyncListenerAnnotationScanner(
             ComponentClassScanner componentClassScanner,
-            SchemasService schemasService,
+            OperationDataScannerUtils operationDataScannerUtils,
             List<OperationBindingProcessor> operationBindingProcessors,
             List<MessageBindingProcessor> messageBindingProcessors) {
         return new AsyncListenerAnnotationScanner(
-                componentClassScanner, schemasService, operationBindingProcessors, messageBindingProcessors);
+                componentClassScanner, operationDataScannerUtils, operationBindingProcessors, messageBindingProcessors);
     }
 
     @Bean
@@ -89,10 +95,10 @@ public class SpringwolfScannerConfiguration {
     @Order(value = ChannelPriority.ASYNC_ANNOTATION)
     public AsyncPublisherAnnotationScanner asyncPublisherAnnotationScanner(
             ComponentClassScanner componentClassScanner,
-            SchemasService schemasService,
+            OperationDataScannerUtils operationDataScannerUtils,
             List<OperationBindingProcessor> operationBindingProcessors,
             List<MessageBindingProcessor> messageBindingProcessors) {
         return new AsyncPublisherAnnotationScanner(
-                componentClassScanner, schemasService, operationBindingProcessors, messageBindingProcessors);
+                componentClassScanner, operationDataScannerUtils, operationBindingProcessors, messageBindingProcessors);
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScanner.java
@@ -1,34 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata;
 
+import com.asyncapi.v2._6_0.model.channel.ChannelItem;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
-import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
-public class ConsumerOperationDataScanner extends AbstractOperationDataScanner {
+public class ConsumerOperationDataScanner implements ChannelsScanner {
 
     private final AsyncApiDocketService asyncApiDocketService;
-    private final SchemasService schemasService;
+    private final OperationDataScannerUtils operationDataScannerUtils;
 
     @Override
-    protected SchemasService getSchemaService() {
-        return this.schemasService;
-    }
-
-    @Override
-    protected List<OperationData> getOperationData() {
-        return new ArrayList<>(asyncApiDocketService.getAsyncApiDocket().getConsumers());
-    }
-
-    @Override
-    protected OperationData.OperationType getOperationType() {
-        return OperationData.OperationType.PUBLISH;
+    public Map<String, ChannelItem> scan() {
+        List<OperationData> consumerData =
+                new ArrayList<>(asyncApiDocketService.getAsyncApiDocket().getConsumers());
+        return operationDataScannerUtils.buildChannelsFromOperationData(
+                consumerData, OperationData.OperationType.PUBLISH);
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScanner.java
@@ -1,34 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata;
 
+import com.asyncapi.v2._6_0.model.channel.ChannelItem;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
-import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
-public class ProducerOperationDataScanner extends AbstractOperationDataScanner {
+public class ProducerOperationDataScanner implements ChannelsScanner {
 
     private final AsyncApiDocketService asyncApiDocketService;
-    private final SchemasService schemasService;
+    private final OperationDataScannerUtils operationDataScannerUtils;
 
     @Override
-    protected SchemasService getSchemaService() {
-        return this.schemasService;
-    }
-
-    @Override
-    protected List<OperationData> getOperationData() {
-        return new ArrayList<>(asyncApiDocketService.getAsyncApiDocket().getProducers());
-    }
-
-    @Override
-    protected OperationData.OperationType getOperationType() {
-        return OperationData.OperationType.SUBSCRIBE;
+    public Map<String, ChannelItem> scan() {
+        List<OperationData> producerData =
+                new ArrayList<>(asyncApiDocketService.getAsyncApiDocket().getProducers());
+        return operationDataScannerUtils.buildChannelsFromOperationData(
+                producerData, OperationData.OperationType.SUBSCRIBE);
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScanner.java
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation;
 
+import com.asyncapi.v2._6_0.model.channel.ChannelItem;
 import com.asyncapi.v2.binding.message.MessageBinding;
 import com.asyncapi.v2.binding.operation.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.MessageBindingProcessor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.OperationBindingProcessor;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.SpringPayloadAnnotationTypeExtractor;
-import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.AbstractOperationDataScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.OperationDataScannerUtils;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.OperationData;
 import io.github.stavshamir.springwolf.asyncapi.types.ProducerData;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
-import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.EmbeddedValueResolverAware;
@@ -25,11 +26,10 @@ import java.util.stream.Stream;
 
 @Slf4j
 @RequiredArgsConstructor
-public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanner
-        implements EmbeddedValueResolverAware {
+public class AsyncPublisherAnnotationScanner implements EmbeddedValueResolverAware, ChannelsScanner {
     private StringValueResolver resolver;
     private final ComponentClassScanner componentClassScanner;
-    private final SchemasService schemasService;
+    private final OperationDataScannerUtils operationDataScannerUtils;
 
     private final List<OperationBindingProcessor> operationBindingProcessors;
 
@@ -41,16 +41,14 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
     }
 
     @Override
-    protected SchemasService getSchemaService() {
-        return this.schemasService;
-    }
-
-    @Override
-    protected List<OperationData> getOperationData() {
-        return componentClassScanner.scan().stream()
+    public Map<String, ChannelItem> scan() {
+        List<OperationData> operationData = componentClassScanner.scan().stream()
                 .flatMap(this::getAnnotatedMethods)
                 .flatMap(this::toOperationData)
                 .toList();
+
+        return operationDataScannerUtils.buildChannelsFromOperationData(
+                operationData, OperationData.OperationType.SUBSCRIBE);
     }
 
     private Stream<Method> getAnnotatedMethods(Class<?> type) {
@@ -96,10 +94,5 @@ public class AsyncPublisherAnnotationScanner extends AbstractOperationDataScanne
                 .messageBinding(messageBindings)
                 .message(message)
                 .build();
-    }
-
-    @Override
-    protected OperationData.OperationType getOperationType() {
-        return OperationData.OperationType.SUBSCRIBE;
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceIntegrationTest.java
@@ -7,6 +7,7 @@ import com.asyncapi.v2._6_0.model.server.Server;
 import com.asyncapi.v2.binding.message.kafka.KafkaMessageBinding;
 import com.asyncapi.v2.binding.operation.kafka.KafkaOperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ConsumerOperationDataScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.OperationDataScannerUtils;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.ProducerOperationDataScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
 import io.github.stavshamir.springwolf.asyncapi.types.ConsumerData;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
             ExampleJsonGenerator.class,
             ProducerOperationDataScanner.class,
             ConsumerOperationDataScanner.class,
+            OperationDataScannerUtils.class
         })
 @Import({
     DefaultAsyncApiServiceIntegrationTest.DefaultAsyncApiServiceTestConfiguration.class,

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ConsumerOperationDataScannerIntegrationTest.java
@@ -35,7 +35,12 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(
-        classes = {ConsumerOperationDataScanner.class, DefaultSchemasService.class, ExampleJsonGenerator.class})
+        classes = {
+            ConsumerOperationDataScanner.class,
+            DefaultSchemasService.class,
+            ExampleJsonGenerator.class,
+            OperationDataScannerUtils.class
+        })
 class ConsumerOperationDataScannerIntegrationTest {
 
     @Autowired

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/ProducerOperationDataScannerIntegrationTest.java
@@ -35,7 +35,12 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(
-        classes = {ProducerOperationDataScanner.class, DefaultSchemasService.class, ExampleJsonGenerator.class})
+        classes = {
+            ProducerOperationDataScanner.class,
+            DefaultSchemasService.class,
+            ExampleJsonGenerator.class,
+            OperationDataScannerUtils.class
+        })
 class ProducerOperationDataScannerIntegrationTest {
 
     @Autowired

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncListenerAnnotationScannerIntegrationTest.java
@@ -4,6 +4,7 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata
 import com.asyncapi.v2._6_0.model.channel.ChannelItem;
 import com.asyncapi.v2._6_0.model.channel.operation.Operation;
 import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.processor.TestOperationBindingProcessor;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.OperationDataScannerUtils;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
@@ -34,6 +35,7 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(
         classes = {
             AsyncListenerAnnotationScanner.class,
+            OperationDataScannerUtils.class,
             DefaultSchemasService.class,
             ExampleJsonGenerator.class,
             TestOperationBindingProcessor.class

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/operationdata/annotation/AsyncPublisherAnnotationScannerIntegrationTest.java
@@ -4,6 +4,7 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata
 import com.asyncapi.v2._6_0.model.channel.ChannelItem;
 import com.asyncapi.v2._6_0.model.channel.operation.Operation;
 import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.processor.TestOperationBindingProcessor;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.OperationDataScannerUtils;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.PayloadReference;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(
         classes = {
             AsyncPublisherAnnotationScanner.class,
+            OperationDataScannerUtils.class,
             DefaultSchemasService.class,
             ExampleJsonGenerator.class,
             TestOperationBindingProcessor.class


### PR DESCRIPTION
This PR is an example for an refactoring of an abstract superclass (here `AbstractOperationDataScanner`) to an 'Utils-Bean' which is uses as dependency in the concrete implementation classes.  It is mainly intended as a basis of discussion. 





