### PR TITLE
fix: Improved error message

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/SpringPayloadAnnotationTypeExtractor.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/SpringPayloadAnnotationTypeExtractor.java
@@ -54,7 +54,7 @@ public class SpringPayloadAnnotationTypeExtractor {
                 int payloadAnnotatedParameterIndex = getPayloadAnnotatedParameterIndex(parameterAnnotations);
                 if (payloadAnnotatedParameterIndex == -1) {
                     String msg =
-                            "Multi-parameter KafkaListener methods must have one parameter annotated with @Payload, "
+                            "Multi-parameter AsyncListener methods must have one parameter annotated with @Payload, "
                                     + "but none was found: "
                                     + methodName;
 
@@ -68,8 +68,7 @@ public class SpringPayloadAnnotationTypeExtractor {
     static int getPayloadAnnotatedParameterIndex(Annotation[][] parameterAnnotations) {
         for (int i = 0, length = parameterAnnotations.length; i < length; i++) {
             Annotation[] annotations = parameterAnnotations[i];
-            boolean hasPayloadAnnotation =
-                    Arrays.stream(annotations).anyMatch(annotation -> annotation instanceof Payload);
+            boolean hasPayloadAnnotation = Arrays.stream(annotations).anyMatch(Payload.class::isInstance);
 
             if (hasPayloadAnnotation) {
                 return i;


### PR DESCRIPTION
When a method defining `@AsyncGenericOperationBinding` has more than 1 argument and misses the `@Payload` annotation, the provided exception message was confusing.

Instead of `Multi-parameter KafkaListener methods must have one parameter annotated with @Payload but none was found` we now provide a more generic `Multi-parameter AsyncListener methods must have one parameter annotated with @Payload but none was found`