### PR TITLE
add @ConditionalOnMissingBean 

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringwolfAutoConfiguration.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringwolfAutoConfiguration.java
@@ -43,12 +43,14 @@ public class SpringwolfAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public SpringwolfInitApplicationListener springwolfInitApplicationListener(
             AsyncApiService asyncApiService, SpringwolfConfigProperties configProperties) {
         return new SpringwolfInitApplicationListener(asyncApiService, configProperties);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public AsyncApiService asyncApiService(
             AsyncApiDocketService asyncApiDocketService,
             ChannelsService channelsService,
@@ -58,16 +60,19 @@ public class SpringwolfAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public ChannelsService channelsService(List<? extends ChannelsScanner> channelsScanners) {
         return new DefaultChannelsService(channelsScanners);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public SchemasService schemasService(List<ModelConverter> modelConverters, ExampleGenerator exampleGenerator) {
         return new DefaultSchemasService(modelConverters, exampleGenerator);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public AsyncApiDocketService asyncApiDocketService(
             Optional<AsyncApiDocket> optionalAsyncApiDocket, SpringwolfConfigProperties springwolfConfigProperties) {
         return new DefaultAsyncApiDocketService(optionalAsyncApiDocket, springwolfConfigProperties);

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringwolfScannerConfiguration.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringwolfScannerConfiguration.java
@@ -14,6 +14,7 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassS
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ConfigurationClassScanner;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,18 +35,21 @@ import static io.github.stavshamir.springwolf.configuration.properties.Springwol
 public class SpringwolfScannerConfiguration {
 
     @Bean
+    @ConditionalOnMissingBean
     public ComponentClassScanner componentClassScanner(
             AsyncApiDocketService asyncApiDocketService, Environment environment) {
         return new ComponentClassScanner(asyncApiDocketService, environment);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public ConfigurationClassScanner configurationClassScanner(
             AsyncApiDocketService asyncApiDocketService, Environment environment) {
         return new ConfigurationClassScanner(asyncApiDocketService, environment);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public BeanMethodsScanner beanMethodsScanner(ConfigurationClassScanner configurationClassScanner) {
         return new DefaultBeanMethodsScanner(configurationClassScanner);
     }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringwolfWebConfiguration.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringwolfWebConfiguration.java
@@ -6,6 +6,7 @@ import io.github.stavshamir.springwolf.asyncapi.AsyncApiService;
 import io.github.stavshamir.springwolf.asyncapi.DefaultAsyncApiSerializerService;
 import io.github.stavshamir.springwolf.asyncapi.controller.ActuatorAsyncApiController;
 import io.github.stavshamir.springwolf.asyncapi.controller.AsyncApiController;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +21,7 @@ public class SpringwolfWebConfiguration {
 
     @Bean
     @ConditionalOnProperty(name = SPRINGWOLF_ENDPOINT_ACTUATOR_ENABLED, havingValue = "false", matchIfMissing = true)
+    @ConditionalOnMissingBean
     public AsyncApiController asyncApiController(
             AsyncApiService asyncApiService, AsyncApiSerializerService asyncApiSerializerService) {
         return new AsyncApiController(asyncApiService, asyncApiSerializerService);
@@ -27,12 +29,14 @@ public class SpringwolfWebConfiguration {
 
     @Bean
     @ConditionalOnProperty(name = SPRINGWOLF_ENDPOINT_ACTUATOR_ENABLED, havingValue = "true")
+    @ConditionalOnMissingBean
     public ActuatorAsyncApiController actuatorAsyncApiController(
             AsyncApiService asyncApiService, AsyncApiSerializerService asyncApiSerializerService) {
         return new ActuatorAsyncApiController(asyncApiService, asyncApiSerializerService);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public AsyncApiSerializerService asyncApiSerializerService() {
         return new DefaultAsyncApiSerializerService();
     }

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/amqp/SpringwolfAmqpProducerConfiguration.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/amqp/SpringwolfAmqpProducerConfiguration.java
@@ -7,6 +7,7 @@ import io.github.stavshamir.springwolf.asyncapi.controller.SpringwolfAmqpControl
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.producer.SpringwolfAmqpProducer;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,12 +28,14 @@ import static io.github.stavshamir.springwolf.configuration.properties.Springwol
 public class SpringwolfAmqpProducerConfiguration {
 
     @Bean
+    @ConditionalOnMissingBean
     public SpringwolfAmqpProducer springwolfAmqpProducer(
             AsyncApiService asyncApiService, @NonNull List<RabbitTemplate> rabbitTemplates) {
         return new SpringwolfAmqpProducer(asyncApiService, rabbitTemplates);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public SpringwolfAmqpController springwolfAmqpController(
             AsyncApiDocketService asyncApiDocketService,
             SpringwolfAmqpProducer springwolfAmqpProducer,

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/amqp/SpringwolfAmqpScannerConfiguration.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/amqp/SpringwolfAmqpScannerConfiguration.java
@@ -12,6 +12,7 @@ import io.github.stavshamir.springwolf.schemas.SchemasService;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Exchange;
 import org.springframework.amqp.core.Queue;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -59,12 +60,14 @@ public class SpringwolfAmqpScannerConfiguration {
 
     @Bean
     @Order(value = BindingProcessorPriority.PROTOCOL_BINDING)
+    @ConditionalOnMissingBean
     public AmqpMessageBindingProcessor amqpMessageBindingProcessor() {
         return new AmqpMessageBindingProcessor();
     }
 
     @Bean
     @Order(value = BindingProcessorPriority.PROTOCOL_BINDING)
+    @ConditionalOnMissingBean
     public AmqpOperationBindingProcessor amqpOperationBindingProcessor() {
         return new AmqpOperationBindingProcessor();
     }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/kafka/SpringwolfKafkaProducerConfiguration.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/kafka/SpringwolfKafkaProducerConfiguration.java
@@ -7,6 +7,7 @@ import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.configuration.properties.SpringwolfKafkaConfigProperties;
 import io.github.stavshamir.springwolf.producer.SpringwolfKafkaProducer;
 import io.github.stavshamir.springwolf.producer.SpringwolfKafkaTemplateFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,6 +23,7 @@ import static io.github.stavshamir.springwolf.configuration.properties.Springwol
 public class SpringwolfKafkaProducerConfiguration {
 
     @Bean
+    @ConditionalOnMissingBean
     public SpringwolfKafkaController springwolfKafkaController(
             AsyncApiDocketService asyncApiDocketService,
             SpringwolfKafkaProducer springwolfKafkaProducer,
@@ -30,11 +32,13 @@ public class SpringwolfKafkaProducerConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public SpringwolfKafkaProducer springwolfKafkaProducer(SpringwolfKafkaTemplateFactory producerTemplateFactory) {
         return new SpringwolfKafkaProducer(producerTemplateFactory.buildKafkaTemplate());
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public SpringwolfKafkaTemplateFactory springwolfKafkaTemplateFactory(
             SpringwolfKafkaConfigProperties springwolfKafkaConfigProperties) {
         return new SpringwolfKafkaTemplateFactory(springwolfKafkaConfigProperties);

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/kafka/SpringwolfKafkaScannerConfiguration.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/kafka/SpringwolfKafkaScannerConfiguration.java
@@ -9,6 +9,7 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.Cla
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelKafkaListenerScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -46,12 +47,14 @@ public class SpringwolfKafkaScannerConfiguration {
 
     @Bean
     @Order(value = BindingProcessorPriority.PROTOCOL_BINDING)
+    @ConditionalOnMissingBean
     public KafkaMessageBindingProcessor kafkaMessageBindingProcessor() {
         return new KafkaMessageBindingProcessor();
     }
 
     @Bean
     @Order(value = BindingProcessorPriority.PROTOCOL_BINDING)
+    @ConditionalOnMissingBean
     public KafkaOperationBindingProcessor kafkaOperationBindingProcessor() {
         return new KafkaOperationBindingProcessor();
     }

--- a/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/sns/SpringwolfSnsProducerConfiguration.java
+++ b/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/sns/SpringwolfSnsProducerConfiguration.java
@@ -6,6 +6,7 @@ import io.awspring.cloud.sns.core.SnsTemplate;
 import io.github.stavshamir.springwolf.asyncapi.controller.SpringwolfSnsController;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.producer.SpringwolfSnsProducer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +24,7 @@ import static io.github.stavshamir.springwolf.configuration.properties.Springwol
 public class SpringwolfSnsProducerConfiguration {
 
     @Bean
+    @ConditionalOnMissingBean
     public SpringwolfSnsController springwolfSnsController(
             AsyncApiDocketService asyncApiDocketService,
             SpringwolfSnsProducer springwolfSnsProducer,
@@ -31,6 +33,7 @@ public class SpringwolfSnsProducerConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public SpringwolfSnsProducer springwolfSnsProducer(List<SnsTemplate> snsTemplate) {
         return new SpringwolfSnsProducer(snsTemplate);
     }

--- a/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/sns/SpringwolfSnsScannerConfiguration.java
+++ b/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/sns/SpringwolfSnsScannerConfiguration.java
@@ -4,6 +4,7 @@ package io.github.stavshamir.springwolf.asyncapi.sns;
 import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.BindingProcessorPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.SnsMessageBindingProcessor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.SnsOperationBindingProcessor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -16,12 +17,14 @@ public class SpringwolfSnsScannerConfiguration {
 
     @Bean
     @Order(value = BindingProcessorPriority.PROTOCOL_BINDING)
+    @ConditionalOnMissingBean
     public SnsMessageBindingProcessor snsMessageBindingProcessor() {
         return new SnsMessageBindingProcessor();
     }
 
     @Bean
     @Order(value = BindingProcessorPriority.PROTOCOL_BINDING)
+    @ConditionalOnMissingBean
     public SnsOperationBindingProcessor snsOperationBindingProcessor() {
         return new SnsOperationBindingProcessor();
     }

--- a/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/sqs/SpringwolfSqsProducerConfiguration.java
+++ b/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/sqs/SpringwolfSqsProducerConfiguration.java
@@ -6,6 +6,7 @@ import io.awspring.cloud.sqs.operations.SqsTemplate;
 import io.github.stavshamir.springwolf.asyncapi.controller.SpringwolfSqsController;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.producer.SpringwolfSqsProducer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,11 +24,13 @@ import static io.github.stavshamir.springwolf.configuration.properties.Springwol
 public class SpringwolfSqsProducerConfiguration {
 
     @Bean
+    @ConditionalOnMissingBean
     public SpringwolfSqsProducer springwolfSqsProducer(List<SqsTemplate> sqsTemplates) {
         return new SpringwolfSqsProducer(sqsTemplates);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public SpringwolfSqsController springwolfSqsController(
             AsyncApiDocketService asyncApiDocketService,
             SpringwolfSqsProducer springwolfSqsProducer,

--- a/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/sqs/SpringwolfSqsScannerConfiguration.java
+++ b/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/sqs/SpringwolfSqsScannerConfiguration.java
@@ -8,6 +8,7 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriorit
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelSqsListenerScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ComponentClassScanner;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,12 +32,14 @@ public class SpringwolfSqsScannerConfiguration {
 
     @Bean
     @Order(value = BindingProcessorPriority.PROTOCOL_BINDING)
+    @ConditionalOnMissingBean
     public SqsMessageBindingProcessor sqsMessageBindingProcessor() {
         return new SqsMessageBindingProcessor();
     }
 
     @Bean
     @Order(value = BindingProcessorPriority.PROTOCOL_BINDING)
+    @ConditionalOnMissingBean
     public SqsOperationBindingProcessor sqsOperationBindingProcessor() {
         return new SqsOperationBindingProcessor();
     }


### PR DESCRIPTION
Addes `@ConditionalOnMissingBean` to all Springwolf service beans. 

I made one exception:  All subclasses of `ChannelScanner` beans are not annotated. As  all `ChannelScanner` beans are collected by `DefaultChannelsService`, an application can simply define its own `ChannelScanner` bean which is recognized by DefaultChannelsService. To suppress the default Springwolf ChannelScanners, there are `*.enabled` properties for each `ChannelScanner` type. 

TBD:  is this decision ok?