### PR TITLE
Adding kafka protubuf example

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,7 @@ include(
         'springwolf-examples:springwolf-cloud-stream-example',
         'springwolf-examples:springwolf-jms-example',
         'springwolf-examples:springwolf-kafka-example',
+        'springwolf-examples:springwolf-kafka-protobuf-example',
         'springwolf-examples:springwolf-sns-example',
         'springwolf-examples:springwolf-sqs-example',
         'springwolf-ui',

--- a/springwolf-examples/springwolf-kafka-protobuf-example/.gitignore
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/.gitignore
@@ -1,0 +1,5 @@
+# ignore all directories with the name target
+target/
+.idea/
+build/
+.gradle/

--- a/springwolf-examples/springwolf-kafka-protobuf-example/README.md
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/README.md
@@ -1,0 +1,10 @@
+### Run with gradle
+1. Verify zookeeper and kafka are running.
+2. If your kafka is not configured to automatically add topics, manually add a topic named `protobuf-topic`.
+3. Define an environment variable with the server details: `$ export BOOTSTRAP_SERVER=localhost:9092` and `$ export SCHEMA_SERVER=http://localhost:8080`.
+4. Clone this repository: `$ git clone https://github.com/springwolf/springwolf-core.git`.
+5. Start the application: `$ cd springwolf-core && ./gradlew build -p springwolf-examples/springwolf-kafka-protobuf-example bootRun`.
+6. Visit `localhost:8080/springwolf/asyncapi-ui.html` or try the API: `$ curl localhost:8080/springwolf/docs`.
+
+_Tested with Kafka version 2.12_0.10.2.2._
+"

--- a/springwolf-examples/springwolf-kafka-protobuf-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/build.gradle
@@ -1,0 +1,137 @@
+plugins {
+    id 'java'
+
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+    id 'ca.cutterslade.analyze'
+
+    id 'com.bmuschko.docker-spring-boot-application'
+    id 'org.springdoc.openapi-gradle-plugin' version '1.8.0'
+    id 'com.google.protobuf' version '0.8.17'
+}
+
+repositories {
+    mavenCentral()
+    maven {
+        url 'https://packages.confluent.io/maven/'
+        name = 'confluent'
+    }
+}
+
+dependencies {
+
+    runtimeOnly  project(":springwolf-core")
+    runtimeOnly  project(":springwolf-plugins:springwolf-kafka")
+
+    runtimeOnly project(":springwolf-add-ons:springwolf-common-model-converters")
+    runtimeOnly project(":springwolf-add-ons:springwolf-json-schema")
+    runtimeOnly project(":springwolf-ui")
+
+    annotationProcessor project(":springwolf-plugins:springwolf-kafka")
+
+    runtimeOnly "org.springframework.boot:spring-boot-starter-web"
+
+    implementation "org.springframework:spring-beans"
+    implementation "org.springframework:spring-context"
+
+    implementation "org.springframework.boot:spring-boot"
+    implementation "org.springframework.boot:spring-boot-autoconfigure"
+
+    implementation "org.springframework.kafka:spring-kafka"
+
+    implementation "org.springframework.security:spring-security-config"
+    implementation "org.springframework.security:spring-security-web"
+
+    implementation  'org.apache.kafka:kafka-clients:3.6.1'
+    runtimeOnly 'io.confluent:kafka-protobuf-serializer:7.4.0'
+
+    runtimeOnly  "io.swagger.core.v3:swagger-annotations:${swaggerVersion}"
+    implementation  "io.swagger.core.v3:swagger-core-jakarta:${swaggerVersion}"
+    implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
+
+//    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
+
+//    testImplementation "org.apache.kafka:kafka-clients:${kafkaClientsVersion}@jar"
+//    testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
+//    testImplementation "org.awaitility:awaitility:${awaitilityVersion}"
+//    testImplementation "org.mockito:mockito-core:${mockitoCoreVersion}"
+//
+//    testImplementation "org.springframework.boot:spring-boot-test"
+//    testImplementation "org.springframework.kafka:spring-kafka-test"
+//    testImplementation "org.springframework:spring-test"
+//
+//    testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"
+//    testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
+
+//    testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
+
+//    permitTestUnusedDeclared "org.apache.kafka:kafka-clients:${kafkaClientsVersion}:test@jar"
+
+//    testImplementation("org.springframework.boot:spring-boot-starter-actuator")
+//    permitTestUnusedDeclared("org.springframework.boot:spring-boot-starter-actuator")
+
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+
+    implementation 'com.google.protobuf:protobuf-java:3.23.1'
+
+    implementation 'com.hubspot.jackson:jackson-datatype-protobuf:0.9.14'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
+    implementation 'com.hubspot.jackson:jackson-datatype-protobuf:0.9.14'
+}
+
+protobuf {
+    protoc {
+        artifact = 'com.google.protobuf:protoc:3.21.1'
+    }
+    generateProtoTasks {
+        all().each { task ->
+            task.builtins {
+                java { }
+            }
+        }
+    }
+}
+
+docker {
+    springBootApplication {
+        maintainer = 'shamir.stav@gmail.com'
+        baseImage = 'eclipse-temurin:17-jre-focal'
+        ports = [8080]
+        images = ["stavshamir/springwolf-kafka-protobuf-example:${project.version}"]
+    }
+
+    registryCredentials {
+        username = project.findProperty('DOCKERHUB_USERNAME') ?: ''
+        password = project.findProperty('DOCKERHUB_TOKEN') ?: ''
+    }
+}
+
+test {
+    dependsOn dockerBuildImage
+    // generate the open api docs before tests are executed so that if it works, the json is already there
+    dependsOn generateOpenApiDocs
+}
+
+openApi {
+    apiDocsUrl = "http://localhost:8080/springwolf/docs"
+    // For testing purposes we put the generated json into the test resources, but it could be any other directory
+    outputDir = file("$buildDir/resources/test")
+    outputFileName = "openapi-generated.json"
+}
+
+afterEvaluate {
+    tasks {
+        forkedSpringBootRun {
+            dependsOn bootJar
+            dependsOn compileTestJava
+            dependsOn dockerCreateDockerfile
+            dependsOn dockerBuildImage
+            dependsOn dockerSyncBuildContext
+            dependsOn jar
+            dependsOn processTestResources
+            dependsOn spotlessJava
+            doNotTrackState("See https://github.com/springdoc/springdoc-openapi-gradle-plugin/issues/102")
+        }
+    }
+}

--- a/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/KafkaProtobufStarterApplication.java
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/KafkaProtobufStarterApplication.java
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.example.kafka.protobuf;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class KafkaProtobufStarterApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(KafkaProtobufStarterApplication.class, args);
+    }
+}

