### PR TITLE
Defer fail-fast initialization to ApplicationReadyEvent

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/SpringwolfInitApplicationListener.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/SpringwolfInitApplicationListener.java
@@ -5,7 +5,6 @@ import io.github.stavshamir.springwolf.configuration.properties.SpringwolfConfig
 import io.github.stavshamir.springwolf.configuration.properties.SpringwolfConfigProperties.InitMode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 
@@ -16,7 +15,7 @@ import org.springframework.context.ApplicationListener;
  */
 @Slf4j
 @RequiredArgsConstructor
-public class SpringwolfInitApplicationListener implements ApplicationListener<ApplicationReadyEvent>, InitializingBean {
+public class SpringwolfInitApplicationListener implements ApplicationListener<ApplicationReadyEvent> {
 
     private final AsyncApiService asyncApiService;
     private final SpringwolfConfigProperties configProperties;
@@ -26,12 +25,7 @@ public class SpringwolfInitApplicationListener implements ApplicationListener<Ap
         if (configProperties.getInitMode() == InitMode.BACKGROUND) {
             log.debug("triggering background asyncapi creation..");
             new Thread(asyncApiService::getAsyncAPI).start();
-        }
-    }
-
-    @Override
-    public void afterPropertiesSet() {
-        if (configProperties.getInitMode() == InitMode.FAIL_FAST) {
+        } else {
             log.debug("triggering asyncapi creation..");
             this.asyncApiService.getAsyncAPI();
         }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/InitModeIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/InitModeIntegrationTest.java
@@ -5,7 +5,6 @@ import io.github.stavshamir.springwolf.asyncapi.DefaultAsyncApiService;
 import io.github.stavshamir.springwolf.asyncapi.controller.AsyncApiController;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -67,7 +66,7 @@ public class InitModeIntegrationTest {
             try {
                 SpringApplication.run(TestApplication.class, args);
                 fail("Exception expected, but not raised.");
-            } catch (BeanCreationException ex) {
+            } catch (Exception ex) {
                 assertThat(ex.getMessage()).contains("Error occured during creation of AsyncAPI");
             }
         }


### PR DESCRIPTION
This PR introduces a small change to the fail-fast initialization of AsyncApi. Until now, the initialization happend during `afterPropertiesSet()` method in `SpringWolfInitApplicationListener` - which means: after the `SpringWolfInitApplicationListener` bean and all dependents (including `AsyncApiService` etc...) have been initialized. 

The disadvantage of initializing the AsyncAPI at this point of time is, that the spring context isn't **completly** initialized, some beans may not exist in the spring-context at this moment. This may be problematic if scanner classes will for example make use of `BeanPostProcessors` or Spring AOP to detect (infrastructre) beans.

I moved the fail-fast initializing branch into the  `onApplicationEvent()` method, which means:

- the AsyncApi initialization happens a little bit later
- the fail-fast semantics remains valid, in case of a validation error the spring application will not boot but abort throwing an exception.