### PR TITLE
test: introduce systemTest target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ springwolf-plugins/springwolf-sqs-plugin/build/
 .idea/
 /gradle.properties
 
+asyncapi.actual.json
+
 # Eclipse IDE
 .classpath
 .project

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ allprojects {
     tasks.register('integrationTest', Test) {
         dependsOn spotlessApply // Automatically fix code formatting if possible
 
-        description = 'Run only unit tests (excludes **SystemTest)'
+        description = 'Run integration tests (excludes **SystemTest)'
         group = 'verification'
 
         useJUnitPlatform()

--- a/build.gradle
+++ b/build.gradle
@@ -79,12 +79,31 @@ allprojects {
         enabled = !it.project.name.contains("-example") // Examples do not contain unit tests and would fail otherwise
         dependsOn spotlessApply // Automatically fix code formatting if possible
 
-        description = 'Run only unit tests (excludes **IntegrationTest)'
+        description = 'Run only unit tests (excludes **IntegrationTest and **SystemTest)'
         group = 'verification'
 
         useJUnitPlatform()
         filter {
-            excludePatterns = ['*IntegrationTest']
+            excludePatterns = ['*IntegrationTest', '*SystemTest']
+        }
+        testLogging {
+            // showStandardStreams = true
+
+            events "skipped", "failed"
+            exceptionFormat = 'full'
+        }
+    }
+
+
+    tasks.register('integrationTest', Test) {
+        dependsOn spotlessApply // Automatically fix code formatting if possible
+
+        description = 'Run only unit tests (excludes **SystemTest)'
+        group = 'verification'
+
+        useJUnitPlatform()
+        filter {
+            excludePatterns = ['*SystemTest']
         }
         testLogging {
             // showStandardStreams = true

--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/amqp/ApiSystemTest.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/amqp/ApiSystemTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package io.github.stavshamir.springwolf.example.cloudstream;
+package io.github.stavshamir.springwolf.example.amqp;
 
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @Testcontainers
 // @Ignore("Uncomment this line if you have issues running this test on your local machine.")
-public class ApiIntegrationWithDockerIntegrationTest {
+public class ApiSystemTest {
 
     private static final RestTemplate restTemplate = new RestTemplate();
     private static final String APP_NAME = "app_1";
@@ -58,7 +58,6 @@ public class ApiIntegrationWithDockerIntegrationTest {
     void asyncapiDocsShouldReturnTheCorrectJsonResponse() throws IOException, JSONException {
         String url = baseUrl() + "/springwolf/docs";
         String actual = restTemplate.getForObject(url, String.class);
-        System.out.println("Got: " + actual);
 
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expected = new String(s.readAllBytes(), StandardCharsets.UTF_8);

--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/amqp/BaseApiIntegrationTest.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/amqp/BaseApiIntegrationTest.java
@@ -11,6 +11,8 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -35,7 +37,7 @@ public abstract class BaseApiIntegrationTest {
     void asyncApiResourceArtifactTest() throws JSONException, IOException {
         String url = "/springwolf/docs";
         String actual = restTemplate.getForObject(url, String.class);
-        System.out.println("Got: " + actual);
+        Files.writeString(Path.of("src", "test", "resources", "asyncapi.actual.json"), actual);
 
         String expectedApiFileName = getExpectedApiFileName();
         InputStream s = this.getClass().getResourceAsStream(expectedApiFileName);

--- a/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/stavshamir/springwolf/example/cloudstream/ApiIntegrationTest.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/stavshamir/springwolf/example/cloudstream/ApiIntegrationTest.java
@@ -13,6 +13,8 @@ import org.springframework.test.annotation.DirtiesContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -35,7 +37,7 @@ public class ApiIntegrationTest {
     void asyncApiResourceArtifactTest() throws JSONException, IOException {
         String url = "/springwolf/docs";
         String actual = restTemplate.getForObject(url, String.class);
-        System.out.println("Got: " + actual);
+        Files.writeString(Path.of("src", "test", "resources", "asyncapi.actual.json"), actual);
 
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expectedWithoutServersKafkaUrlPatch = new String(s.readAllBytes(), StandardCharsets.UTF_8);

--- a/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/stavshamir/springwolf/example/cloudstream/ApiSystemTest.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/stavshamir/springwolf/example/cloudstream/ApiSystemTest.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-package io.github.stavshamir.springwolf.example.sns;
+package io.github.stavshamir.springwolf.example.cloudstream;
 
-import lombok.extern.slf4j.Slf4j;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestTemplate;
@@ -22,12 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * While the assertion of this test is identical to ApiIntegrationTests,
- * the setup uses a full docker-compose context with a real sns instance.
+ * the setup uses a full docker-compose context with a real kafka instance.
  */
 @Testcontainers
-@Slf4j
 // @Ignore("Uncomment this line if you have issues running this test on your local machine.")
-public class ApiIntegrationWithDockerIntegrationTest {
+public class ApiSystemTest {
 
     private static final RestTemplate restTemplate = new RestTemplate();
     private static final String APP_NAME = "app_1";
@@ -46,10 +44,9 @@ public class ApiIntegrationWithDockerIntegrationTest {
     }
 
     @Container
-    public DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+    public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
             .withExposedService(APP_NAME, APP_PORT)
-            .withEnv(ENV)
-            .withLogConsumer(APP_NAME, l -> log.debug("APP: %s".formatted(l.getUtf8StringWithoutLineEnding())));
+            .withEnv(ENV);
 
     private String baseUrl() {
         String host = environment.getServiceHost(APP_NAME, APP_PORT);
@@ -61,7 +58,6 @@ public class ApiIntegrationWithDockerIntegrationTest {
     void asyncapiDocsShouldReturnTheCorrectJsonResponse() throws IOException, JSONException {
         String url = baseUrl() + "/springwolf/docs";
         String actual = restTemplate.getForObject(url, String.class);
-        System.out.println("Got: " + actual);
 
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expected = new String(s.readAllBytes(), StandardCharsets.UTF_8);

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ApiIntegrationTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ApiIntegrationTest.java
@@ -13,6 +13,8 @@ import org.springframework.test.annotation.DirtiesContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -38,7 +40,7 @@ public class ApiIntegrationTest {
     void asyncApiResourceArtifactTest() throws JSONException, IOException {
         String url = "/springwolf/docs";
         String actual = restTemplate.getForObject(url, String.class);
-        System.out.println("Got: " + actual);
+        Files.writeString(Path.of("src", "test", "resources", "asyncapi.actual.json"), actual);
 
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expectedWithoutServersKafkaUrlPatch = new String(s.readAllBytes(), StandardCharsets.UTF_8);

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ApiIntegrationWithActuatorIntegrationTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ApiIntegrationWithActuatorIntegrationTest.java
@@ -42,7 +42,6 @@ public class ApiIntegrationWithActuatorIntegrationTest {
     void asyncApiResourceArtifactTest() throws JSONException, IOException {
         String url = "http://localhost:" + managementPort + "/actuator/springwolf/docs";
         String actual = restTemplate.getForObject(url, String.class);
-        System.out.println("Got: " + actual);
 
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expectedWithoutServersKafkaUrlPatch = new String(s.readAllBytes(), StandardCharsets.UTF_8);

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ApiSystemTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ApiSystemTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package io.github.stavshamir.springwolf.example.sqs;
+package io.github.stavshamir.springwolf.example.kafka;
 
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
@@ -21,11 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * While the assertion of this test is identical to ApiIntegrationTests,
- * the setup uses a full docker-compose context with a real sqs instance.
+ * the setup uses a full docker-compose context with a real kafka instance.
  */
 @Testcontainers
 // @Ignore("Uncomment this line if you have issues running this test on your local machine.")
-public class ApiIntegrationWithDockerIntegrationTest {
+public class ApiSystemTest {
 
     private static final RestTemplate restTemplate = new RestTemplate();
     private static final String APP_NAME = "app_1";
@@ -44,7 +44,7 @@ public class ApiIntegrationWithDockerIntegrationTest {
     }
 
     @Container
-    public DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+    public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
             .withExposedService(APP_NAME, APP_PORT)
             .withEnv(ENV);
 
@@ -58,7 +58,6 @@ public class ApiIntegrationWithDockerIntegrationTest {
     void asyncapiDocsShouldReturnTheCorrectJsonResponse() throws IOException, JSONException {
         String url = baseUrl() + "/springwolf/docs";
         String actual = restTemplate.getForObject(url, String.class);
-        System.out.println("Got: " + actual);
 
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expected = new String(s.readAllBytes(), StandardCharsets.UTF_8);

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/OpenApiGeneratorSystemTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/OpenApiGeneratorSystemTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * The generateOpenApiDocs task will generate the openapi-generated.json into the test-resources so that
  * this test can pick up the openapi-generated.json afterwards and compare it to the reference asyncapi.json
  */
-class OpenApiGeneratorTest {
+class OpenApiGeneratorSystemTest {
 
     @Test
     void asyncApiResourceArtifactTest() throws IOException {

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ProducerSystemTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/ProducerSystemTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.verify;
 @DirtiesContext
 @TestMethodOrder(OrderAnnotation.class)
 // @Ignore("Uncomment this line if you have issues running this test on your local machine.")
-public class ProducerIntegrationWithDockerIntegrationTest {
+public class ProducerSystemTest {
 
     @Autowired
     SpringwolfKafkaProducer springwolfKafkaProducer;

--- a/springwolf-examples/springwolf-sns-example/src/test/java/io/github/stavshamir/springwolf/example/sns/ApiIntegrationTest.java
+++ b/springwolf-examples/springwolf-sns-example/src/test/java/io/github/stavshamir/springwolf/example/sns/ApiIntegrationTest.java
@@ -14,6 +14,8 @@ import org.springframework.test.context.DynamicPropertySource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -38,7 +40,7 @@ class ApiIntegrationTest {
     void asyncApiResourceArtifactTest() throws JSONException, IOException {
         String url = "/springwolf/docs";
         String actual = restTemplate.getForObject(url, String.class);
-        System.out.println("Got: " + actual);
+        Files.writeString(Path.of("src", "test", "resources", "asyncapi.actual.json"), actual);
 
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expected = new String(s.readAllBytes(), StandardCharsets.UTF_8);

--- a/springwolf-examples/springwolf-sqs-example/src/test/java/io/github/stavshamir/springwolf/example/sqs/ApiIntegrationTest.java
+++ b/springwolf-examples/springwolf-sqs-example/src/test/java/io/github/stavshamir/springwolf/example/sqs/ApiIntegrationTest.java
@@ -14,6 +14,8 @@ import org.springframework.test.context.DynamicPropertySource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -38,7 +40,7 @@ class ApiIntegrationTest {
     void asyncApiResourceArtifactTest() throws JSONException, IOException {
         String url = "/springwolf/docs";
         String actual = restTemplate.getForObject(url, String.class);
-        System.out.println("Got: " + actual);
+        Files.writeString(Path.of("src", "test", "resources", "asyncapi.actual.json"), actual);
 
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expected = new String(s.readAllBytes(), StandardCharsets.UTF_8);

--- a/springwolf-examples/springwolf-sqs-example/src/test/java/io/github/stavshamir/springwolf/example/sqs/ApiSystemTest.java
+++ b/springwolf-examples/springwolf-sqs-example/src/test/java/io/github/stavshamir/springwolf/example/sqs/ApiSystemTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package io.github.stavshamir.springwolf.example.kafka;
+package io.github.stavshamir.springwolf.example.sqs;
 
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
@@ -21,11 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * While the assertion of this test is identical to ApiIntegrationTests,
- * the setup uses a full docker-compose context with a real kafka instance.
+ * the setup uses a full docker-compose context with a real sqs instance.
  */
 @Testcontainers
 // @Ignore("Uncomment this line if you have issues running this test on your local machine.")
-public class ApiIntegrationWithDockerIntegrationTest {
+public class ApiSystemTest {
 
     private static final RestTemplate restTemplate = new RestTemplate();
     private static final String APP_NAME = "app_1";
@@ -44,7 +44,7 @@ public class ApiIntegrationWithDockerIntegrationTest {
     }
 
     @Container
-    public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+    public DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
             .withExposedService(APP_NAME, APP_PORT)
             .withEnv(ENV);
 
@@ -58,7 +58,6 @@ public class ApiIntegrationWithDockerIntegrationTest {
     void asyncapiDocsShouldReturnTheCorrectJsonResponse() throws IOException, JSONException {
         String url = baseUrl() + "/springwolf/docs";
         String actual = restTemplate.getForObject(url, String.class);
-        System.out.println("Got: " + actual);
 
         InputStream s = this.getClass().getResourceAsStream("/asyncapi.json");
         String expected = new String(s.readAllBytes(), StandardCharsets.UTF_8);

--- a/springwolf-examples/springwolf-sqs-example/src/test/java/io/github/stavshamir/springwolf/example/sqs/ProducerSystemTest.java
+++ b/springwolf-examples/springwolf-sqs-example/src/test/java/io/github/stavshamir/springwolf/example/sqs/ProducerSystemTest.java
@@ -1,31 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
-package io.github.stavshamir.springwolf.example.amqp;
+package io.github.stavshamir.springwolf.example.sqs;
 
-import io.github.stavshamir.springwolf.example.amqp.consumers.ExampleConsumer;
-import io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto;
-import io.github.stavshamir.springwolf.producer.SpringwolfAmqpProducer;
+import io.github.stavshamir.springwolf.example.sqs.consumers.ExampleConsumer;
+import io.github.stavshamir.springwolf.example.sqs.dtos.ExamplePayloadDto;
+import io.github.stavshamir.springwolf.producer.SpringwolfSqsProducer;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.springframework.amqp.AmqpIOException;
-import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.DockerComposeContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.File;
 
-import static io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto.ExampleEnum.FOO1;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import static io.github.stavshamir.springwolf.example.sqs.dtos.ExamplePayloadDto.ExampleEnum.FOO1;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
@@ -34,34 +27,23 @@ import static org.mockito.Mockito.verify;
  * the setup uses a full docker-compose context with a real sqs instance.
  */
 @SpringBootTest(
-        classes = {SpringwolfAmqpExampleApplication.class},
+        classes = {SpringwolfSqsExampleApplication.class},
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
 @DirtiesContext
 @TestMethodOrder(OrderAnnotation.class)
-@TestPropertySource(properties = {"spring.rabbitmq.host=localhost"})
 // @Ignore("Uncomment this line if you have issues running this test on your local machine.")
-public class ProducerIntegrationWithDockerIntegrationTest {
+public class ProducerSystemTest {
 
     @Autowired
-    SpringwolfAmqpProducer springwolfAmqpProducer;
+    SpringwolfSqsProducer springwolfSqsProducer;
 
     @SpyBean
     ExampleConsumer exampleConsumer;
 
     @Container
     public static DockerComposeContainer<?> environment =
-            new DockerComposeContainer<>(new File("docker-compose.yml")).withServices("amqp");
-
-    @Test
-    @Order(1)
-    void verifyAmqpIsAvailable() {
-        ConnectionFactory factory = new CachingConnectionFactory("localhost");
-
-        await().atMost(60, SECONDS).ignoreException(AmqpIOException.class).untilAsserted(() -> assertThat(
-                        factory.createConnection().isOpen())
-                .isTrue());
-    }
+            new DockerComposeContainer<>(new File("docker-compose.yml")).withServices("localstack");
 
     @Test
     @Order(2)
@@ -73,7 +55,7 @@ public class ProducerIntegrationWithDockerIntegrationTest {
         payload.setSomeEnum(FOO1);
 
         // when
-        springwolfAmqpProducer.send("example-queue", payload);
+        springwolfSqsProducer.send("example-queue", payload);
 
         // then
         verify(exampleConsumer, timeout(10000)).receiveExamplePayload(payload);


### PR DESCRIPTION
While IntegrationTest allows to use the SpringContext, SystemTest goes one level higher in the test pyramid and runs using the docker containers.

Motivation: SystemTest take longer to run as the docker containers need to be started. IntegrationTest strike a balance between fast to execute and high test coverage.