--- a/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/configuration/CustomWebSecurityConfigurerAdapter.java
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/configuration/CustomWebSecurityConfigurerAdapter.java
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.example.kafka.protobuf.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Demonstrate how to use spring-security with springwolf.
+ */
+@Configuration
+@EnableWebSecurity
+public class CustomWebSecurityConfigurerAdapter {
+    private static final String DOCS_ENDPOINT = "/springwolf/docs";
+    private static final String KAFKA_PUBLISH_ENDPOINT = "/springwolf/kafka/publish";
+    private static final String UI_RESOURCES = "/springwolf/**";
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http.authorizeHttpRequests(it -> it
+                        // allow anonymous access to all actuator endpoint
+                        .requestMatchers("/actuator/**")
+                        .anonymous()
+                        // anyone can read the springwolf docs + ui
+                        // also, anyone can publish messages (as enabled in application.properties)
+                        .requestMatchers(DOCS_ENDPOINT, UI_RESOURCES, KAFKA_PUBLISH_ENDPOINT)
+                        .permitAll()
+                        .anyRequest()
+                        .denyAll())
+                // Please review the following lines before copying them to your application
+                .cors(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .build();
+    }
+}

--- a/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/configuration/ObjectMapperConfiguration.java
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/configuration/ObjectMapperConfiguration.java
@@ -1,0 +1,33 @@
+package io.github.stavshamir.springwolf.example.kafka.protobuf.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
+import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
+import io.swagger.v3.core.jackson.ModelResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Configuration
+public class ObjectMapperConfiguration {
+    @Autowired
+    private Jackson2ObjectMapperBuilder builder;
+
+    /**
+     * Creates and returns an ObjectMapper instance with the necessary modules registered.
+     * @return ObjectMapper instance.
+     */
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = builder.build();
+        objectMapper.registerModules(new ProtobufModule(ProtobufJacksonConfig.builder().acceptLiteralFieldnames(true).build()), new ProtobufPropertiesModule());
+        return objectMapper;
+    }
+
+    @Bean
+    public ModelResolver modelResolver(ObjectMapper objectMapper) {
+        return new ModelResolver(objectMapper);
+    }
+}

--- a/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/configuration/ObjectMapperConfiguration.java
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/configuration/ObjectMapperConfiguration.java
@@ -1,7 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
 package io.github.stavshamir.springwolf.example.kafka.protobuf.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
 import io.swagger.v3.core.jackson.ModelResolver;
@@ -22,7 +22,11 @@ public class ObjectMapperConfiguration {
     @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = builder.build();
-        objectMapper.registerModules(new ProtobufModule(ProtobufJacksonConfig.builder().acceptLiteralFieldnames(true).build()), new ProtobufPropertiesModule());
+        objectMapper.registerModules(
+                new ProtobufModule(ProtobufJacksonConfig.builder()
+                        .acceptLiteralFieldnames(true)
+                        .build()),
+                new ProtobufPropertiesModule());
         return objectMapper;
     }
 

--- a/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/configuration/ProtobufPropertiesModule.java
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/configuration/ProtobufPropertiesModule.java
@@ -1,0 +1,180 @@
+package io.github.stavshamir.springwolf.example.kafka.protobuf.configuration;
+
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.util.VersionUtil;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.PropertyNamingStrategyBase;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.introspect.*;
+import com.fasterxml.jackson.databind.type.SimpleType;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Message;
+import com.google.protobuf.Timestamp;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * We use this class because there is no build version at maven central
+ *
+ * Jackson module that works together with com.hubspot.jackson.datatype.protobuf.ProtobufModule.
+ * When added to the springdoc/springfox ObjectMapper, it allows protobuf messages to show up in swagger ui.
+ * <p>
+ * Copyright (c) 2018 InnoGames GmbH  MIT license
+ */
+public class ProtobufPropertiesModule extends Module {
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ProtobufPropertiesModule.class);
+
+    private Map<Class<?>, Map<String, FieldDescriptor>> cache = new ConcurrentHashMap<>();
+
+    @Override
+    public String getModuleName() {
+        return "ProtobufPropertyModule";
+    }
+
+    @Override
+    public Version version() {
+        return VersionUtil.packageVersionFor(getClass());
+    }
+
+
+    @Override
+    public void setupModule(SetupContext context) {
+
+        context.setClassIntrospector(new ProtobufClassIntrospector());
+
+        context.insertAnnotationIntrospector(annotationIntrospector);
+
+    }
+
+    NopAnnotationIntrospector annotationIntrospector = new NopAnnotationIntrospector() {
+
+        @Override
+        public VisibilityChecker<?> findAutoDetectVisibility(AnnotatedClass ac, VisibilityChecker<?> checker) {
+            if (Message.class.isAssignableFrom(ac.getRawType())) {
+                return checker.withGetterVisibility(Visibility.PUBLIC_ONLY)
+                        .withFieldVisibility(Visibility.ANY);
+            }
+            return super.findAutoDetectVisibility(ac, checker);
+        }
+
+
+        @Override
+        public Object findNamingStrategy(AnnotatedClass ac) {
+            if (!Message.class.isAssignableFrom(ac.getRawType())) {
+                return super.findNamingStrategy(ac);
+            }
+
+            return new PropertyNamingStrategyBase() {
+                @Override
+                public String translate(String propertyName) {
+                    if (propertyName.endsWith("_")) {
+                        return propertyName.substring(0, propertyName.length() - 1);
+                    }
+                    return propertyName;
+                }
+            };
+        }
+
+    };
+
+
+    class ProtobufClassIntrospector extends BasicClassIntrospector {
+
+        @Override
+        public BasicBeanDescription forDeserialization(DeserializationConfig cfg, JavaType type, MixInResolver r) {
+            BasicBeanDescription desc = super.forDeserialization(cfg, type, r);
+
+            if (Message.class.isAssignableFrom(type.getRawClass())) {
+                return protobufBeanDescription(cfg, type, r, desc);
+            }
+
+            return desc;
+        }
+
+
+        @Override
+        public BasicBeanDescription forSerialization(SerializationConfig cfg, JavaType type, MixInResolver r) {
+            BasicBeanDescription desc = super.forSerialization(cfg, type, r);
+
+            if (Timestamp.class == type.getRawClass()) {
+                return STRING_DESC;
+            }
+            if (Message.class.isAssignableFrom(type.getRawClass())) {
+                return protobufBeanDescription(cfg, type, r, desc);
+            }
+
+            return desc;
+        }
+
+        private BasicBeanDescription protobufBeanDescription(MapperConfig<?> cfg, JavaType type, MixInResolver r, BasicBeanDescription baseDesc) {
+            Map<String, FieldDescriptor> types = cache.computeIfAbsent(type.getRawClass(), this::getDescriptorForType);
+
+            AnnotatedClass ac = AnnotatedClassResolver.resolve(cfg, type, r);
+
+            List<BeanPropertyDefinition> props = new ArrayList<>();
+
+
+            for (BeanPropertyDefinition p : baseDesc.findProperties()) {
+                String name = p.getName();
+                if (!types.containsKey(name)) {
+                    continue;
+                }
+
+                if (p.hasField() && p.getField().getType().isJavaLangObject()
+                        && types.get(name).getType().equals(FieldDescriptor.Type.STRING)) {
+                    addStringFormatAnnotation(p);
+                }
+
+                props.add(p.withSimpleName(name));
+            }
+
+
+            return new BasicBeanDescription(cfg, type, ac, new ArrayList<>(props)) {
+            };
+        }
+
+        @JsonFormat(shape = Shape.STRING)
+        class AnnotationHelper {
+
+        }
+
+        private void addStringFormatAnnotation(BeanPropertyDefinition p) {
+            JsonFormat annotation = AnnotationHelper.class.getAnnotation(JsonFormat.class);
+            p.getField().getAllAnnotations()
+                    .addIfNotPresent(annotation);
+        }
+
+
+        private Map<String, FieldDescriptor> getDescriptorForType(Class<?> type) {
+            try {
+                Descriptor invoke = (Descriptor) type.getMethod("getDescriptor").invoke(null);
+                Map<String, FieldDescriptor> descriptorsForType = new HashMap<>();
+                invoke
+                        .getFields()
+                        .stream()
+                        .forEach(
+                                fieldDescriptor -> {
+                                    descriptorsForType.put(fieldDescriptor.getName(), fieldDescriptor);
+                                    descriptorsForType.put(fieldDescriptor.getJsonName(), fieldDescriptor);
+                                });
+                return descriptorsForType;
+            } catch (Exception e) {
+                log.error("Error getting protobuf descriptor for swagger.", e);
+                return new HashMap<>();
+            }
+        }
+
+    }
+}

--- a/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/consumer/ProtobufSpringConsumer.java
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/consumer/ProtobufSpringConsumer.java
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.example.kafka.protobuf.consumer;
+
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.confluent.protobuf.entity.CustomerMessagePayload;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProtobufSpringConsumer {
+
+    private final Logger logger = LoggerFactory.getLogger(ProtobufSpringConsumer.class);
+    private static final String TOPIC = "protobuf-topic";
+
+    @KafkaListener(topics = TOPIC, groupId = "group_id_v1")
+    public void processEvent(CustomerMessagePayload.CustomerMessage message) {
+        logger.info(String.format("#### -> Consuming message -> %s", message.toString()));
+    }
+}

--- a/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/consumer/ProtobufSpringConsumer.java
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/consumer/ProtobufSpringConsumer.java
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.stavshamir.springwolf.example.kafka.protobuf.consumer;
 
-import com.google.protobuf.DynamicMessage;
-import com.google.protobuf.InvalidProtocolBufferException;
 import io.confluent.protobuf.entity.CustomerMessagePayload;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;

--- a/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/model/MessageRequest.java
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/model/MessageRequest.java
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.example.kafka.protobuf.model;
+
+import lombok.Data;
+
+/* This class is a Command object and could be used to transform incoming request body into a Java object
+ */
+@Data
+public class MessageRequest {
+
+    private String firstName;
+    private String lastName;
+}

--- a/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/producer/ProtobufSpringProducer.java
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/src/main/java/io/github/stavshamir/springwolf/example/kafka/protobuf/producer/ProtobufSpringProducer.java
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.example.kafka.protobuf.producer;
+
+import io.confluent.protobuf.entity.CustomerMessagePayload;
+import io.github.stavshamir.springwolf.example.kafka.protobuf.model.MessageRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class ProtobufSpringProducer {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProtobufSpringProducer.class);
+    private static final String TOPIC = "protobuf-topic";
+
+    @Autowired
+    private KafkaTemplate<String, CustomerMessagePayload.CustomerMessage> kafkaTemplate;
+
+    public void sendMessage(MessageRequest message) {
+        logger.info(String.format("#### -> Producing message -> %s", message));
+
+        CustomerMessagePayload.CustomerMessage messageCustomer = CustomerMessagePayload.CustomerMessage.newBuilder()
+                .setFirstName(message.getFirstName())
+                .setLastName(message.getLastName())
+                .setId(UUID.randomUUID().toString())
+                .build();
+
+        this.kafkaTemplate.send(TOPIC, messageCustomer.getId(), messageCustomer);
+    }
+}

--- a/springwolf-examples/springwolf-kafka-protobuf-example/src/main/proto/CustomerMessage.proto
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/src/main/proto/CustomerMessage.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "io.confluent.protobuf.entity";
+option java_outer_classname = "CustomerMessagePayload";
+
+message CustomerMessage {
+  string id = 1;
+  string first_name = 2;
+  string last_name = 3;
+}

--- a/springwolf-examples/springwolf-kafka-protobuf-example/src/main/resources/application.properties
+++ b/springwolf-examples/springwolf-kafka-protobuf-example/src/main/resources/application.properties
@@ -1,0 +1,59 @@
+#########
+# Spring configuration
+spring.application.name=Springwolf example project - Kafka Protobuf
+
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1} - %m%n
+
+
+spring.kafka.consumer.group-id=test
+spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.enable-auto-commit=false
+spring.kafka.consumer.bootstrap-servers=${BOOTSTRAP_SERVER:192.168.2.107:63373}
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer
+spring.kafka.consumer.properties.schema.registry.url=${SCHEMA_SERVER:http://192.168.2.107:63375}
+spring.kafka.consumer.properties.derive.type=true
+
+spring.kafka.producer.retries=1
+spring.kafka.producer.bootstrap-servers=${BOOTSTRAP_SERVER:192.168.2.107:63373}
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer
+spring.kafka.producer.properties.schema.registry.url=${SCHEMA_SERVER:http://192.168.2.107:63375}
+spring.kafka.producer.client-id=producer1
+
+
+#########
+# Springwolf configuration
+springwolf.enabled=true
+springwolf.init-mode=background
+springwolf.docket.base-package=io.github.stavshamir.springwolf.example.kafka
+springwolf.docket.info.title=${spring.application.name}
+springwolf.docket.info.version=1.0.0
+springwolf.docket.info.description=Springwolf example project to demonstrate springwolfs abilities
+springwolf.docket.info.terms-of-service=http://asyncapi.org/terms
+springwolf.docket.info.contact.name=springwolf
+springwolf.docket.info.contact.email=example@example.com
+springwolf.docket.info.contact.url=https://github.com/springwolf/springwolf-core
+springwolf.docket.info.license.name=Apache License 2.0
+springwolf.payload.extractable-classes.java.util.List=0
+springwolf.payload.extractable-classes.java.util.Optional=0
+springwolf.use-fqn=true
+springwolf.example-generator=false
+
+# Springwolf kafka configuration
+springwolf.docket.servers.kafka.protocol=kafka
+springwolf.docket.servers.kafka.url=${spring.kafka.producer.bootstrap-servers}
+springwolf.plugin.kafka.scanner.kafka-listener.enabled=true
+springwolf.plugin.kafka.publishing.enabled=true
+springwolf.plugin.kafka.publishing.producer.bootstrap-servers=${BOOTSTRAP_SERVER:192.168.2.107:63373}
+springwolf.plugin.kafka.publishing.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+springwolf.plugin.kafka.publishing.producer.value-serializer=io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer
+springwolf.plugin.kafka.publishing.producer.properties.schema.registry.url=${SCHEMA_SERVER:http://192.168.2.107:63375}
+# springwolf publisher has its own kafka configuration.


### PR DESCRIPTION
I added kafka probuf example for springwolf. You can try it by reading README.md

Important bits:

- ObjectMapperConfiguration adds ProtobufModule so Jackson can create correct shemas for protobuf objects also convert them correctly.
- ProtobufPropertiesModule class is copy paste from internet they do not have maven artifact so this is best I can do
