### PR TITLE
AsyncAPI v3 Migration Fixes

### DIFF
--- a/springwolf-asyncapi/src/main/java/io/github/stavshamir/springwolf/asyncapi/v3/model/channel/message/MessageObject.java
+++ b/springwolf-asyncapi/src/main/java/io/github/stavshamir/springwolf/asyncapi/v3/model/channel/message/MessageObject.java
@@ -118,4 +118,14 @@ public class MessageObject extends ExtendableObject implements Message {
      */
     @JsonProperty(value = "traits")
     private List<MessageTrait> traits;
+
+    /*
+     * Override the getMessageId to guarantee that there's always a value. Defaults to 'name'
+     */
+    public String getMessageId() {
+        if (messageId == null) {
+            return this.name;
+        }
+        return messageId;
+    }
 }

--- a/springwolf-asyncapi/src/main/java/io/github/stavshamir/springwolf/asyncapi/v3/model/channel/message/MessageReference.java
+++ b/springwolf-asyncapi/src/main/java/io/github/stavshamir/springwolf/asyncapi/v3/model/channel/message/MessageReference.java
@@ -26,14 +26,10 @@ public class MessageReference implements Message, Reference {
     /**
      * Convenient Builder to create a Message reference to an existing Message
      * @param message Message to create the reference to. This Message MUST have a 'messageId' field
-     * @return a Message with the 'ref' field pointing to "#/components/messages/{messageId"
+     * @return a Message with the 'ref' field pointing to "#/components/messages/{messageName}"
      */
     public static MessageReference fromMessage(MessageObject message) {
-        var messageId = message.getMessageId();
-        if (messageId == null) {
-            throw new IllegalArgumentException("The message must have a 'messageId' defined");
-        }
-        return new MessageReference("#/components/messages/" + messageId);
+        return fromMessage(message.getName());
     }
 
     public static MessageReference fromMessage(String messageName) {

--- a/springwolf-asyncapi/src/test/java/io/github/stavshamir/springwolf/asyncapi/v3/model/AsyncAPITest.java
+++ b/springwolf-asyncapi/src/test/java/io/github/stavshamir/springwolf/asyncapi/v3/model/AsyncAPITest.java
@@ -59,7 +59,7 @@ class AsyncAPITest {
         var channelUserSignedup = ChannelObject.builder()
                 .channelId("userSignedup")
                 .address("user/signedup")
-                .messages(Map.of(userSignUpMessage.getMessageId(), MessageReference.fromMessage(userSignUpMessage)))
+                .messages(Map.of(userSignUpMessage.getMessageId(), MessageReference.fromMessage("UserSignedUp")))
                 .build();
 
         AsyncAPI asyncAPI = AsyncAPI.builder()

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/ChannelsService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/ChannelsService.java
@@ -2,6 +2,7 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 
 import java.util.Map;
 
@@ -11,9 +12,16 @@ import java.util.Map;
 public interface ChannelsService {
 
     /**
-     * Detects all available AsyncAPI ChannelItem in the spring context.
+     * Detects all available AsyncAPI ChannelObject in the spring context.
      *
      * @return Map of channel names mapping to detected ChannelItems
      */
     Map<String, ChannelObject> findChannels();
+
+    /**
+     * Detects all available AsyncAPI Operation in the spring context.
+     *
+     * @return Map of operation names mapping to detected Operations
+     */
+    Map<String, Operation> findOperations();
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.java
@@ -4,6 +4,7 @@ package io.github.stavshamir.springwolf.asyncapi;
 import io.github.stavshamir.springwolf.asyncapi.types.AsyncAPI;
 import io.github.stavshamir.springwolf.asyncapi.types.Components;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
@@ -64,6 +65,8 @@ public class DefaultAsyncApiService implements AsyncApiService {
             // SchemasService.
             Map<String, ChannelObject> channels = channelsService.findChannels();
 
+            Map<String, Operation> operations = channelsService.findOperations();
+
             Components components = Components.builder()
                     .schemas(schemasService.getDefinitions())
                     .build();
@@ -74,6 +77,7 @@ public class DefaultAsyncApiService implements AsyncApiService {
                     .defaultContentType(docket.getDefaultContentType())
                     .servers(docket.getServers())
                     .channels(channels)
+                    .operations(operations)
                     .components(components)
                     .build();
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsService.java
@@ -4,6 +4,7 @@ package io.github.stavshamir.springwolf.asyncapi;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelMerger;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,12 +32,28 @@ public class DefaultChannelsService implements ChannelsService {
 
         for (ChannelsScanner scanner : channelsScanners) {
             try {
-                Map<String, ChannelObject> channels = scanner.scan();
+                Map<String, ChannelObject> channels = scanner.scanChannels();
                 foundChannelItems.addAll(channels.entrySet());
             } catch (Exception e) {
                 log.error("An error was encountered during channel scanning with {}: {}", scanner, e.getMessage(), e);
             }
         }
-        return ChannelMerger.merge(foundChannelItems);
+        return ChannelMerger.mergeChannels(foundChannelItems);
+    }
+
+    // FIXME
+    @Override
+    public Map<String, Operation> findOperations() {
+        List<Map.Entry<String, Operation>> foundOperations = new ArrayList<>();
+        for (ChannelsScanner scanner : channelsScanners) {
+            try {
+                Map<String, Operation> channels = scanner.scanOperations();
+                foundOperations.addAll(channels.entrySet());
+            } catch (Exception e) {
+                log.error("An error was encountered during operation scanning with {}: {}", scanner, e.getMessage(), e);
+            }
+        }
+
+        return ChannelMerger.mergeOperations(foundOperations);
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.stavshamir.springwolf.asyncapi;
 
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
 import lombok.extern.slf4j.Slf4j;
 
@@ -8,28 +9,28 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 @Slf4j
 public class MessageHelper {
-    private static final String ONE_OF = "oneOf";
-
     private static final Comparator<MessageObject> byMessageName = Comparator.comparing(MessageObject::getName);
 
     private static final Supplier<Set<MessageObject>> messageSupplier = () -> new TreeSet<>(byMessageName);
 
-    public static Object toMessageObjectOrComposition(Set<MessageObject> messages) {
-        return switch (messages.size()) {
-            case 0 -> throw new IllegalArgumentException("messages must not be empty");
-            case 1 -> messages.toArray()[0];
-            default -> Map.of(
-                    ONE_OF, new ArrayList<>(messages.stream().collect(Collectors.toCollection(messageSupplier))));
-        };
+    private MessageHelper() {}
+
+    public static Map<String, Message> toMessagesMap(Set<MessageObject> messages) {
+        if (messages.isEmpty()) {
+            throw new IllegalArgumentException("messages must not be empty");
+        }
+
+        return new ArrayList<>(messages.stream().collect(Collectors.toCollection(messageSupplier)))
+                .stream().collect(Collectors.toMap(MessageObject::getMessageId, Function.identity()));
     }
 
     @SuppressWarnings("unchecked")
@@ -38,10 +39,11 @@ public class MessageHelper {
             return new HashSet<>(Collections.singletonList(message));
         }
 
-        if (messageObject instanceof Map) {
-            List<MessageObject> messages = ((Map<String, List<MessageObject>>) messageObject).get(ONE_OF);
-            return new HashSet<>(messages);
-        }
+        // FIXME
+        // if (messageObject instanceof Map) {
+        //     List<MessageObject> messages = ((Map<String, List<MessageObject>>) messageObject).get(ONE_OF);
+        //     return new HashSet<>(messages);
+        // }
 
         log.warn(
                 "Message object must contain either a Message or a Map<String, Set<Message>, but contained: {}",

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/MessageHelper.java
@@ -6,7 +6,6 @@ import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.Message
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
@@ -33,21 +32,9 @@ public class MessageHelper {
                 .stream().collect(Collectors.toMap(MessageObject::getMessageId, Function.identity()));
     }
 
+    // FIXME: Do we need this method?
     @SuppressWarnings("unchecked")
-    public static Set<MessageObject> messageObjectToSet(Object messageObject) {
-        if (messageObject instanceof MessageObject message) {
-            return new HashSet<>(Collections.singletonList(message));
-        }
-
-        // FIXME
-        // if (messageObject instanceof Map) {
-        //     List<MessageObject> messages = ((Map<String, List<MessageObject>>) messageObject).get(ONE_OF);
-        //     return new HashSet<>(messages);
-        // }
-
-        log.warn(
-                "Message object must contain either a Message or a Map<String, Set<Message>, but contained: {}",
-                messageObject.getClass());
-        return new HashSet<>();
+    public static Set<Message> messageObjectToSet(Map<String, Message> messages) {
+        return new HashSet<>(messages.values());
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelsScanner.java
@@ -2,6 +2,7 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
 
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 
 import java.util.Map;
 
@@ -10,5 +11,10 @@ public interface ChannelsScanner {
     /**
      * @return A mapping of channel names to their respective channel object for a given protocol.
      */
-    Map<String, ChannelObject> scan();
+    Map<String, ChannelObject> scanChannels();
+
+    /**
+     * @return A mapping of operation names to their respective operation object for a given protocol.
+     */
+    Map<String, Operation> scanOperations();
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/SimpleChannelsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/SimpleChannelsScanner.java
@@ -3,6 +3,7 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
 
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -18,19 +19,34 @@ public class SimpleChannelsScanner implements ChannelsScanner {
     private final ClassProcessor classProcessor;
 
     @Override
-    public Map<String, ChannelObject> scan() {
+    public Map<String, ChannelObject> scanChannels() {
         Set<Class<?>> components = classScanner.scan();
 
         List<Map.Entry<String, ChannelObject>> channels = mapToChannels(components);
 
-        return ChannelMerger.merge(channels);
+        return ChannelMerger.mergeChannels(channels);
+    }
+
+    @Override
+    public Map<String, Operation> scanOperations() {
+        Set<Class<?>> components = classScanner.scan();
+
+        List<Map.Entry<String, Operation>> operations = mapToOperations(components);
+
+        return ChannelMerger.mergeOperations(operations);
     }
 
     private List<Map.Entry<String, ChannelObject>> mapToChannels(Set<Class<?>> components) {
-        return components.stream().flatMap(classProcessor::process).toList();
+        return components.stream().flatMap(classProcessor::processChannels).toList();
+    }
+
+    private List<Map.Entry<String, Operation>> mapToOperations(Set<Class<?>> components) {
+        return components.stream().flatMap(classProcessor::processOperations).toList();
     }
 
     public interface ClassProcessor {
-        Stream<Map.Entry<String, ChannelObject>> process(Class<?> clazz);
+        Stream<Map.Entry<String, ChannelObject>> processChannels(Class<?> clazz);
+
+        Stream<Map.Entry<String, Operation>> processOperations(Class<?> clazz);
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationChannelsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationChannelsScanner.java
@@ -14,8 +14,13 @@ import io.github.stavshamir.springwolf.asyncapi.v3.bindings.MessageBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ServerReference;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.server.Server;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
@@ -117,8 +122,10 @@ public class AsyncAnnotationChannelsScanner<A extends Annotation>
                     .map(it -> ServerReference.builder().ref(it).build())
                     .toList());
         }
+        MessageObject message = buildMessage(operationAnnotation, methodAndAnnotation.method());
 
-        ChannelObject channelItem = channelBuilder.build();
+        ChannelObject channelItem =
+                channelBuilder.messages(Map.of(message.getMessageId(), message)).build();
         return Map.entry(channelName, channelItem);
     }
 
@@ -133,12 +140,13 @@ public class AsyncAnnotationChannelsScanner<A extends Annotation>
         Map<String, OperationBinding> operationBinding =
                 AsyncAnnotationScannerUtil.processOperationBindingFromAnnotation(method, operationBindingProcessors);
         Map<String, OperationBinding> opBinding = operationBinding != null ? new HashMap<>(operationBinding) : null;
+        MessageObject message = buildMessage(asyncOperation, method);
 
         return Operation.builder()
                 .description(description)
                 .title(operationTitle)
-                // FIXME: Message should be the reference
-                //                .message(buildMessage(asyncOperation, method))
+                // FIXME: We can use the message reference once everything else works
+                .messages(List.of(MessageReference.fromMessage(message)))
                 .bindings(opBinding)
                 .build();
     }
@@ -151,6 +159,7 @@ public class AsyncAnnotationChannelsScanner<A extends Annotation>
         String modelName = this.schemasService.register(payloadType);
         AsyncHeaders asyncHeaders = AsyncAnnotationScannerUtil.getAsyncHeaders(operationData, resolver);
         String headerModelName = this.schemasService.register(asyncHeaders);
+        var headers = MessageHeaders.of(MessageReference.fromSchema(headerModelName));
 
         var schema = payloadType.getAnnotation(Schema.class);
         String description = schema != null ? schema.description() : null;
@@ -158,12 +167,17 @@ public class AsyncAnnotationChannelsScanner<A extends Annotation>
         Map<String, MessageBinding> messageBinding =
                 AsyncAnnotationScannerUtil.processMessageBindingFromAnnotation(method, messageBindingProcessors);
 
+        var messagePayload = MessagePayload.of(MultiFormatSchema.builder()
+                .schema(SchemaReference.fromSchema(modelName))
+                .build());
+
         var builder = MessageObject.builder()
+                .messageId(payloadType.getName())
                 .name(payloadType.getName())
                 .title(payloadType.getSimpleName())
                 .description(description)
-                //                .payload(PayloadReference.fromModelName(modelName)) FIXME
-                //                .headers(HeaderReference.fromModelName(headerModelName)) FIXME
+                .payload(messagePayload)
+                .headers(headers)
                 .bindings(messageBinding);
 
         // Retrieve the Message information obtained from the @AsyncMessage annotation. These values have higher

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationScannerUtil.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationScannerUtil.java
@@ -25,6 +25,8 @@ import java.util.stream.Collectors;
 import static java.util.stream.Collectors.groupingBy;
 
 class AsyncAnnotationScannerUtil {
+    private AsyncAnnotationScannerUtil() {}
+
     public static AsyncHeaders getAsyncHeaders(AsyncOperation op, StringValueResolver resolver) {
         if (op.headers().values().length == 0) {
             return AsyncHeaders.NOT_DOCUMENTED;
@@ -61,7 +63,7 @@ class AsyncAnnotationScannerUtil {
                 .map(AsyncOperation.Headers.Header::value)
                 .map(resolver::resolveStringValue)
                 .sorted()
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static String getDescription(List<AsyncOperation.Headers.Header> value, StringValueResolver resolver) {
@@ -126,7 +128,7 @@ class AsyncAnnotationScannerUtil {
     }
 
     /**
-     * extracts servers array from the given AsyncOperation, resolves placeholdes with spring variables and
+     * extracts servers array from the given AsyncOperation, resolves placeholders with spring variables and
      * return a List of server names.
      *
      * @param op       the given AsyncOperation

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationScannerUtil.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationScannerUtil.java
@@ -42,6 +42,14 @@ class AsyncAnnotationScannerUtil {
                             .enumValue(values)
                             .example(exampleValue)
                             .build());
+
+                    // FIXME: Replace AsyncHeaders by proper AsyncAPI v3 Headers
+                    // MessageHeaders.of(
+                    //         SchemaObject.builder()
+                    //                 .description(getDescription(headers, resolver))
+                    //                 .enumValues(values)
+                    //                 .examples(exampleValue != null ? List.of(exampleValue) : null)
+                    //                 .build());
                 });
 
         return asyncHeaders;
@@ -106,8 +114,8 @@ class AsyncAnnotationScannerUtil {
         }
 
         // FIXME
-        //        String annotationSchemaFormat = asyncMessage.schemaFormat();
-        //        var schemaFormat = annotationSchemaFormat != null ? annotationSchemaFormat :
+        // String annotationSchemaFormat = asyncMessage.schemaFormat();
+        // var schemaFormat = annotationSchemaFormat != null ? annotationSchemaFormat :
         // Message.DEFAULT_SCHEMA_FORMAT;
         //        messageBuilder.schemaFormat(schemaFormat);
 

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScanner.java
@@ -7,10 +7,14 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.Payloa
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeadersBuilder;
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.ChannelBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.MessageBinding;
-import io.github.stavshamir.springwolf.asyncapi.v3.bindings.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.Message;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.toMessageObjectOrComposition;
+import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.toMessagesMap;
 import static java.util.stream.Collectors.toSet;
 
 @RequiredArgsConstructor
@@ -75,20 +79,18 @@ public class ClassLevelAnnotationChannelsScanner<
         }
 
         String channelName = bindingFactory.getChannelName(classAnnotation);
-        String operationId = channelName + "_publish_" + component.getSimpleName();
 
-        ChannelObject channelItem = buildChannelItem(classAnnotation, operationId, annotatedMethods);
+        ChannelObject channelItem = buildChannelItem(classAnnotation, annotatedMethods);
 
         return Stream.of(Map.entry(channelName, channelItem));
     }
 
-    private ChannelObject buildChannelItem(ClassAnnotation classAnnotation, String operationId, Set<Method> methods) {
-        Object message = buildMessageObject(classAnnotation, methods);
-        Operation operation = buildOperation(classAnnotation, operationId, message);
-        return buildChannelItem(classAnnotation, operation);
+    private ChannelObject buildChannelItem(ClassAnnotation classAnnotation, Set<Method> methods) {
+        var messages = buildMessages(classAnnotation, methods);
+        return buildChannelItem(classAnnotation, messages);
     }
 
-    private Object buildMessageObject(ClassAnnotation classAnnotation, Set<Method> methods) {
+    private Map<String, Message> buildMessages(ClassAnnotation classAnnotation, Set<Method> methods) {
         Set<MessageObject> messages = methods.stream()
                 .map((Method method) -> {
                     Class<?> payloadType = payloadClassExtractor.extractFrom(method);
@@ -96,7 +98,7 @@ public class ClassLevelAnnotationChannelsScanner<
                 })
                 .collect(toSet());
 
-        return toMessageObjectOrComposition(messages);
+        return toMessagesMap(messages);
     }
 
     private MessageObject buildMessage(ClassAnnotation classAnnotation, Class<?> payloadType) {
@@ -104,33 +106,24 @@ public class ClassLevelAnnotationChannelsScanner<
         String modelName = schemasService.register(payloadType);
         String headerModelName = schemasService.register(asyncHeadersBuilder.buildHeaders(payloadType));
 
+        MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
+                .schema(SchemaReference.fromSchema(modelName))
+                .build());
+
         return MessageObject.builder()
+                .messageId(payloadType.getName())
                 .name(payloadType.getName())
                 .title(payloadType.getSimpleName())
                 .description(null)
-                //                .payload(PayloadReference.fromModelName(modelName)) FIXME
-                //                .headers(HeaderReference.fromModelName(headerModelName)) FIXME
+                .payload(payload)
+                .headers(MessageHeaders.of(MessageReference.fromSchema(headerModelName)))
                 .bindings(messageBinding)
                 .build();
     }
 
-    private Operation buildOperation(ClassAnnotation classAnnotation, String operationTitle, Object message) {
-        Map<String, OperationBinding> operationBinding = bindingFactory.buildOperationBinding(classAnnotation);
-        Map<String, OperationBinding> opBinding = operationBinding != null ? new HashMap<>(operationBinding) : null;
-
-        return Operation.builder()
-                .description("Auto-generated description")
-                .title(operationTitle)
-                //                .message(message)
-                .bindings(opBinding)
-                .build();
-    }
-
-    private ChannelObject buildChannelItem(ClassAnnotation classAnnotation, Operation operation) {
+    private ChannelObject buildChannelItem(ClassAnnotation classAnnotation, Map<String, Message> messages) {
         Map<String, ChannelBinding> channelBinding = bindingFactory.buildChannelBinding(classAnnotation);
         Map<String, ChannelBinding> chBinding = channelBinding != null ? new HashMap<>(channelBinding) : null;
-        return ChannelObject.builder()
-                .bindings(chBinding) /*.publish(operation) FIXME*/
-                .build();
+        return ChannelObject.builder().bindings(chBinding).messages(messages).build();
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/OperationData.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/OperationData.java
@@ -60,6 +60,7 @@ public interface OperationData {
 
     MessageObject getMessage();
 
+    // FIXME: With AsyncAPI v3 this should be Action: SEND / RECEIVER
     enum OperationType {
         PUBLISH("publish"),
         SUBSCRIBE("subscribe");

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeadersNotDocumented.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/types/channel/operation/message/header/AsyncHeadersNotDocumented.java
@@ -10,6 +10,6 @@ public class AsyncHeadersNotDocumented implements AsyncHeadersBuilder {
 
     @Override
     public AsyncHeaders buildHeaders(Class<?> payloadType) {
-        return AsyncHeaders.NOT_DOCUMENTED;
+        return NOT_DOCUMENTED;
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsServiceIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsServiceIntegrationTest.java
@@ -40,24 +40,36 @@ class DefaultChannelsServiceIntegrationTest {
         Map<String, ChannelObject> actualChannels = defaultChannelsService.findChannels();
 
         assertThat(actualChannels)
-                .containsAllEntriesOf(fooChannelScanner.scan())
-                .containsAllEntriesOf(barChannelScanner.scan())
+                .containsAllEntriesOf(fooChannelScanner.scanChannels())
+                .containsAllEntriesOf(barChannelScanner.scanChannels())
                 .containsEntry(SameTopic.topicName, SameTopic.expectedMergedChannel);
     }
 
     @Component
     static class FooChannelScanner implements ChannelsScanner {
         @Override
-        public Map<String, ChannelObject> scan() {
+        public Map<String, ChannelObject> scanChannels() {
             return Map.of("foo", new ChannelObject());
+        }
+
+        @Override
+        public Map<String, Operation> scanOperations() {
+            // FIXME
+            return Map.of();
         }
     }
 
     @Component
     static class BarChannelScanner implements ChannelsScanner {
         @Override
-        public Map<String, ChannelObject> scan() {
+        public Map<String, ChannelObject> scanChannels() {
             return Map.of("bar", new ChannelObject());
+        }
+
+        @Override
+        public Map<String, Operation> scanOperations() {
+            // FIXME
+            return Map.of();
         }
     }
 
@@ -74,11 +86,17 @@ class DefaultChannelsServiceIntegrationTest {
                     Operation.builder() /*.message("publish")FIXME*/.build();
 
             @Override
-            public Map<String, ChannelObject> scan() {
+            public Map<String, ChannelObject> scanChannels() {
                 return Map.of(
                         topicName,
                         ChannelObject.builder() /*.publish(publishOperation) FIXME*/
                                 .build());
+            }
+
+            @Override
+            public Map<String, Operation> scanOperations() {
+                // FIXME
+                return Map.of();
             }
         }
 
@@ -88,11 +106,17 @@ class DefaultChannelsServiceIntegrationTest {
                     Operation.builder() /*.message("consumer")FIXME*/.build();
 
             @Override
-            public Map<String, ChannelObject> scan() {
+            public Map<String, ChannelObject> scanChannels() {
                 return Map.of(
                         topicName,
                         ChannelObject.builder() /*.subscribe(subscribeOperation)FIXME*/
                                 .build());
+            }
+
+            @Override
+            public Map<String, Operation> scanOperations() {
+                // FIXME
+                return Map.of();
             }
         }
     }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.stavshamir.springwolf.asyncapi;
 
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
 import org.junit.jupiter.api.Test;
 
@@ -97,20 +98,11 @@ class MessageHelperTest {
     }
 
     @Test
-    void messageObjectToSet_notAMessageOrAMap() {
-        Object string = "foo";
-
-        Set<MessageObject> messages = messageObjectToSet(string);
-
-        assertThat(messages).isEmpty();
-    }
-
-    @Test
     void messageObjectToSet_Message() {
         MessageObject message = MessageObject.builder().name("foo").build();
-        Object asObject = toMessagesMap(Set.of(message));
+        var asMap = toMessagesMap(Set.of(message));
 
-        Set<MessageObject> messages = messageObjectToSet(asObject);
+        Set<Message> messages = messageObjectToSet(asMap);
 
         assertThat(messages).containsExactly(message);
     }
@@ -121,9 +113,9 @@ class MessageHelperTest {
 
         MessageObject message2 = MessageObject.builder().name("bar").build();
 
-        Object asObject = toMessagesMap(Set.of(message1, message2));
+        var asMap = toMessagesMap(Set.of(message1, message2));
 
-        Set<MessageObject> messages = messageObjectToSet(asObject);
+        Set<Message> messages = messageObjectToSet(asMap);
 
         assertThat(messages).containsExactlyInAnyOrder(message1, message2);
     }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.stavshamir.springwolf.asyncapi;
 
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.Message;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.messageObjectToSet;
-import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.toMessageObjectOrComposition;
+import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.toMessagesMap;
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -19,32 +18,31 @@ class MessageHelperTest {
 
     @Test
     void toMessageObjectOrComposition_emptySet() {
-        assertThatThrownBy(() -> toMessageObjectOrComposition(Collections.emptySet()))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> toMessagesMap(Collections.emptySet())).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void toMessageObjectOrComposition_oneMessage() {
+    void toMessagesMap_oneMessage() {
         MessageObject message = MessageObject.builder().name("foo").build();
 
-        Object asObject = toMessageObjectOrComposition(Set.of(message));
+        var messagesMap = toMessagesMap(Set.of(message));
 
-        assertThat(asObject).isInstanceOf(Message.class).isEqualTo(message);
+        assertThat(messagesMap).containsExactlyInAnyOrderEntriesOf(Map.of("foo", message));
     }
 
     @Test
-    void toMessageObjectOrComposition_multipleMessages() {
+    void toMessagesMap_multipleMessages() {
         MessageObject message1 = MessageObject.builder().name("foo").build();
 
         MessageObject message2 = MessageObject.builder().name("bar").build();
 
-        Object asObject = toMessageObjectOrComposition(Set.of(message1, message2));
+        var messages = toMessagesMap(Set.of(message1, message2));
 
-        assertThat(asObject).isInstanceOf(Map.class).isEqualTo(Map.of("oneOf", List.of(message2, message1)));
+        assertThat(messages).containsExactlyEntriesOf(Map.of("bar", message2, "foo", message1));
     }
 
     @Test
-    void toMessageObjectOrComposition_multipleMessages_remove_duplicates() {
+    void toMessagesMap_multipleMessages_remove_duplicates() {
         MessageObject message1 = MessageObject.builder()
                 .name("foo")
                 .description("This is message 1")
@@ -60,17 +58,17 @@ class MessageHelperTest {
                 .description("This is message 3, but in essence the same payload type as message 2")
                 .build();
 
-        Object asObject = toMessageObjectOrComposition(Set.of(message1, message2, message3));
+        var messages = toMessagesMap(Set.of(message1, message2, message3));
 
-        Map<String, List<Message>> oneOfMap = (Map<String, List<Message>>) asObject;
-        assertThat(oneOfMap).hasSize(1);
-        List<Message> deduplicatedMessageList = oneOfMap.get("oneOf");
-        // we do not have any guarantee wether message2 or message3 won the deduplication.
-        assertThat(deduplicatedMessageList).hasSize(2).contains(message1).containsAnyOf(message2, message3);
+        // we do not have any guarantee whether message2 or message3 won the deduplication.
+        assertThat(messages)
+                .hasSize(2)
+                .containsValue(message1)
+                .containsAnyOf(entry("bar", message2), entry("bar", message3));
     }
 
     @Test
-    void toMessageObjectOrComposition_multipleMessages_should_not_break_deep_equals() {
+    void toMessagesMap_multipleMessages_should_not_break_deep_equals() {
         MessageObject actualMessage1 = MessageObject.builder()
                 .name("foo")
                 .description("This is actual message 1")
@@ -81,7 +79,7 @@ class MessageHelperTest {
                 .description("This is actual message 2")
                 .build();
 
-        Object actualObject = toMessageObjectOrComposition(Set.of(actualMessage1, actualMessage2));
+        Object actualObject = toMessagesMap(Set.of(actualMessage1, actualMessage2));
 
         MessageObject expectedMessage1 = MessageObject.builder()
                 .name("foo")
@@ -93,7 +91,7 @@ class MessageHelperTest {
                 .description("This is expected message 2")
                 .build();
 
-        Object expectedObject = toMessageObjectOrComposition(Set.of(expectedMessage1, expectedMessage2));
+        Object expectedObject = toMessagesMap(Set.of(expectedMessage1, expectedMessage2));
 
         assertThat(actualObject).isNotEqualTo(expectedObject);
     }
@@ -110,7 +108,7 @@ class MessageHelperTest {
     @Test
     void messageObjectToSet_Message() {
         MessageObject message = MessageObject.builder().name("foo").build();
-        Object asObject = toMessageObjectOrComposition(Set.of(message));
+        Object asObject = toMessagesMap(Set.of(message));
 
         Set<MessageObject> messages = messageObjectToSet(asObject);
 
@@ -123,7 +121,7 @@ class MessageHelperTest {
 
         MessageObject message2 = MessageObject.builder().name("bar").build();
 
-        Object asObject = toMessageObjectOrComposition(Set.of(message1, message2));
+        Object asObject = toMessagesMap(Set.of(message1, message2));
 
         Set<MessageObject> messages = messageObjectToSet(asObject);
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/MessageHelperTest.java
@@ -39,7 +39,7 @@ class MessageHelperTest {
 
         var messages = toMessagesMap(Set.of(message1, message2));
 
-        assertThat(messages).containsExactlyEntriesOf(Map.of("bar", message2, "foo", message1));
+        assertThat(messages).containsExactlyInAnyOrderEntriesOf(Map.of("bar", message2, "foo", message1));
     }
 
     @Test

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
@@ -4,11 +4,13 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
 import io.github.stavshamir.springwolf.asyncapi.MessageHelper;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.OperationAction;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -105,28 +107,34 @@ class ChannelMergerTest {
         // given
         String channelName = "channel";
         MessageObject message1 = MessageObject.builder()
+                .messageId("message1")
                 .name(String.class.getCanonicalName())
                 .description("This is a string")
                 .build();
         MessageObject message2 = MessageObject.builder()
+                .messageId("message2")
                 .name(Integer.class.getCanonicalName())
                 .description("This is an integer")
                 .build();
         MessageObject message3 = MessageObject.builder()
+                .messageId("message3")
                 .name(Integer.class.getCanonicalName())
                 .description("This is also an integer, but in essence the same payload type")
                 .build();
         Operation publishOperation1 = Operation.builder()
                 .action(OperationAction.SEND)
-                .title("publisher1") /*.message(message1)FIXME*/
+                .title("publisher1")
+                .messages(List.of(MessageReference.fromMessage(message1)))
                 .build();
         Operation publishOperation2 = Operation.builder()
                 .action(OperationAction.SEND)
-                .title("publisher2") /*.message(message2)FIXME*/
+                .title("publisher2")
+                .messages(List.of(MessageReference.fromMessage(message2)))
                 .build();
         Operation publishOperation3 = Operation.builder()
                 .action(OperationAction.SEND)
-                .title("publisher3") /*.message(message3)FIXME*/
+                .title("publisher3")
+                .messages(List.of(MessageReference.fromMessage(message3)))
                 .build();
         ChannelObject publisherChannel1 = ChannelObject.builder().build();
         ChannelObject publisherChannel2 = ChannelObject.builder().build();
@@ -157,6 +165,7 @@ class ChannelMergerTest {
         // given
         String channelName = "channel";
         MessageObject message2 = MessageObject.builder()
+                .messageId("message2")
                 .name(String.class.getCanonicalName())
                 .description("This is a string")
                 .build();
@@ -166,7 +175,8 @@ class ChannelMergerTest {
                 .build();
         Operation publishOperation2 = Operation.builder()
                 .action(OperationAction.SEND)
-                .title("publisher2") /*.message(message2)FIXME*/
+                .title("publisher2")
+                .messages(List.of(MessageReference.fromMessage(message2)))
                 .build();
         ChannelObject publisherChannel1 =
                 ChannelObject.builder() /*.publish(publishOperation1)FIXME*/.build();

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
@@ -148,7 +148,7 @@ class ChannelMergerTest {
 
         // then expectedMessage only includes message1 and message2.
         // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
-        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Set.of(message1, message2));
+        Object expectedMessages = MessageHelper.toMessagesMap(Set.of(message1, message2));
         assertThat(mergedChannels).hasSize(1);
         //                .hasEntrySatisfying(channelName, it -> {
         //            assertThat(it.getPublish())
@@ -188,7 +188,7 @@ class ChannelMergerTest {
                 Arrays.asList(Map.entry(channelName, publisherChannel1), Map.entry(channelName, publisherChannel2)));
 
         // then expectedMessage message2
-        Object expectedMessages = MessageHelper.toMessageObjectOrComposition(Set.of(message2));
+        Object expectedMessages = MessageHelper.toMessagesMap(Set.of(message2));
         assertThat(mergedChannels).hasSize(1).hasEntrySatisfying(channelName, it -> {
             //            assertThat(it.getPublish()) FIXME
             //                    .isEqualTo(Operation.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/SimpleChannelsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/SimpleChannelsScannerTest.java
@@ -3,6 +3,7 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
 
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -25,28 +26,26 @@ class SimpleChannelsScannerTest {
     @Test
     void noClassFoundTest() {
         // when
-        Map<String, ChannelObject> channels = simpleChannelsScanner.scan();
+        Map<String, ChannelObject> channels = simpleChannelsScanner.scanChannels();
+        Map<String, Operation> operations = simpleChannelsScanner.scanOperations();
 
         // then
         assertThat(channels).isEmpty();
+        assertThat(operations).isEmpty();
     }
 
     @Test
     void processClassTest() {
         // given
         when(classScanner.scan()).thenReturn(Set.of(String.class));
-        Map.Entry<String, ChannelObject> channel1 = Map.entry(
-                "channel1",
-                ChannelObject.builder() /*.publish(Operation.builder().build())FIXME*/
-                        .build());
-        Map.Entry<String, ChannelObject> channel2 = Map.entry(
-                "channel2",
-                ChannelObject.builder() /*.subscribe(Operation.builder().build())FIXME*/
-                        .build());
-        when(classProcessor.process(any())).thenReturn(Stream.of(channel1, channel2));
+        Map.Entry<String, ChannelObject> channel1 =
+                Map.entry("channel1", ChannelObject.builder().build());
+        Map.Entry<String, ChannelObject> channel2 =
+                Map.entry("channel2", ChannelObject.builder().build());
+        when(classProcessor.processChannels(any())).thenReturn(Stream.of(channel1, channel2));
 
         // when
-        Map<String, ChannelObject> channels = simpleChannelsScanner.scan();
+        Map<String, ChannelObject> channels = simpleChannelsScanner.scanChannels();
 
         // then
         assertThat(channels).containsExactly(channel1, channel2);
@@ -56,41 +55,28 @@ class SimpleChannelsScannerTest {
     void sameChannelsAreMergedTest() {
         // given
         when(classScanner.scan()).thenReturn(Set.of(String.class));
-        Map.Entry<String, ChannelObject> channel1 = Map.entry(
-                "channel1",
-                ChannelObject.builder()
-                        //                        .publish(Operation.builder().operationId("pub").build()) FIXME
-                        .build());
-        Map.Entry<String, ChannelObject> channel2 = Map.entry(
-                "channel1",
-                ChannelObject.builder()
-                        //                        .subscribe(Operation.builder().operationId("sub").build()) FIXME
-                        .build());
-        when(classProcessor.process(any())).thenReturn(Stream.of(channel1, channel2));
+        Map.Entry<String, ChannelObject> channel1 =
+                Map.entry("channel1", ChannelObject.builder().build());
+        Map.Entry<String, ChannelObject> channel2 =
+                Map.entry("channel1", ChannelObject.builder().build());
+        when(classProcessor.processChannels(any())).thenReturn(Stream.of(channel1, channel2));
 
         // when
-        Map<String, ChannelObject> channels = simpleChannelsScanner.scan();
+        Map<String, ChannelObject> channels = simpleChannelsScanner.scanChannels();
 
         // then
         assertThat(channels)
-                .containsExactly(Map.entry(
-                        "channel1",
-                        ChannelObject.builder()
-                                //
-                                // .publish(Operation.builder().operationId("pub").build())  FIXME
-                                //
-                                // .subscribe(Operation.builder().operationId("sub").build()) FIXME
-                                .build()));
+                .containsExactly(Map.entry("channel1", ChannelObject.builder().build()));
     }
 
     @Test
     void processEmptyClassTest() {
         // given
         when(classScanner.scan()).thenReturn(Set.of(String.class));
-        when(classProcessor.process(any())).thenReturn(Stream.of());
+        when(classProcessor.processChannels(any())).thenReturn(Stream.of());
 
         // when
-        Map<String, ChannelObject> channels = simpleChannelsScanner.scan();
+        Map<String, ChannelObject> channels = simpleChannelsScanner.scanChannels();
 
         // then
         assertThat(channels).isEmpty();

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationChannelsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationChannelsScannerTest.java
@@ -15,9 +15,12 @@ import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ServerReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.info.Info;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.server.Server;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
@@ -137,12 +140,17 @@ class AsyncAnnotationChannelsScannerTest {
         Map<String, ChannelObject> actualChannels = channelScanner.scan();
 
         // Then the returned collection contains the channel
+        MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
+                .schema(SchemaReference.fromSchema(SimpleFoo.class.getSimpleName()))
+                .build());
+
         MessageObject message = MessageObject.builder()
+                .messageId(SimpleFoo.class.getName())
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
                 .description("SimpleFoo Message Description")
-                //                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName())) FIXME
-                //                .schemaFormat(Message.DEFAULT_SCHEMA_FORMAT)
+                .payload(payload)
+                // .schemaFormat(Message.DEFAULT_SCHEMA_FORMAT)
                 .headers(MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
                 // FIXME
                 .bindings(EMPTY_MAP)
@@ -157,6 +165,7 @@ class AsyncAnnotationChannelsScannerTest {
 
         ChannelObject expectedChannel = ChannelObject.builder()
                 .bindings(null) /*.publish(operation) FIXME*/
+                .messages(Map.of(message.getMessageId(), message))
                 .build();
 
         assertThat(actualChannels).containsExactly(Map.entry("test-channel", expectedChannel));
@@ -182,12 +191,17 @@ class AsyncAnnotationChannelsScannerTest {
         Map<String, ChannelObject> actualChannels = channelScanner.scan();
 
         // Then the returned collection contains the channel
+        MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
+                .schema(SchemaReference.fromSchema(String.class.getSimpleName()))
+                .build());
+
         MessageObject message = MessageObject.builder()
+                .messageId(String.class.getName())
                 .name(String.class.getName())
                 .title(String.class.getSimpleName())
                 .description(null)
-                //                .schemaFormat(Message.DEFAULT_SCHEMA_FORMAT)
-                //                .payload(PayloadReference.fromModelName(String.class.getSimpleName())) FIXME
+                // .schemaFormat(Message.DEFAULT_SCHEMA_FORMAT)
+                .payload(payload)
                 .headers(MessageHeaders.of(MessageReference.fromSchema("TestSchema")))
                 .bindings(EMPTY_MAP)
                 .build();
@@ -201,6 +215,7 @@ class AsyncAnnotationChannelsScannerTest {
 
         ChannelObject expectedChannel = ChannelObject.builder()
                 .bindings(null)
+                .messages(Map.of(message.getMessageId(), message))
                 .servers(List.of(
                         ServerReference.builder().ref("server1").build(),
                         ServerReference.builder().ref("server2").build()))
@@ -219,34 +234,44 @@ class AsyncAnnotationChannelsScannerTest {
         Map<String, ChannelObject> actualChannels = channelScanner.scan();
 
         // Then the returned collection contains the channel
-        MessageObject.MessageObjectBuilder builder = MessageObject.builder()
+        MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
+                .schema(SchemaReference.fromSchema(SimpleFoo.class.getSimpleName()))
+                .build());
+
+        MessageObject message = MessageObject.builder()
+                .messageId(SimpleFoo.class.getName())
                 .name(SimpleFoo.class.getName())
                 .title(SimpleFoo.class.getSimpleName())
-                //                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName())) FIXME
-                //                .schemaFormat(Message.DEFAULT_SCHEMA_FORMAT)
+                .payload(payload)
+                //  .schemaFormat(Message.DEFAULT_SCHEMA_FORMAT) // FIXME
                 .headers(MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
-                // FIXME
-                .bindings(EMPTY_MAP);
+                .bindings(EMPTY_MAP)
+                .description("SimpleFoo Message Description")
+                .build();
 
         Operation operation1 = Operation.builder()
                 .description("test-channel-1-description")
                 .title("test-channel-1_publish")
                 .bindings(EMPTY_MAP)
-                //                .message(builder.description("SimpleFoo Message Description").build()) FIXME
+                // .message(builder.description("SimpleFoo Message Description").build()) FIXME
                 .build();
 
-        ChannelObject expectedChannel1 =
-                ChannelObject.builder().bindings(null) /*.publish(operation1)*/.build();
+        ChannelObject expectedChannel1 = ChannelObject.builder()
+                .messages(Map.of(message.getMessageId(), message))
+                .bindings(null) /*.publish(operation1)*/
+                .build();
 
         Operation operation2 = Operation.builder()
                 .description("test-channel-2-description")
                 .title("test-channel-2_publish")
                 .bindings(EMPTY_MAP)
-                //                .message(builder.description("SimpleFoo Message Description").build()) FIXME
+                //  .message(builder.description("SimpleFoo Message Description").build()) FIXME
                 .build();
 
-        ChannelObject expectedChannel2 =
-                ChannelObject.builder().bindings(null) /*.publish(operation2)*/.build();
+        ChannelObject expectedChannel2 = ChannelObject.builder()
+                .messages(Map.of(message.getMessageId(), message))
+                .bindings(null) /*.publish(operation2)*/
+                .build();
 
         assertThat(actualChannels)
                 .containsExactlyInAnyOrderEntriesOf(Map.of(
@@ -263,13 +288,17 @@ class AsyncAnnotationChannelsScannerTest {
         Map<String, ChannelObject> actualChannels = channelScanner.scan();
 
         // Then the returned collection contains the channel
+        MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
+                .schema(SchemaReference.fromSchema(SimpleFoo.class.getSimpleName()))
+                .build());
+
         MessageObject message = MessageObject.builder()
                 .messageId("simpleFoo")
                 .name("SimpleFooPayLoad")
                 .title("Message Title")
                 .description("Message description")
-                //                .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName())) FIXME
-                //                .schemaFormat("application/schema+json;version=draft-07")
+                .payload(payload)
+                // .schemaFormat("application/schema+json;version=draft-07")
                 .headers(MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
                 // FIXME
                 .bindings(EMPTY_MAP)
@@ -279,11 +308,12 @@ class AsyncAnnotationChannelsScannerTest {
                 .description("test channel operation description")
                 .title("test-channel_publish")
                 .bindings(EMPTY_MAP)
-                //                .message(message) FIXME
+                // .message(message) FIXME
                 .build();
 
         ChannelObject expectedChannel = ChannelObject.builder()
                 .bindings(null) /*.publish(operation) FIXME*/
+                .messages(Map.of(message.getMessageId(), message))
                 .build();
 
         assertThat(actualChannels).containsExactly(Map.entry("test-channel", expectedChannel));
@@ -375,12 +405,12 @@ class AsyncAnnotationChannelsScannerTest {
 
             // Then the returned collection contains the channel with the actual method, excluding type erased methods
             MessageObject message = MessageObject.builder()
+                    .messageId(String.class.getName())
                     .name(String.class.getName())
                     .title(String.class.getSimpleName())
                     .description(null)
-                    //                    .payload(PayloadReference.fromModelName(String.class.getSimpleName())) FIXME
-                    //                    .schemaFormat("application/vnd.oai.openapi+json;version=3.0.0")
-                    //
+                    // .payload(PayloadReference.fromModelName(String.class.getSimpleName())) FIXME
+                    // .schemaFormat("application/vnd.oai.openapi+json;version=3.0.0") FIXME
                     .headers(
                             MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
                     .bindings(EMPTY_MAP)
@@ -390,11 +420,12 @@ class AsyncAnnotationChannelsScannerTest {
                     .description("test channel operation description")
                     .title("test-channel_publish")
                     .bindings(EMPTY_MAP)
-                    //                    .message(message) FIXME
+                    // .message(message) FIXME
                     .build();
 
             ChannelObject expectedChannel = ChannelObject.builder()
                     .bindings(null) /*.publish(operation) FIXME*/
+                    .messages(Map.of(message.getMessageId(), message))
                     .build();
 
             assertThat(actualChannels).containsExactly(Map.entry("test-channel", expectedChannel));
@@ -443,6 +474,7 @@ class AsyncAnnotationChannelsScannerTest {
 
             // Then the returned collection contains the channel
             MessageObject message = MessageObject.builder()
+                    .messageId(String.class.getName())
                     .name(String.class.getName())
                     .title(String.class.getSimpleName())
                     .description(null)
@@ -463,6 +495,7 @@ class AsyncAnnotationChannelsScannerTest {
 
             ChannelObject expectedChannel = ChannelObject.builder()
                     .bindings(null) /*.publish(operation) FIXME*/
+                    .messages(Map.of(message.getMessageId(), message))
                     .build();
 
             assertThat(actualChannels).containsExactly(Map.entry("test-channel", expectedChannel));

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationChannelsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationChannelsScannerTest.java
@@ -126,7 +126,7 @@ class AsyncAnnotationChannelsScannerTest {
     void scan_componentHasNoListenerMethods() {
         setClassToScan(ClassWithoutListenerAnnotation.class);
 
-        Map<String, ChannelObject> channels = channelScanner.scan();
+        Map<String, ChannelObject> channels = channelScanner.scanChannels();
 
         assertThat(channels).isEmpty();
     }
@@ -137,7 +137,7 @@ class AsyncAnnotationChannelsScannerTest {
         setClassToScan(ClassWithListenerAnnotation.class);
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = channelScanner.scan();
+        Map<String, ChannelObject> actualChannels = channelScanner.scanChannels();
 
         // Then the returned collection contains the channel
         MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
@@ -150,21 +150,21 @@ class AsyncAnnotationChannelsScannerTest {
                 .title(SimpleFoo.class.getSimpleName())
                 .description("SimpleFoo Message Description")
                 .payload(payload)
+                // FIXME
                 // .schemaFormat(Message.DEFAULT_SCHEMA_FORMAT)
                 .headers(MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
-                // FIXME
                 .bindings(EMPTY_MAP)
                 .build();
 
         Operation operation = Operation.builder()
                 .description("Auto-generated description")
-                //                .operationId("test-channel_publish") FIXME
-                //                .bindings(EMPTY_MAP)
-                //                .message(message)
+                // .operationId("test-channel_publish") FIXME
+                // .bindings(EMPTY_MAP)
+                // .message(message)
                 .build();
 
         ChannelObject expectedChannel = ChannelObject.builder()
-                .bindings(null) /*.publish(operation) FIXME*/
+                .bindings(null)
                 .messages(Map.of(message.getMessageId(), message))
                 .build();
 
@@ -176,7 +176,7 @@ class AsyncAnnotationChannelsScannerTest {
         // Given a class with method annotated with AsyncListener, with an unknown servername
         setClassToScan(ClassWithListenerAnnotationWithInvalidServer.class);
 
-        assertThatThrownBy(channelScanner::scan)
+        assertThatThrownBy(channelScanner::scanChannels)
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(
                         "Operation 'test-channel_publish' defines unknown server ref 'server3'. This AsyncApi defines these server(s): [server1, server2]");
@@ -188,7 +188,7 @@ class AsyncAnnotationChannelsScannerTest {
         setClassToScan(ClassWithListenerAnnotationWithAllAttributes.class);
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = channelScanner.scan();
+        Map<String, ChannelObject> actualChannels = channelScanner.scanChannels();
 
         // Then the returned collection contains the channel
         MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
@@ -200,6 +200,7 @@ class AsyncAnnotationChannelsScannerTest {
                 .name(String.class.getName())
                 .title(String.class.getSimpleName())
                 .description(null)
+                // FIXME
                 // .schemaFormat(Message.DEFAULT_SCHEMA_FORMAT)
                 .payload(payload)
                 .headers(MessageHeaders.of(MessageReference.fromSchema("TestSchema")))
@@ -210,7 +211,7 @@ class AsyncAnnotationChannelsScannerTest {
                 .description("description")
                 .title("test-channel_publish")
                 .bindings(Map.of(TestOperationBindingProcessor.TYPE, TestOperationBindingProcessor.BINDING))
-                //                .message(message) FIXME
+                //  .message(message) FIXME
                 .build();
 
         ChannelObject expectedChannel = ChannelObject.builder()
@@ -219,7 +220,6 @@ class AsyncAnnotationChannelsScannerTest {
                 .servers(List.of(
                         ServerReference.builder().ref("server1").build(),
                         ServerReference.builder().ref("server2").build()))
-                //                .publish(operation) FIXME
                 .build();
 
         assertThat(actualChannels).containsExactly(Map.entry("test-channel", expectedChannel));
@@ -231,7 +231,7 @@ class AsyncAnnotationChannelsScannerTest {
         setClassToScan(ClassWithMultipleListenerAnnotations.class);
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = channelScanner.scan();
+        Map<String, ChannelObject> actualChannels = channelScanner.scanChannels();
 
         // Then the returned collection contains the channel
         MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
@@ -285,7 +285,7 @@ class AsyncAnnotationChannelsScannerTest {
         setClassToScan(ClassWithMessageAnnotation.class);
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = channelScanner.scan();
+        Map<String, ChannelObject> actualChannels = channelScanner.scanChannels();
 
         // Then the returned collection contains the channel
         MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
@@ -298,9 +298,9 @@ class AsyncAnnotationChannelsScannerTest {
                 .title("Message Title")
                 .description("Message description")
                 .payload(payload)
+                // FIXME
                 // .schemaFormat("application/schema+json;version=draft-07")
                 .headers(MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
-                // FIXME
                 .bindings(EMPTY_MAP)
                 .build();
 
@@ -401,7 +401,7 @@ class AsyncAnnotationChannelsScannerTest {
             setClassToScan(clazz);
 
             // When scan is called
-            Map<String, ChannelObject> actualChannels = channelScanner.scan();
+            Map<String, ChannelObject> actualChannels = channelScanner.scanChannels();
 
             // Then the returned collection contains the channel with the actual method, excluding type erased methods
             MessageObject message = MessageObject.builder()
@@ -470,17 +470,21 @@ class AsyncAnnotationChannelsScannerTest {
             setClassToScan(ClassWithMetaAnnotation.class);
 
             // When scan is called
-            Map<String, ChannelObject> actualChannels = channelScanner.scan();
+            Map<String, ChannelObject> actualChannels = channelScanner.scanChannels();
 
             // Then the returned collection contains the channel
+            var messagePayload = MessagePayload.of(MultiFormatSchema.builder()
+                    .schema(SchemaReference.fromSchema(String.class.getSimpleName()))
+                    .build());
+
             MessageObject message = MessageObject.builder()
                     .messageId(String.class.getName())
                     .name(String.class.getName())
                     .title(String.class.getSimpleName())
                     .description(null)
-                    //                    .payload(PayloadReference.fromModelName(String.class.getSimpleName())) FIXME
-                    //                    .schemaFormat("application/vnd.oai.openapi+json;version=3.0.0")
-                    //
+                    .payload(messagePayload)
+                    //  FIXME
+                    // .schemaFormat("application/vnd.oai.openapi+json;version=3.0.0")
                     .headers(
                             MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
                     .bindings(EMPTY_MAP)
@@ -490,7 +494,7 @@ class AsyncAnnotationChannelsScannerTest {
                     .description("test channel operation description")
                     .title("test-channel_publish")
                     .bindings(EMPTY_MAP)
-                    //                    .message(message) FIXME
+                    // .message(message) FIXME
                     .build();
 
             ChannelObject expectedChannel = ChannelObject.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScannerIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScannerIntegrationTest.java
@@ -78,7 +78,7 @@ class ClassLevelAnnotationChannelsScannerIntegrationTest {
         void scan_componentHasNoClassLevelRabbitListenerAnnotation() {
             // when
             List<Map.Entry<String, ChannelObject>> channels =
-                    scanner.process(ClassWithoutClassListener.class).toList();
+                    scanner.processChannels(ClassWithoutClassListener.class).toList();
 
             // then
             assertThat(channels).isEmpty();
@@ -97,7 +97,7 @@ class ClassLevelAnnotationChannelsScannerIntegrationTest {
         void scan_componentHasNoClassLevelRabbitListenerAnnotation() {
             // when
             List<Map.Entry<String, ChannelObject>> channels =
-                    scanner.process(ClassWithoutMethodListener.class).toList();
+                    scanner.processChannels(ClassWithoutMethodListener.class).toList();
 
             // then
             assertThat(channels).isEmpty();
@@ -115,8 +115,9 @@ class ClassLevelAnnotationChannelsScannerIntegrationTest {
         @Test
         void scan_componentWithOneMethodLevelAnnotation() {
             // when
-            List<Map.Entry<String, ChannelObject>> actualChannels =
-                    scanner.process(ClassWithOneMethodLevelHandler.class).toList();
+            List<Map.Entry<String, ChannelObject>> actualChannels = scanner.processChannels(
+                            ClassWithOneMethodLevelHandler.class)
+                    .toList();
 
             // then
             MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
@@ -157,8 +158,9 @@ class ClassLevelAnnotationChannelsScannerIntegrationTest {
         @Test
         void scan_componentWithMultipleRabbitHandlerMethods() {
             // when
-            List<Map.Entry<String, ChannelObject>> actualChannels =
-                    scanner.process(ClassWithMultipleMethodLevelHandlers.class).toList();
+            List<Map.Entry<String, ChannelObject>> actualChannels = scanner.processChannels(
+                            ClassWithMultipleMethodLevelHandlers.class)
+                    .toList();
 
             // Then the returned collection contains the channel with message set to oneOf
             MessagePayload simpleFooPayload = MessagePayload.of(MultiFormatSchema.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScannerIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScannerIntegrationTest.java
@@ -3,7 +3,6 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 
 import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.BindingFactory;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
-import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeadersNotDocumented;
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.ChannelBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.MessageBinding;
@@ -11,8 +10,10 @@ import io.github.stavshamir.springwolf.asyncapi.v3.bindings.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
 import io.github.stavshamir.springwolf.configuration.properties.SpringwolfConfigProperties;
 import io.github.stavshamir.springwolf.schemas.DefaultSchemasService;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
@@ -118,28 +119,23 @@ class ClassLevelAnnotationChannelsScannerIntegrationTest {
                     scanner.process(ClassWithOneMethodLevelHandler.class).toList();
 
             // then
+            MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
+                    .schema(SchemaReference.fromSchema(SimpleFoo.class.getSimpleName()))
+                    .build());
+
             MessageObject message = MessageObject.builder()
+                    .messageId(SimpleFoo.class.getName())
                     .name(SimpleFoo.class.getName())
                     .title(SimpleFoo.class.getSimpleName())
-                    //                    .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
-                    // FIXME
-                    //
-                    .headers(
-                            MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
-                    // FIXME
+                    .payload(payload)
+                    .headers(MessageHeaders.of(
+                            MessageReference.fromSchema(AsyncHeadersNotDocumented.NOT_DOCUMENTED.getSchemaName())))
                     .bindings(TestBindingFactory.defaultMessageBinding)
-                    .build();
-
-            Operation operation = Operation.builder()
-                    .description("Auto-generated description")
-                    .title("test-channel_publish_ClassWithOneMethodLevelHandler")
-                    .bindings(TestBindingFactory.defaultOperationBinding)
-                    //                    .message(message) FIXME
                     .build();
 
             ChannelObject expectedChannel = ChannelObject.builder()
                     .bindings(TestBindingFactory.defaultChannelBinding)
-                    //                    .publish(operation) FIXME
+                    .messages(Map.of(message.getMessageId(), message))
                     .build();
 
             assertThat(actualChannels).containsExactly(Map.entry(TestBindingFactory.CHANNEL, expectedChannel));
@@ -165,39 +161,35 @@ class ClassLevelAnnotationChannelsScannerIntegrationTest {
                     scanner.process(ClassWithMultipleMethodLevelHandlers.class).toList();
 
             // Then the returned collection contains the channel with message set to oneOf
+            MessagePayload simpleFooPayload = MessagePayload.of(MultiFormatSchema.builder()
+                    .schema(SchemaReference.fromSchema(SimpleFoo.class.getSimpleName()))
+                    .build());
+
             MessageObject fooMessage = MessageObject.builder()
                     .name(SimpleFoo.class.getName())
                     .title(SimpleFoo.class.getSimpleName())
-                    //                    .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
-                    // FIXME
-                    //
-                    .headers(
-                            MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
-                    // FIXME
+                    .payload(simpleFooPayload)
+                    .headers(MessageHeaders.of(
+                            MessageReference.fromSchema(AsyncHeadersNotDocumented.NOT_DOCUMENTED.getSchemaName())))
                     .bindings(TestBindingFactory.defaultMessageBinding)
                     .build();
+
+            MessagePayload stringPayload = MessagePayload.of(MultiFormatSchema.builder()
+                    .schema(SchemaReference.fromSchema(String.class.getSimpleName()))
+                    .build());
 
             MessageObject barMessage = MessageObject.builder()
                     .name(String.class.getName())
                     .title(String.class.getSimpleName())
-                    //                    .payload(PayloadReference.fromModelName(String.class.getSimpleName())) FIXME
-                    //
-                    .headers(
-                            MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
+                    .payload(stringPayload)
+                    .headers(MessageHeaders.of(
+                            MessageReference.fromSchema(AsyncHeadersNotDocumented.NOT_DOCUMENTED.getSchemaName())))
                     .bindings(TestBindingFactory.defaultMessageBinding)
-                    .build();
-
-            Operation operation = Operation.builder()
-                    .description("Auto-generated description")
-                    //                    .operationId("test-channel_publish_ClassWithMultipleMethodLevelHandlers")
-                    // FIXME
-                    .bindings(TestBindingFactory.defaultOperationBinding)
-                    //                    .message(toMessageObjectOrComposition(Set.of(fooMessage, barMessage))) FIXME
                     .build();
 
             ChannelObject expectedChannel = ChannelObject.builder()
                     .bindings(TestBindingFactory.defaultChannelBinding)
-                    //                    .publish(operation) FIXME
+                    .messages(Map.of(fooMessage.getMessageId(), fooMessage, barMessage.getMessageId(), barMessage))
                     .build();
 
             assertThat(actualChannels).containsExactly(Map.entry(TestBindingFactory.CHANNEL, expectedChannel));
@@ -248,12 +240,12 @@ class ClassLevelAnnotationChannelsScannerIntegrationTest {
 
         @Override
         public Map<String, ChannelBinding> buildChannelBinding(TestClassListener annotation) {
-            return (Map) defaultChannelBinding;
+            return defaultChannelBinding;
         }
 
         @Override
         public Map<String, OperationBinding> buildOperationBinding(TestClassListener annotation) {
-            return (Map) defaultOperationBinding;
+            return defaultOperationBinding;
         }
 
         @Override

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScannerTest.java
@@ -12,10 +12,10 @@ import io.github.stavshamir.springwolf.asyncapi.v3.bindings.amqp.AMQPChannelBind
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.amqp.AMQPMessageBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.amqp.AMQPOperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -82,24 +82,23 @@ class ClassLevelAnnotationChannelsScannerTest {
                 scanner.process(ClassWithTestListenerAnnotation.class).collect(Collectors.toList());
 
         // then
+        MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
+                .schema(SchemaReference.fromSchema(String.class.getSimpleName()))
+                .build());
+
         MessageObject message = MessageObject.builder()
+                .messageId(String.class.getName())
                 .name(String.class.getName())
                 .title(String.class.getSimpleName())
-                //                .payload(PayloadReference.fromModelName(String.class.getSimpleName())) FIXME
-                .headers(MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
+                .payload(payload)
+                // FIXME
+                // .headers(MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
                 .bindings(defaultMessageBinding)
-                .build();
-
-        Operation operation = Operation.builder()
-                .description("Auto-generated description")
-                .title(CHANNEL + "_publish_ClassWithTestListenerAnnotation")
-                .bindings(defaultOperationBinding)
-                //                .message(message) FIXME
                 .build();
 
         ChannelObject expectedChannelItem = ChannelObject.builder()
                 .bindings(defaultChannelBinding)
-                //                .publish(operation) FIXME
+                .messages(Map.of(message.getMessageId(), message))
                 .build();
 
         assertThat(channels).containsExactly(Map.entry(CHANNEL, expectedChannelItem));

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScannerTest.java
@@ -79,7 +79,7 @@ class ClassLevelAnnotationChannelsScannerTest {
     void scan_componentHasTestListenerMethods() {
         // when
         List<Map.Entry<String, ChannelObject>> channels =
-                scanner.process(ClassWithTestListenerAnnotation.class).collect(Collectors.toList());
+                scanner.processChannels(ClassWithTestListenerAnnotation.class).collect(Collectors.toList());
 
         // then
         MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationChannelsScannerIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationChannelsScannerIntegrationTest.java
@@ -10,8 +10,10 @@ import io.github.stavshamir.springwolf.asyncapi.v3.bindings.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
 import io.github.stavshamir.springwolf.configuration.properties.SpringwolfConfigProperties;
 import io.github.stavshamir.springwolf.schemas.DefaultSchemasService;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
@@ -37,7 +39,6 @@ import java.util.Map;
 
 import static io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelAnnotationChannelsScannerIntegrationTest.TestBindingFactory.defaultChannelBinding;
 import static io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelAnnotationChannelsScannerIntegrationTest.TestBindingFactory.defaultMessageBinding;
-import static io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelAnnotationChannelsScannerIntegrationTest.TestBindingFactory.defaultOperationBinding;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
@@ -93,27 +94,23 @@ class MethodLevelAnnotationChannelsScannerIntegrationTest {
                     scanner.process(ClassWithListenerAnnotation.class).toList();
 
             // then
+            MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
+                    .schema(SchemaReference.fromSchema(SimpleFoo.class.getSimpleName()))
+                    .build());
+
             MessageObject message = MessageObject.builder()
+                    .messageId(SimpleFoo.class.getName())
                     .name(SimpleFoo.class.getName())
                     .title(SimpleFoo.class.getSimpleName())
-                    //                    .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
-                    // FIXME
-                    //
+                    .payload(payload)
                     .headers(
                             MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
                     .bindings(TestBindingFactory.defaultMessageBinding)
                     .build();
 
-            Operation operation = Operation.builder()
-                    .description("Auto-generated description")
-                    .title("test-channel_publish_methodWithAnnotation")
-                    .bindings(TestBindingFactory.defaultOperationBinding)
-                    //                    .message(message) FIXME
-                    .build();
-
             ChannelObject expectedChannel = ChannelObject.builder()
                     .bindings(defaultChannelBinding)
-                    //                    .publish(operation) FIXME
+                    .messages(Map.of(message.getMessageId(), message))
                     .build();
 
             assertThat(actualChannels).containsExactly(Map.entry(TestBindingFactory.CHANNEL, expectedChannel));
@@ -138,46 +135,40 @@ class MethodLevelAnnotationChannelsScannerIntegrationTest {
                     .toList();
 
             // then
+            MessagePayload simpleFooPayload = MessagePayload.of(MultiFormatSchema.builder()
+                    .schema(SchemaReference.fromSchema(SimpleFoo.class.getSimpleName()))
+                    .build());
+            MessagePayload stringPayload = MessagePayload.of(MultiFormatSchema.builder()
+                    .schema(SchemaReference.fromSchema(String.class.getSimpleName()))
+                    .build());
+
             MessageObject messageSimpleFoo = MessageObject.builder()
+                    .messageId(SimpleFoo.class.getName())
                     .name(SimpleFoo.class.getName())
                     .title(SimpleFoo.class.getSimpleName())
-                    //                    .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
-                    // FIXME
-                    //
+                    .payload(simpleFooPayload)
                     .headers(
                             MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
                     .bindings(TestBindingFactory.defaultMessageBinding)
                     .build();
             MessageObject messageString = MessageObject.builder()
+                    .messageId(String.class.getName())
                     .name(String.class.getName())
                     .title(String.class.getSimpleName())
-                    //                    .payload(PayloadReference.fromModelName(String.class.getSimpleName())) FIXME
-                    //
+                    .payload(stringPayload)
                     .headers(
                             MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
                     .bindings(TestBindingFactory.defaultMessageBinding)
                     .build();
 
             ChannelObject expectedChannelItem = ChannelObject.builder()
+                    .messages(Map.of(messageSimpleFoo.getMessageId(), messageSimpleFoo))
                     .bindings(defaultChannelBinding)
-                    //                    .publish(Operation.builder() FIXME
-                    //                            .description("Auto-generated description")
-                    //                            .operationId(TestBindingFactory.CHANNEL +
-                    // "_publish_methodWithAnnotation")
-                    //                            .bindings(TestBindingFactory.defaultOperationBinding)
-                    //                            .message(messageSimpleFoo)
-                    //                            .build())
                     .build();
 
             ChannelObject expectedChannelItem2 = ChannelObject.builder()
                     .bindings(defaultChannelBinding)
-                    //                    .publish(Operation.builder() FIXME
-                    //                            .description("Auto-generated description")
-                    //                            .operationId(TestBindingFactory.CHANNEL +
-                    // "_publish_methodWithAnnotation")
-                    //                            .bindings(TestBindingFactory.defaultOperationBinding)
-                    //                            .message(messageString)
-                    //                            .build())
+                    .messages(Map.of(messageString.getMessageId(), messageSimpleFoo))
                     .build();
 
             assertThat(channels)
@@ -205,27 +196,23 @@ class MethodLevelAnnotationChannelsScannerIntegrationTest {
                     scanner.process(ClassWithListenerMetaAnnotation.class).toList();
 
             // then
+            MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
+                    .schema(SchemaReference.fromSchema(SimpleFoo.class.getSimpleName()))
+                    .build());
+
             MessageObject message = MessageObject.builder()
+                    .messageId(SimpleFoo.class.getName())
                     .name(SimpleFoo.class.getName())
                     .title(SimpleFoo.class.getSimpleName())
-                    //                    .payload(PayloadReference.fromModelName(SimpleFoo.class.getSimpleName()))
-                    // FIXME
-                    //
+                    .payload(payload)
                     .headers(
                             MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
                     .bindings(defaultMessageBinding)
                     .build();
 
-            Operation operation = Operation.builder()
-                    .description("Auto-generated description")
-                    .title("test-channel_publish_methodWithAnnotation")
-                    .bindings(defaultOperationBinding)
-                    //                    .message(message) FIXME
-                    .build();
-
             ChannelObject expectedChannel = ChannelObject.builder()
                     .bindings(defaultChannelBinding)
-                    //                    .publish(operation) FIXME
+                    .messages(Map.of(message.getMessageId(), message))
                     .build();
 
             assertThat(actualChannels).containsExactly(Map.entry(TestBindingFactory.CHANNEL, expectedChannel));
@@ -275,12 +262,12 @@ class MethodLevelAnnotationChannelsScannerIntegrationTest {
 
         @Override
         public Map<String, ChannelBinding> buildChannelBinding(TestChannelListener annotation) {
-            return (Map) defaultChannelBinding;
+            return defaultChannelBinding;
         }
 
         @Override
         public Map<String, OperationBinding> buildOperationBinding(TestChannelListener annotation) {
-            return (Map) defaultOperationBinding;
+            return defaultOperationBinding;
         }
 
         @Override

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationChannelsScannerIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationChannelsScannerIntegrationTest.java
@@ -73,8 +73,9 @@ class MethodLevelAnnotationChannelsScannerIntegrationTest {
         @Test
         void scan_componentHasNoListenerMethods() {
             // when
-            List<Map.Entry<String, ChannelObject>> channels =
-                    scanner.process(ClassWithoutListenerAnnotation.class).toList();
+            List<Map.Entry<String, ChannelObject>> channels = scanner.processChannels(
+                            ClassWithoutListenerAnnotation.class)
+                    .toList();
 
             // then
             assertThat(channels).isEmpty();
@@ -91,7 +92,7 @@ class MethodLevelAnnotationChannelsScannerIntegrationTest {
         void scan_componentHasListenerMethod() {
             // when
             List<Map.Entry<String, ChannelObject>> actualChannels =
-                    scanner.process(ClassWithListenerAnnotation.class).toList();
+                    scanner.processChannels(ClassWithListenerAnnotation.class).toList();
 
             // then
             MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
@@ -130,7 +131,7 @@ class MethodLevelAnnotationChannelsScannerIntegrationTest {
         @Test
         void scan_componentHasTestListenerMethods_multiplePayloads() {
             // when
-            List<Map.Entry<String, ChannelObject>> channels = scanner.process(
+            List<Map.Entry<String, ChannelObject>> channels = scanner.processChannels(
                             ClassWithTestListenerAnnotationMultiplePayloads.class)
                     .toList();
 
@@ -192,8 +193,9 @@ class MethodLevelAnnotationChannelsScannerIntegrationTest {
         @Test
         void scan_componentHasListenerMetaMethod() {
             // when
-            List<Map.Entry<String, ChannelObject>> actualChannels =
-                    scanner.process(ClassWithListenerMetaAnnotation.class).toList();
+            List<Map.Entry<String, ChannelObject>> actualChannels = scanner.processChannels(
+                            ClassWithListenerMetaAnnotation.class)
+                    .toList();
 
             // then
             MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationChannelsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationChannelsScannerTest.java
@@ -82,7 +82,7 @@ class MethodLevelAnnotationChannelsScannerTest {
     void scan_componentHasTestListenerMethods() {
         // when
         List<Map.Entry<String, ChannelObject>> channels =
-                scanner.process(ClassWithTestListenerAnnotation.class).collect(Collectors.toList());
+                scanner.processChannels(ClassWithTestListenerAnnotation.class).collect(Collectors.toList());
 
         // then
         MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
@@ -118,8 +118,9 @@ class MethodLevelAnnotationChannelsScannerTest {
     @Test
     void scan_componentHasMultipleTestListenerMethods() {
         // when
-        List<Map.Entry<String, ChannelObject>> channels =
-                scanner.process(ClassWithMultipleTestListenerAnnotation.class).toList();
+        List<Map.Entry<String, ChannelObject>> channels = scanner.processChannels(
+                        ClassWithMultipleTestListenerAnnotation.class)
+                .toList();
 
         // then
         MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationChannelsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationChannelsScannerTest.java
@@ -13,8 +13,10 @@ import io.github.stavshamir.springwolf.asyncapi.v3.bindings.amqp.AMQPOperationBi
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -75,24 +77,22 @@ class MethodLevelAnnotationChannelsScannerTest {
                 scanner.process(ClassWithTestListenerAnnotation.class).collect(Collectors.toList());
 
         // then
+        MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
+                .schema(SchemaReference.fromSchema(String.class.getSimpleName()))
+                .build());
+
         MessageObject message = MessageObject.builder()
+                .messageId(String.class.getName())
                 .name(String.class.getName())
                 .title(String.class.getSimpleName())
-                //                .payload(PayloadReference.fromModelName(String.class.getSimpleName())) FIXME
+                .payload(payload)
                 .headers(MessageHeaders.of(MessageReference.fromSchema(AsyncHeaders.NOT_DOCUMENTED.getSchemaName())))
                 .bindings(defaultMessageBinding)
                 .build();
 
-        Operation operation = Operation.builder()
-                .description("Auto-generated description")
-                .title(CHANNEL + "_publish_methodWithAnnotation")
-                .bindings(defaultOperationBinding)
-                //                .message(message) FIXME
-                .build();
-
         ChannelObject expectedChannelItem = ChannelObject.builder()
                 .bindings(defaultChannelBinding)
-                //                .publish(operation) FIXME
+                .messages(Map.of(message.getMessageId(), message))
                 .build();
 
         assertThat(channels).containsExactly(Map.entry(CHANNEL, expectedChannelItem));

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfConfigPropertiesIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfConfigPropertiesIntegrationTest.java
@@ -77,7 +77,7 @@ public class SpringwolfConfigPropertiesIntegrationTest {
                 "springwolf.docket.info.extension-fields.x-api-name=api-name",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
             })
     static class PayloadWithoutCustomizingIntegrationTest {
 
@@ -109,7 +109,7 @@ public class SpringwolfConfigPropertiesIntegrationTest {
                 "springwolf.docket.info.extension-fields.x-api-name=api-name",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
                 "springwolf.payload.extractable-classes.my.custom.class=1"
             })
     static class PayloadWithCustomizingIntegrationTest {
@@ -144,7 +144,7 @@ public class SpringwolfConfigPropertiesIntegrationTest {
                 "springwolf.docket.info.extension-fields.x-api-name=api-name",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
                 "springwolf.payload.extractable-classes.java.util.List=-1"
             })
     static class PayloadDisabledIntegrationTest {

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/fixtures/MinimalIntegrationTestContextConfiguration.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/fixtures/MinimalIntegrationTestContextConfiguration.java
@@ -22,6 +22,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
             "springwolf.docket.default-content-type=application/yaml",
             "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=test",
-            "springwolf.docket.servers.test-protocol.url=some-server:1234",
+            "springwolf.docket.servers.test-protocol.host=some-server:1234",
         })
 public @interface MinimalIntegrationTestContextConfiguration {}

--- a/springwolf-examples/springwolf-amqp-example/src/main/resources/application.properties
+++ b/springwolf-examples/springwolf-amqp-example/src/main/resources/application.properties
@@ -28,7 +28,7 @@ springwolf.docket.info.contact.extension-fields.x-phone=+49 123 456789
 springwolf.docket.info.license.name=Apache License 2.0
 springwolf.docket.info.license.extension-fields.x-desc=some description
 springwolf.docket.servers.amqp.protocol=amqp
-springwolf.docket.servers.amqp.url=${spring.rabbitmq.host}:${spring.rabbitmq.port}
+springwolf.docket.servers.amqp.host=${spring.rabbitmq.host}:${spring.rabbitmq.port}
 springwolf.use-fqn=true
 
 springwolf.plugin.amqp.publishing.enabled=true

--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/amqp/SpringContextIntegrationTest.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/amqp/SpringContextIntegrationTest.java
@@ -23,7 +23,7 @@ public class SpringContextIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=amqp",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
             })
     class ApplicationPropertiesConfigurationTest {
 

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -26,13 +26,12 @@
   },
   "channels": {
     "another-queue": {
-      "address": "another-queue",
       "messages": {
         "another-queue_publish_receiveAnotherPayload.message": {
           "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
           "title": "AnotherPayloadDto",
           "payload": {
-            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto"
             }
@@ -69,14 +68,13 @@
       }
     },
     "example-producer-channel-publisher": {
-      "address": "example-producer-channel-publisher",
       "messages": {
         "example-producer-channel-publisher_subscribe.message": {
           "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
           "title": "AnotherPayloadDto",
           "description": "Another payload model",
           "payload": {
-            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto"
             }
@@ -93,13 +91,12 @@
       }
     },
     "example-queue": {
-      "address": "example-queue",
       "messages": {
         "example-queue_publish_receiveExamplePayload.message": {
           "name": "io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto",
           "title": "ExamplePayloadDto",
           "payload": {
-            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto"
             }
@@ -136,13 +133,12 @@
       }
     },
     "example-topic-routing-key": {
-      "address": "example-topic-routing-key",
       "messages": {
         "example-topic-routing-key_publish_bindingsExample.message": {
           "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
           "title": "AnotherPayloadDto",
           "payload": {
-            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto"
             }
@@ -179,13 +175,12 @@
       }
     },
     "multi-payload-queue": {
-      "address": "multi-payload-queue",
       "messages": {
         "multi-payload-queue_publish_bindingsBeanExample.message.0": {
           "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
           "title": "AnotherPayloadDto",
           "payload": {
-            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto"
             }
@@ -203,7 +198,7 @@
           "name": "io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto",
           "title": "ExamplePayloadDto",
           "payload": {
-            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto"
             }
@@ -272,7 +267,7 @@
           "expiration": 0,
           "cc": [],
           "priority": 0,
-          "deliveryMode": 0,
+          "deliveryMode": 1,
           "mandatory": false,
           "timestamp": false,
           "ack": false,

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -235,6 +235,76 @@
       }
     }
   },
+  "components": {
+    "schemas": {
+      "HeadersNotDocumented": {
+        "type": "object",
+        "properties": { },
+        "example": { }
+      },
+      "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto": {
+        "required": [
+          "example"
+        ],
+        "type": "object",
+        "properties": {
+          "example": {
+            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto"
+          },
+          "foo": {
+            "type": "string",
+            "description": "Foo field",
+            "example": "bar"
+          }
+        },
+        "description": "Another payload model",
+        "example": {
+          "example": {
+            "someEnum": "FOO2",
+            "someLong": 5,
+            "someString": "some string value"
+          },
+          "foo": "bar"
+        }
+      },
+      "io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto": {
+        "required": [
+          "someEnum",
+          "someString"
+        ],
+        "type": "object",
+        "properties": {
+          "someEnum": {
+            "type": "string",
+            "description": "Some enum field",
+            "example": "FOO2",
+            "enum": [
+              "FOO1",
+              "FOO2",
+              "FOO3"
+            ]
+          },
+          "someLong": {
+            "type": "integer",
+            "description": "Some long field",
+            "format": "int64",
+            "example": 5
+          },
+          "someString": {
+            "type": "string",
+            "description": "Some string field",
+            "example": "some string value"
+          }
+        },
+        "description": "Example payload model",
+        "example": {
+          "someEnum": "FOO2",
+          "someLong": 5,
+          "someString": "some string value"
+        }
+      }
+    }
+  },
   "operations": {
     "another-queue_publish_receiveAnotherPayload": {
       "action": "receive",
@@ -342,76 +412,6 @@
           "$ref": "#/channels/multi-payload-queue/messages/multi-payload-queue_publish_bindingsBeanExample.message.1"
         }
       ]
-    }
-  },
-  "components": {
-    "schemas": {
-      "HeadersNotDocumented": {
-        "type": "object",
-        "properties": {},
-        "example": {}
-      },
-      "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto": {
-        "required": [
-          "example"
-        ],
-        "type": "object",
-        "properties": {
-          "example": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto"
-          },
-          "foo": {
-            "type": "string",
-            "description": "Foo field",
-            "example": "bar"
-          }
-        },
-        "description": "Another payload model",
-        "example": {
-          "example": {
-            "someEnum": "FOO2",
-            "someLong": 5,
-            "someString": "some string value"
-          },
-          "foo": "bar"
-        }
-      },
-      "io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto": {
-        "required": [
-          "someEnum",
-          "someString"
-        ],
-        "type": "object",
-        "properties": {
-          "someEnum": {
-            "type": "string",
-            "description": "Some enum field",
-            "example": "FOO2",
-            "enum": [
-              "FOO1",
-              "FOO2",
-              "FOO3"
-            ]
-          },
-          "someLong": {
-            "type": "integer",
-            "description": "Some long field",
-            "format": "int64",
-            "example": 5
-          },
-          "someString": {
-            "type": "string",
-            "description": "Some string field",
-            "example": "some string value"
-          }
-        },
-        "description": "Example payload model",
-        "example": {
-          "someEnum": "FOO2",
-          "someLong": 5,
-          "someString": "some string value"
-        }
-      }
     }
   }
 }

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -177,17 +177,17 @@
     "multi-payload-queue": {
       "messages": {
         "multi-payload-queue_publish_bindingsBeanExample.message.0": {
-          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
-          "title": "AnotherPayloadDto",
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
           "payload": {
             "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto"
             }
           },
-          "headers": {
-            "$ref": "#/components/schemas/HeadersNotDocumented"
-          },
+          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
           "bindings": {
             "amqp": {
               "bindingVersion": "0.3.0"

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -28,17 +28,17 @@
     "another-queue": {
       "messages": {
         "another-queue_publish_receiveAnotherPayload.message": {
-          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
-          "title": "AnotherPayloadDto",
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
           "payload": {
             "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto"
             }
           },
-          "headers": {
-            "$ref": "#/components/schemas/HeadersNotDocumented"
-          },
+          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
           "bindings": {
             "amqp": {
               "bindingVersion": "0.3.0"
@@ -70,18 +70,18 @@
     "example-producer-channel-publisher": {
       "messages": {
         "example-producer-channel-publisher_subscribe.message": {
-          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
-          "title": "AnotherPayloadDto",
-          "description": "Another payload model",
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
           "payload": {
             "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto"
             }
           },
-          "headers": {
-            "$ref": "#/components/schemas/HeadersNotDocumented"
-          },
+          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
+          "description": "Another payload model",
           "bindings": {
             "amqp": {
               "bindingVersion": "0.3.0"
@@ -93,17 +93,17 @@
     "example-queue": {
       "messages": {
         "example-queue_publish_receiveExamplePayload.message": {
-          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto",
-          "title": "ExamplePayloadDto",
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
           "payload": {
             "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto"
             }
           },
-          "headers": {
-            "$ref": "#/components/schemas/HeadersNotDocumented"
-          },
+          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto",
+          "title": "ExamplePayloadDto",
           "bindings": {
             "amqp": {
               "bindingVersion": "0.3.0"
@@ -135,17 +135,17 @@
     "example-topic-routing-key": {
       "messages": {
         "example-topic-routing-key_publish_bindingsExample.message": {
-          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
-          "title": "AnotherPayloadDto",
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
           "payload": {
             "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto"
             }
           },
-          "headers": {
-            "$ref": "#/components/schemas/HeadersNotDocumented"
-          },
+          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
           "bindings": {
             "amqp": {
               "bindingVersion": "0.3.0"
@@ -195,17 +195,17 @@
           }
         },
         "multi-payload-queue_publish_bindingsBeanExample.message.1": {
-          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto",
-          "title": "ExamplePayloadDto",
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
           "payload": {
             "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto"
             }
           },
-          "headers": {
-            "$ref": "#/components/schemas/HeadersNotDocumented"
-          },
+          "name": "io.github.stavshamir.springwolf.example.amqp.dtos.ExamplePayloadDto",
+          "title": "ExamplePayloadDto",
           "bindings": {
             "amqp": {
               "bindingVersion": "0.3.0"

--- a/springwolf-examples/springwolf-cloud-stream-example/src/main/resources/application.properties
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/main/resources/application.properties
@@ -25,7 +25,7 @@ springwolf.docket.info.contact.email=example@example.com
 springwolf.docket.info.contact.url=https://github.com/springwolf/springwolf-core
 springwolf.docket.info.license.name=Apache License 2.0
 springwolf.docket.servers.kafka.protocol=kafka
-springwolf.docket.servers.kafka.url=${spring.kafka.bootstrap-servers}
+springwolf.docket.servers.kafka.host=${spring.kafka.bootstrap-servers}
 
 
 # For debugging purposes

--- a/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/stavshamir/springwolf/example/cloudstream/SpringContextIntegrationTest.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/stavshamir/springwolf/example/cloudstream/SpringContextIntegrationTest.java
@@ -29,7 +29,7 @@ public class SpringContextIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=kafka",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
             })
     class ApplicationPropertiesConfigurationTest {
 

--- a/springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json
@@ -1,5 +1,5 @@
 {
-  "asyncapi": "2.6.0",
+  "asyncapi": "3.0.0",
   "info": {
     "title": "Springwolf example project - Cloud Stream",
     "version": "1.0.0",
@@ -12,88 +12,127 @@
     "license": {
       "name": "Apache License 2.0"
     },
+    "tags": [],
     "x-generator": "springwolf"
   },
   "defaultContentType": "application/json",
   "servers": {
     "kafka": {
-      "url": "kafka:29092",
+      "host": "kafka:29092",
       "protocol": "kafka"
     }
   },
   "channels": {
     "another-topic": {
-      "subscribe": {
-        "operationId": "another-topic_subscribe_process",
-        "description": "Auto-generated description",
-        "bindings": {
-          "kafka": { }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+      "address": "another-topic",
+      "messages": {
+        "another-topic_publish_consumerMethod.message": {
           "name": "io.github.stavshamir.springwolf.example.cloudstream.dtos.AnotherPayloadDto",
           "title": "AnotherPayloadDto",
           "payload": {
-            "$ref": "#/components/schemas/AnotherPayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/AnotherPayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
           },
           "bindings": {
-            "kafka": { }
+            "kafka": {}
           }
-        }
-      },
-      "publish": {
-        "operationId": "another-topic_publish_consumerMethod",
-        "description": "Auto-generated description",
-        "bindings": {
-          "kafka": { }
         },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+        "another-topic_subscribe_process.message": {
           "name": "io.github.stavshamir.springwolf.example.cloudstream.dtos.AnotherPayloadDto",
           "title": "AnotherPayloadDto",
           "payload": {
-            "$ref": "#/components/schemas/AnotherPayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/AnotherPayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
           },
           "bindings": {
-            "kafka": { }
+            "kafka": {}
           }
         }
       },
       "bindings": {
-        "kafka": { }
+        "kafka": {}
       }
     },
     "example-topic": {
-      "publish": {
-        "operationId": "example-topic_publish_process",
-        "description": "Auto-generated description",
-        "bindings": {
-          "kafka": { }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+      "address": "example-topic",
+      "messages": {
+        "example-topic_publish_process.message": {
           "name": "io.github.stavshamir.springwolf.example.cloudstream.dtos.ExamplePayloadDto",
           "title": "ExamplePayloadDto",
           "payload": {
-            "$ref": "#/components/schemas/ExamplePayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/ExamplePayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
           },
           "bindings": {
-            "kafka": { }
+            "kafka": {}
           }
         }
       },
       "bindings": {
-        "kafka": { }
+        "kafka": {}
       }
+    }
+  },
+  "operations": {
+    "another-topic_publish_consumerMethod": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/another-topic"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "kafka": {}
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-topic/messages/another-topic_publish_consumerMethod.message"
+        }
+      ]
+    },
+    "another-topic_subscribe_process": {
+      "action": "send",
+      "channel": {
+        "$ref": "#/channels/another-topic"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "kafka": {}
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-topic/messages/another-topic_subscribe_process.message"
+        }
+      ]
+    },
+    "example-topic_publish_process": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/example-topic"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "kafka": {}
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/example-topic/messages/example-topic_publish_process.message"
+        }
+      ]
     }
   },
   "components": {
@@ -161,10 +200,9 @@
       },
       "HeadersNotDocumented": {
         "type": "object",
-        "properties": { },
-        "example": { }
+        "properties": {},
+        "example": {}
       }
     }
-  },
-  "tags": [ ]
+  }
 }

--- a/springwolf-examples/springwolf-jms-example/src/main/resources/application.properties
+++ b/springwolf-examples/springwolf-jms-example/src/main/resources/application.properties
@@ -23,7 +23,7 @@ springwolf.docket.info.contact.email=example@example.com
 springwolf.docket.info.contact.url=https://github.com/springwolf/springwolf-core
 springwolf.docket.info.license.name=Apache License 2.0
 springwolf.docket.servers.jms.protocol=jms
-springwolf.docket.servers.jms.url=${spring.artemis.broker-url}
+springwolf.docket.servers.jms.host=${spring.artemis.broker-url}
 springwolf.use-fqn=true
 
 springwolf.plugin.jms.publishing.enabled=true

--- a/springwolf-examples/springwolf-jms-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-jms-example/src/test/resources/asyncapi.json
@@ -1,5 +1,5 @@
 {
-  "asyncapi": "2.6.0",
+  "asyncapi": "3.0.0",
   "info": {
     "title": "Springwolf example project - JMS",
     "version": "1.0.0",
@@ -12,99 +12,138 @@
     "license": {
       "name": "Apache License 2.0"
     },
+    "tags": [],
     "x-generator": "springwolf"
   },
   "defaultContentType": "application/json",
   "servers": {
     "jms": {
-      "url": "tcp://activemq:61616",
+      "host": "activemq:61616",
       "protocol": "jms"
     }
   },
   "channels": {
     "another-queue": {
-      "subscribe": {
-        "operationId": "another-queue_subscribe",
-        "description": "Custom, optional description defined in the AsyncPublisher annotation",
-        "bindings": {
-          "jms": {
-            "internal-field": "customValue",
-            "nested": {
-              "key": "nestedValue"
+      "address": "another-queue",
+      "messages": {
+        "another-queue_publish_receiveAnotherPayload.message": {
+          "name": "io.github.stavshamir.springwolf.example.jms.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
+          "payload": {
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.jms.dtos.AnotherPayloadDto"
             }
+          },
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
+          "bindings": {
+            "jms": {}
           }
         },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+        "another-queue_subscribe.message": {
           "name": "io.github.stavshamir.springwolf.example.jms.dtos.AnotherPayloadDto",
           "title": "AnotherPayloadDto",
           "description": "Another payload model",
           "payload": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.jms.dtos.AnotherPayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.jms.dtos.AnotherPayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
           },
           "bindings": {
-            "jms": { }
-          }
-        }
-      },
-      "publish": {
-        "operationId": "another-queue_publish_receiveAnotherPayload",
-        "description": "Auto-generated description",
-        "bindings": {
-          "jms": { }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
-          "name": "io.github.stavshamir.springwolf.example.jms.dtos.AnotherPayloadDto",
-          "title": "AnotherPayloadDto",
-          "payload": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.jms.dtos.AnotherPayloadDto"
-          },
-          "headers": {
-            "$ref": "#/components/schemas/HeadersNotDocumented"
-          },
-          "bindings": {
-            "jms": { }
+            "jms": {}
           }
         }
       }
     },
     "example-queue": {
-      "publish": {
-        "operationId": "example-queue_publish_receiveExamplePayload",
-        "description": "Auto-generated description",
-        "bindings": {
-          "jms": { }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+      "address": "example-queue",
+      "messages": {
+        "example-queue_publish_receiveExamplePayload.message": {
           "name": "io.github.stavshamir.springwolf.example.jms.dtos.ExamplePayloadDto",
           "title": "ExamplePayloadDto",
           "payload": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.jms.dtos.ExamplePayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.jms.dtos.ExamplePayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
           },
           "bindings": {
-            "jms": { }
+            "jms": {}
           }
         }
       },
       "bindings": {
-        "jms": { }
+        "jms": {}
       }
+    }
+  },
+  "operations": {
+    "another-queue_publish_receiveAnotherPayload": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/another-queue"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "jms": {}
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-queue/messages/another-queue_publish_receiveAnotherPayload.message"
+        }
+      ]
+    },
+    "another-queue_subscribe": {
+      "action": "send",
+      "channel": {
+        "$ref": "#/channels/another-queue"
+      },
+      "description": "Custom, optional description defined in the AsyncPublisher annotation",
+      "bindings": {
+        "jms": {
+          "internal-field": "customValue",
+          "nested": {
+            "key": "nestedValue"
+          }
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-queue/messages/another-queue_subscribe.message"
+        }
+      ]
+    },
+    "example-queue_publish_receiveExamplePayload": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/example-queue"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "jms": {}
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/example-queue/messages/example-queue_publish_receiveExamplePayload.message"
+        }
+      ]
     }
   },
   "components": {
     "schemas": {
       "HeadersNotDocumented": {
         "type": "object",
-        "properties": { },
-        "example": { }
+        "properties": {},
+        "example": {}
       },
       "io.github.stavshamir.springwolf.example.jms.dtos.AnotherPayloadDto": {
         "required": [
@@ -168,6 +207,5 @@
         }
       }
     }
-  },
-  "tags": [ ]
+  }
 }

--- a/springwolf-examples/springwolf-kafka-example/src/main/resources/application.properties
+++ b/springwolf-examples/springwolf-kafka-example/src/main/resources/application.properties
@@ -41,7 +41,7 @@ springwolf.use-fqn=true
 
 # Springwolf kafka configuration
 springwolf.docket.servers.kafka.protocol=kafka
-springwolf.docket.servers.kafka.url=${spring.kafka.bootstrap-servers}
+springwolf.docket.servers.kafka.host=${spring.kafka.bootstrap-servers}
 springwolf.plugin.kafka.publishing.enabled=true
 springwolf.plugin.kafka.publishing.producer.bootstrap-servers=${BOOTSTRAP_SERVER_SASL:localhost:9093}
 springwolf.plugin.kafka.publishing.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/SpringContextIntegrationTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/stavshamir/springwolf/example/kafka/SpringContextIntegrationTest.java
@@ -29,7 +29,7 @@ public class SpringContextIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=kafka",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
             })
     class ApplicationPropertiesConfigurationTest {
 

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -1,5 +1,5 @@
 {
-  "asyncapi": "2.6.0",
+  "asyncapi": "3.0.0",
   "info": {
     "title": "Springwolf example project - Kafka",
     "version": "1.0.0",
@@ -12,37 +12,28 @@
     "license": {
       "name": "Apache License 2.0"
     },
+    "tags": [],
     "x-generator": "springwolf"
   },
   "defaultContentType": "application/json",
   "servers": {
     "kafka": {
-      "url": "kafka:29092",
+      "host": "kafka:29092",
       "protocol": "kafka"
     }
   },
   "channels": {
     "another-topic": {
-      "publish": {
-        "operationId": "another-topic_publish_receiveAnotherPayloadBatched",
-        "description": "Auto-generated description",
-        "bindings": {
-          "kafka": {
-            "groupId": {
-              "type": "string",
-              "enum": [
-                "example-group-id"
-              ]
-            },
-            "bindingVersion": "0.4.0"
-          }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+      "address": "another-topic",
+      "messages": {
+        "another-topic_publish_receiveAnotherPayloadBatched.message": {
           "name": "io.github.stavshamir.springwolf.example.kafka.dtos.AnotherPayloadDto",
           "title": "AnotherPayloadDto",
           "payload": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.kafka.dtos.AnotherPayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.kafka.dtos.AnotherPayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
@@ -61,20 +52,16 @@
       }
     },
     "example-topic": {
-      "publish": {
-        "operationId": "example-topic_publish_receiveExamplePayload",
-        "description": "Auto-generated description",
-        "bindings": {
-          "kafka": {
-            "bindingVersion": "0.4.0"
-          }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+      "address": "example-topic",
+      "messages": {
+        "example-topic_publish_receiveExamplePayload.message": {
           "name": "io.github.stavshamir.springwolf.example.kafka.dtos.ExamplePayloadDto",
           "title": "ExamplePayloadDto",
           "payload": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.kafka.dtos.ExamplePayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.kafka.dtos.ExamplePayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
@@ -93,100 +80,80 @@
       }
     },
     "multi-payload-topic": {
-      "publish": {
-        "operationId": "multi-payload-topic_publish",
-        "description": "Override description in the AsyncListener annotation with servers at kafka:29092",
-        "bindings": {
-          "kafka": {
-            "groupId": {
-              "type": "string",
-              "enum": [
-                "foo-groupId"
-              ]
-            },
-            "clientId": {
-              "type": "string",
-              "enum": [
-                "foo-clientId"
-              ]
-            },
-            "bindingVersion": "0.4.0"
+      "address": "multi-payload-topic",
+      "messages": {
+        "multi-payload-topic_publish.message.0": {
+          "name": "io.github.stavshamir.springwolf.example.kafka.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
+          "payload": {
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.kafka.dtos.AnotherPayloadDto"
+            }
+          },
+          "headers": {
+            "$ref": "#/components/schemas/SpringKafkaDefaultHeaders-AnotherPayloadDto"
+          },
+          "bindings": {
+            "kafka": {
+              "bindingVersion": "0.4.0"
+            }
           }
         },
-        "message": {
-          "oneOf": [
-            {
-              "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
-              "name": "io.github.stavshamir.springwolf.example.kafka.dtos.AnotherPayloadDto",
-              "title": "AnotherPayloadDto",
-              "payload": {
-                "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.kafka.dtos.AnotherPayloadDto"
-              },
-              "headers": {
-                "$ref": "#/components/schemas/SpringKafkaDefaultHeaders-AnotherPayloadDto"
-              },
-              "bindings": {
-                "kafka": {
-                  "bindingVersion": "0.4.0"
-                }
-              }
-            },
-            {
-              "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
-              "name": "io.github.stavshamir.springwolf.example.kafka.dtos.ExamplePayloadDto",
-              "title": "ExamplePayloadDto",
-              "payload": {
-                "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.kafka.dtos.ExamplePayloadDto"
-              },
-              "headers": {
-                "$ref": "#/components/schemas/SpringKafkaDefaultHeaders-ExamplePayloadDto"
-              },
-              "bindings": {
-                "kafka": {
-                  "bindingVersion": "0.4.0"
-                }
-              }
-            },
-            {
-              "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
-              "name": "javax.money.MonetaryAmount",
-              "title": "MonetaryAmount",
-              "payload": {
-                "$ref": "#/components/schemas/io.github.stavshamir.springwolf.addons.common_model_converters.converters.monetaryamount.MonetaryAmount"
-              },
-              "headers": {
-                "$ref": "#/components/schemas/SpringKafkaDefaultHeaders-MonetaryAmount"
-              },
-              "bindings": {
-                "kafka": {
-                  "key": {
-                    "type": "string",
-                    "description": "Kafka Consumer Message Key",
-                    "example": "example-key"
-                  },
-                  "bindingVersion": "0.4.0"
-                }
-              }
+        "multi-payload-topic_publish.message.1": {
+          "name": "io.github.stavshamir.springwolf.example.kafka.dtos.ExamplePayloadDto",
+          "title": "ExamplePayloadDto",
+          "payload": {
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.kafka.dtos.ExamplePayloadDto"
             }
-          ]
+          },
+          "headers": {
+            "$ref": "#/components/schemas/SpringKafkaDefaultHeaders-ExamplePayloadDto"
+          },
+          "bindings": {
+            "kafka": {
+              "bindingVersion": "0.4.0"
+            }
+          }
+        },
+        "multi-payload-topic_publish.message.2": {
+          "name": "javax.money.MonetaryAmount",
+          "title": "MonetaryAmount",
+          "payload": {
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.addons.common_model_converters.converters.monetaryamount.MonetaryAmount"
+            }
+          },
+          "headers": {
+            "$ref": "#/components/schemas/SpringKafkaDefaultHeaders-MonetaryAmount"
+          },
+          "bindings": {
+            "kafka": {
+              "key": {
+                "type": "string",
+                "description": "Kafka Consumer Message Key",
+                "example": "example-key"
+              },
+              "bindingVersion": "0.4.0"
+            }
+          }
         }
       }
     },
     "primitive-topic": {
-      "publish": {
-        "operationId": "primitive-topic_publish_receivePrimitivePayload",
-        "description": "Auto-generated description",
-        "bindings": {
-          "kafka": {
-            "bindingVersion": "0.4.0"
-          }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+      "address": "primitive-topic",
+      "messages": {
+        "primitive-topic_publish_receivePrimitivePayload.message": {
           "name": "java.lang.String",
           "title": "String",
           "payload": {
-            "$ref": "#/components/schemas/String"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/String"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
@@ -205,27 +172,17 @@
       }
     },
     "topic-defined-via-asyncPublisher-annotation": {
-      "subscribe": {
-        "operationId": "topic-defined-via-asyncPublisher-annotation_subscribe",
-        "description": "Custom, optional description defined in the AsyncPublisher annotation",
-        "bindings": {
-          "kafka": {
-            "clientId": {
-              "type": "string",
-              "enum": [
-                "foo-clientId"
-              ]
-            },
-            "bindingVersion": "0.4.0"
-          }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+      "address": "topic-defined-via-asyncPublisher-annotation",
+      "messages": {
+        "topic-defined-via-asyncPublisher-annotation_subscribe.message": {
           "name": "io.github.stavshamir.springwolf.example.kafka.dtos.NestedPayloadDto",
           "title": "NestedPayloadDto",
           "description": "Payload model with nested complex types",
           "payload": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.kafka.dtos.NestedPayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.kafka.dtos.NestedPayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/SpringDefaultHeaderAndCloudEvent"
@@ -244,12 +201,129 @@
       }
     }
   },
+  "operations": {
+    "another-topic_publish_receiveAnotherPayloadBatched": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/another-topic"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "kafka": {
+          "groupId": {
+            "type": "string",
+            "enum": [
+              "example-group-id"
+            ]
+          },
+          "bindingVersion": "0.4.0"
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-topic/messages/another-topic_publish_receiveAnotherPayloadBatched.message"
+        }
+      ]
+    },
+    "example-topic_publish_receiveExamplePayload": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/example-topic"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "kafka": {
+          "bindingVersion": "0.4.0"
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/example-topic/messages/example-topic_publish_receiveExamplePayload.message"
+        }
+      ]
+    },
+    "multi-payload-topic_publish": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/multi-payload-topic"
+      },
+      "description": "Override description in the AsyncListener annotation with servers at kafka:29092",
+      "bindings": {
+        "kafka": {
+          "groupId": {
+            "type": "string",
+            "enum": [
+              "foo-groupId"
+            ]
+          },
+          "clientId": {
+            "type": "string",
+            "enum": [
+              "foo-clientId"
+            ]
+          },
+          "bindingVersion": "0.4.0"
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/multi-payload-topic/messages/multi-payload-topic_publish.message.0"
+        },
+        {
+          "$ref": "#/channels/multi-payload-topic/messages/multi-payload-topic_publish.message.1"
+        },
+        {
+          "$ref": "#/channels/multi-payload-topic/messages/multi-payload-topic_publish.message.2"
+        }
+      ]
+    },
+    "primitive-topic_publish_receivePrimitivePayload": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/primitive-topic"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "kafka": {
+          "bindingVersion": "0.4.0"
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/primitive-topic/messages/primitive-topic_publish_receivePrimitivePayload.message"
+        }
+      ]
+    },
+    "topic-defined-via-asyncPublisher-annotation_subscribe": {
+      "action": "send",
+      "channel": {
+        "$ref": "#/channels/topic-defined-via-asyncPublisher-annotation"
+      },
+      "description": "Custom, optional description defined in the AsyncPublisher annotation",
+      "bindings": {
+        "kafka": {
+          "clientId": {
+            "type": "string",
+            "enum": [
+              "foo-clientId"
+            ]
+          },
+          "bindingVersion": "0.4.0"
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/topic-defined-via-asyncPublisher-annotation/messages/topic-defined-via-asyncPublisher-annotation_subscribe.message"
+        }
+      ]
+    }
+  },
   "components": {
     "schemas": {
       "HeadersNotDocumented": {
         "type": "object",
-        "properties": { },
-        "example": { },
+        "properties": {},
+        "example": {},
         "x-json-schema": {
           "$schema": "https://json-schema.org/draft-04/schema#",
           "name": "HeadersNotDocumented",
@@ -710,7 +784,7 @@
           "name": "io.github.stavshamir.springwolf.example.kafka.dtos.NestedPayloadDto",
           "properties": {
             "examplePayloads": {
-              "items": { },
+              "items": {},
               "name": "examplePayloads",
               "type": "array"
             },
@@ -728,6 +802,5 @@
         }
       }
     }
-  },
-  "tags": [ ]
+  }
 }

--- a/springwolf-examples/springwolf-sns-example/src/main/resources/application.properties
+++ b/springwolf-examples/springwolf-sns-example/src/main/resources/application.properties
@@ -26,7 +26,7 @@ springwolf.docket.info.contact.email=example@example.com
 springwolf.docket.info.contact.url=https://github.com/springwolf/springwolf-core
 springwolf.docket.info.license.name=Apache License 2.0
 springwolf.docket.servers.sns.protocol=sns
-springwolf.docket.servers.sns.url=http://localhost:4566
+springwolf.docket.servers.sns.host=http://localhost:4566
 springwolf.use-fqn=true
 
 springwolf.plugin.sns.publishing.enabled=true

--- a/springwolf-examples/springwolf-sns-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-sns-example/src/test/resources/asyncapi.json
@@ -12,7 +12,6 @@
     "license": {
       "name": "Apache License 2.0"
     },
-    "tags": [],
     "x-generator": "springwolf"
   },
   "defaultContentType": "application/json",
@@ -83,83 +82,6 @@
           }
         }
       }
-    }
-  },
-  "operations": {
-    "another-topic_publish": {
-      "action": "receive",
-      "channel": {
-        "$ref": "#/channels/another-topic"
-      },
-      "description": "Auto-generated description",
-      "bindings": {
-        "sns": {
-          "consumers": [
-            {
-              "protocol": "sqs",
-              "endpoint": {
-                "name": "myQueue"
-              },
-              "rawMessageDelivery": false
-            }
-          ]
-        }
-      },
-      "messages": [
-        {
-          "$ref": "#/channels/another-topic/messages/another-topic_publish.message"
-        }
-      ]
-    },
-    "another-topic_subscribe": {
-      "action": "send",
-      "channel": {
-        "$ref": "#/channels/another-topic"
-      },
-      "description": "Custom, optional description defined in the AsyncPublisher annotation",
-      "bindings": {
-        "sns": {
-          "consumers": [
-            {
-              "protocol": "sqs",
-              "endpoint": {
-                "name": "myQueue"
-              },
-              "rawMessageDelivery": false
-            }
-          ]
-        }
-      },
-      "messages": [
-        {
-          "$ref": "#/channels/another-topic/messages/another-topic_subscribe.message"
-        }
-      ]
-    },
-    "example-topic_publish": {
-      "action": "receive",
-      "channel": {
-        "$ref": "#/channels/example-topic"
-      },
-      "description": "Auto-generated description",
-      "bindings": {
-        "sns": {
-          "consumers": [
-            {
-              "protocol": "sqs",
-              "endpoint": {
-                "name": "myQueue"
-              },
-              "rawMessageDelivery": false
-            }
-          ]
-        }
-      },
-      "messages": [
-        {
-          "$ref": "#/channels/example-topic/messages/example-topic_publish.message"
-        }
-      ]
     }
   },
   "components": {
@@ -316,6 +238,83 @@
           "type": "object"
         }
       }
+    }
+  },
+  "operations": {
+    "another-topic_publish": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/another-topic"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "sns": {
+          "consumers": [
+            {
+              "protocol": "sqs",
+              "endpoint": {
+                "name": "myQueue"
+              },
+              "rawMessageDelivery": false
+            }
+          ]
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-topic/messages/another-topic_publish.message"
+        }
+      ]
+    },
+    "another-topic_subscribe": {
+      "action": "send",
+      "channel": {
+        "$ref": "#/channels/another-topic"
+      },
+      "description": "Custom, optional description defined in the AsyncPublisher annotation",
+      "bindings": {
+        "sns": {
+          "consumers": [
+            {
+              "protocol": "sqs",
+              "endpoint": {
+                "name": "myQueue"
+              },
+              "rawMessageDelivery": false
+            }
+          ]
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-topic/messages/another-topic_subscribe.message"
+        }
+      ]
+    },
+    "example-topic_publish": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/example-topic"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "sns": {
+          "consumers": [
+            {
+              "protocol": "sqs",
+              "endpoint": {
+                "name": "myQueue"
+              },
+              "rawMessageDelivery": false
+            }
+          ]
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/example-topic/messages/example-topic_publish.message"
+        }
+      ]
     }
   }
 }

--- a/springwolf-examples/springwolf-sns-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-sns-example/src/test/resources/asyncapi.json
@@ -1,5 +1,5 @@
 {
-  "asyncapi": "2.6.0",
+  "asyncapi": "3.0.0",
   "info": {
     "title": "Springwolf example project - SNS",
     "version": "1.0.0",
@@ -12,93 +12,162 @@
     "license": {
       "name": "Apache License 2.0"
     },
+    "tags": [],
     "x-generator": "springwolf"
   },
   "defaultContentType": "application/json",
   "servers": {
     "sns": {
-      "url": "http://localhost:4566",
+      "host": "localhost:4566",
       "protocol": "sns"
     }
   },
   "channels": {
     "another-topic": {
-      "subscribe": {
-        "operationId": "another-topic_subscribe",
-        "description": "Custom, optional description defined in the AsyncPublisher annotation",
-        "bindings": {
-          "sns": { }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+      "address": "another-topic",
+      "messages": {
+        "another-topic_publish.message": {
           "name": "io.github.stavshamir.springwolf.example.sns.dtos.AnotherPayloadDto",
           "title": "AnotherPayloadDto",
           "description": "Another payload model",
           "payload": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sns.dtos.AnotherPayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sns.dtos.AnotherPayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
           },
           "bindings": {
-            "sns": { }
+            "sns": {}
           }
-        }
-      },
-      "publish": {
-        "operationId": "another-topic_publish",
-        "description": "Auto-generated description",
-        "bindings": {
-          "sns": { }
         },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+        "another-topic_subscribe.message": {
           "name": "io.github.stavshamir.springwolf.example.sns.dtos.AnotherPayloadDto",
           "title": "AnotherPayloadDto",
           "description": "Another payload model",
           "payload": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sns.dtos.AnotherPayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sns.dtos.AnotherPayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
           },
           "bindings": {
-            "sns": { }
+            "sns": {}
           }
         }
       }
     },
     "example-topic": {
-      "publish": {
-        "operationId": "example-topic_publish",
-        "description": "Auto-generated description",
-        "bindings": {
-          "sns": { }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+      "address": "example-topic",
+      "messages": {
+        "example-topic_publish.message": {
           "name": "io.github.stavshamir.springwolf.example.sns.dtos.ExamplePayloadDto",
           "title": "ExamplePayloadDto",
           "description": "Example payload model",
           "payload": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sns.dtos.ExamplePayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sns.dtos.ExamplePayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
           },
           "bindings": {
-            "sns": { }
+            "sns": {}
           }
         }
       }
+    }
+  },
+  "operations": {
+    "another-topic_publish": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/another-topic"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "sns": {
+          "consumers": [
+            {
+              "protocol": "sqs",
+              "endpoint": {
+                "name": "myQueue"
+              },
+              "rawMessageDelivery": false
+            }
+          ]
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-topic/messages/another-topic_publish.message"
+        }
+      ]
+    },
+    "another-topic_subscribe": {
+      "action": "send",
+      "channel": {
+        "$ref": "#/channels/another-topic"
+      },
+      "description": "Custom, optional description defined in the AsyncPublisher annotation",
+      "bindings": {
+        "sns": {
+          "consumers": [
+            {
+              "protocol": "sqs",
+              "endpoint": {
+                "name": "myQueue"
+              },
+              "rawMessageDelivery": false
+            }
+          ]
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-topic/messages/another-topic_subscribe.message"
+        }
+      ]
+    },
+    "example-topic_publish": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/example-topic"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "sns": {
+          "consumers": [
+            {
+              "protocol": "sqs",
+              "endpoint": {
+                "name": "myQueue"
+              },
+              "rawMessageDelivery": false
+            }
+          ]
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/example-topic/messages/example-topic_publish.message"
+        }
+      ]
     }
   },
   "components": {
     "schemas": {
       "HeadersNotDocumented": {
         "type": "object",
-        "properties": { },
-        "example": { },
+        "properties": {},
+        "example": {},
         "x-json-schema": {
           "$schema": "https://json-schema.org/draft-04/schema#",
           "name": "HeadersNotDocumented",
@@ -248,6 +317,5 @@
         }
       }
     }
-  },
-  "tags": [ ]
+  }
 }

--- a/springwolf-examples/springwolf-sqs-example/src/main/resources/application.properties
+++ b/springwolf-examples/springwolf-sqs-example/src/main/resources/application.properties
@@ -26,7 +26,7 @@ springwolf.docket.info.contact.email=example@example.com
 springwolf.docket.info.contact.url=https://github.com/springwolf/springwolf-core
 springwolf.docket.info.license.name=Apache License 2.0
 springwolf.docket.servers.sqs.protocol=sqs
-springwolf.docket.servers.sqs.url=http://localhost:4566
+springwolf.docket.servers.sqs.host=http://localhost:4566
 springwolf.use-fqn=true
 
 springwolf.plugin.sqs.publishing.enabled=true

--- a/springwolf-examples/springwolf-sqs-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-sqs-example/src/test/resources/asyncapi.json
@@ -88,68 +88,6 @@
       }
     }
   },
-  "operations": {
-    "another-queue_publish_receiveAnotherPayload": {
-      "action": "receive",
-      "channel": {
-        "$ref": "#/channels/another-queue"
-      },
-      "description": "Auto-generated description",
-      "bindings": {
-        "sqs": {
-          "queues": [{
-            "name": "another-queue",
-            "fifoQueue": true,
-          }]
-        }
-      },
-      "messages": [
-        {
-          "$ref": "#/channels/another-queue/messages/another-queue_publish_receiveAnotherPayload.message"
-        }
-      ]
-    },
-    "another-queue_subscribe": {
-      "action": "send",
-      "channel": {
-        "$ref": "#/channels/another-queue"
-      },
-      "description": "Custom, optional description defined in the AsyncPublisher annotation",
-      "bindings": {
-        "sqs": {
-          "queues": [{
-            "name": "another-queue",
-            "fifoQueue": true,
-          }]
-        }
-      },
-      "messages": [
-        {
-          "$ref": "#/channels/another-queue/messages/another-queue_subscribe.message"
-        }
-      ]
-    },
-    "example-queue_publish_receiveExamplePayload": {
-      "action": "receive",
-      "channel": {
-        "$ref": "#/channels/example-queue"
-      },
-      "description": "Auto-generated description",
-      "bindings": {
-        "sqs": {
-          "queues": [{
-            "name": "another-queue",
-            "fifoQueue": true,
-          }]
-        }
-      },
-      "messages": [
-        {
-          "$ref": "#/channels/example-queue/messages/example-queue_publish_receiveExamplePayload.message"
-        }
-      ]
-    }
-  },
   "components": {
     "schemas": {
       "HeadersNotDocumented": {
@@ -218,6 +156,68 @@
           "someString": "some string value"
         }
       }
+    }
+  },
+  "operations": {
+    "another-queue_publish_receiveAnotherPayload": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/another-queue"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "sqs": {
+          "queues": [{
+            "name": "another-queue",
+            "fifoQueue": true,
+          }]
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-queue/messages/another-queue_publish_receiveAnotherPayload.message"
+        }
+      ]
+    },
+    "another-queue_subscribe": {
+      "action": "send",
+      "channel": {
+        "$ref": "#/channels/another-queue"
+      },
+      "description": "Custom, optional description defined in the AsyncPublisher annotation",
+      "bindings": {
+        "sqs": {
+          "queues": [{
+            "name": "another-queue",
+            "fifoQueue": true,
+          }]
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-queue/messages/another-queue_subscribe.message"
+        }
+      ]
+    },
+    "example-queue_publish_receiveExamplePayload": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/example-queue"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "sqs": {
+          "queues": [{
+            "name": "another-queue",
+            "fifoQueue": true,
+          }]
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/example-queue/messages/example-queue_publish_receiveExamplePayload.message"
+        }
+      ]
     }
   }
 }

--- a/springwolf-examples/springwolf-sqs-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-sqs-example/src/test/resources/asyncapi.json
@@ -12,49 +12,47 @@
     "license": {
       "name": "Apache License 2.0"
     },
-    "tags": [],
     "x-generator": "springwolf"
   },
   "defaultContentType": "application/json",
   "servers": {
     "sqs": {
-      "host": "localhost:4566",
+      "host": "http://localhost:4566",
       "protocol": "sqs"
     }
   },
   "channels": {
     "another-queue": {
-      "address": "another-queue",
       "messages": {
         "another-queue_publish_receiveAnotherPayload.message": {
-          "name": "io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto",
-          "title": "AnotherPayloadDto",
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
           "payload": {
-            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto"
             }
           },
-          "headers": {
-            "$ref": "#/components/schemas/HeadersNotDocumented"
-          },
+          "name": "io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
           "bindings": {
             "sqs": {}
           }
         },
         "another-queue_subscribe.message": {
-          "name": "io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto",
-          "title": "AnotherPayloadDto",
           "description": "Another payload model",
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
           "payload": {
-            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto"
             }
           },
-          "headers": {
-            "$ref": "#/components/schemas/HeadersNotDocumented"
-          },
+          "name": "io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
           "bindings": {
             "sqs": {}
           }
@@ -62,20 +60,19 @@
       }
     },
     "example-queue": {
-      "address": "example-queue",
       "messages": {
         "example-queue_publish_receiveExamplePayload.message": {
-          "name": "io.github.stavshamir.springwolf.example.sqs.dtos.ExamplePayloadDto",
-          "title": "ExamplePayloadDto",
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
           "payload": {
-            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schemaFormat": "application/vnd.aai.asyncapi+json;version=3.0.0",
             "schema": {
               "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sqs.dtos.ExamplePayloadDto"
             }
           },
-          "headers": {
-            "$ref": "#/components/schemas/HeadersNotDocumented"
-          },
+          "name": "io.github.stavshamir.springwolf.example.sqs.dtos.ExamplePayloadDto",
+          "title": "ExamplePayloadDto",
           "bindings": {
             "sqs": {}
           }

--- a/springwolf-examples/springwolf-sqs-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-sqs-example/src/test/resources/asyncapi.json
@@ -1,5 +1,5 @@
 {
-  "asyncapi": "2.6.0",
+  "asyncapi": "3.0.0",
   "info": {
     "title": "Springwolf example project - SQS",
     "version": "1.0.0",
@@ -12,99 +12,153 @@
     "license": {
       "name": "Apache License 2.0"
     },
+    "tags": [],
     "x-generator": "springwolf"
   },
   "defaultContentType": "application/json",
   "servers": {
     "sqs": {
-      "url": "http://localhost:4566",
+      "host": "localhost:4566",
       "protocol": "sqs"
     }
   },
   "channels": {
     "another-queue": {
-      "subscribe": {
-        "operationId": "another-queue_subscribe",
-        "description": "Custom, optional description defined in the AsyncPublisher annotation",
-        "bindings": {
-          "sqs": {
-            "internal-field": "customValue",
-            "nested": {
-              "key": "nestedValue"
+      "address": "another-queue",
+      "messages": {
+        "another-queue_publish_receiveAnotherPayload.message": {
+          "name": "io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto",
+          "title": "AnotherPayloadDto",
+          "payload": {
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto"
             }
+          },
+          "headers": {
+            "$ref": "#/components/schemas/HeadersNotDocumented"
+          },
+          "bindings": {
+            "sqs": {}
           }
         },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+        "another-queue_subscribe.message": {
           "name": "io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto",
           "title": "AnotherPayloadDto",
           "description": "Another payload model",
           "payload": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
           },
           "bindings": {
-            "sqs": { }
-          }
-        }
-      },
-      "publish": {
-        "operationId": "another-queue_publish_receiveAnotherPayload",
-        "description": "Auto-generated description",
-        "bindings": {
-          "sqs": { }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
-          "name": "io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto",
-          "title": "AnotherPayloadDto",
-          "payload": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto"
-          },
-          "headers": {
-            "$ref": "#/components/schemas/HeadersNotDocumented"
-          },
-          "bindings": {
-            "sqs": { }
+            "sqs": {}
           }
         }
       }
     },
     "example-queue": {
-      "publish": {
-        "operationId": "example-queue_publish_receiveExamplePayload",
-        "description": "Auto-generated description",
-        "bindings": {
-          "sqs": { }
-        },
-        "message": {
-          "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+      "address": "example-queue",
+      "messages": {
+        "example-queue_publish_receiveExamplePayload.message": {
           "name": "io.github.stavshamir.springwolf.example.sqs.dtos.ExamplePayloadDto",
           "title": "ExamplePayloadDto",
           "payload": {
-            "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sqs.dtos.ExamplePayloadDto"
+            "schemaFormat": "application/vnd.oai.openapi+json;version=3.0.0",
+            "schema": {
+              "$ref": "#/components/schemas/io.github.stavshamir.springwolf.example.sqs.dtos.ExamplePayloadDto"
+            }
           },
           "headers": {
             "$ref": "#/components/schemas/HeadersNotDocumented"
           },
           "bindings": {
-            "sqs": { }
+            "sqs": {}
           }
         }
       },
       "bindings": {
-        "sqs": { }
+        "sqs": {
+          "queue": {
+            "name": "example-queue",
+            "fifoQueue": true,
+          }
+        }
       }
+    }
+  },
+  "operations": {
+    "another-queue_publish_receiveAnotherPayload": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/another-queue"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "sqs": {
+          "queues": [{
+            "name": "another-queue",
+            "fifoQueue": true,
+          }]
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-queue/messages/another-queue_publish_receiveAnotherPayload.message"
+        }
+      ]
+    },
+    "another-queue_subscribe": {
+      "action": "send",
+      "channel": {
+        "$ref": "#/channels/another-queue"
+      },
+      "description": "Custom, optional description defined in the AsyncPublisher annotation",
+      "bindings": {
+        "sqs": {
+          "queues": [{
+            "name": "another-queue",
+            "fifoQueue": true,
+          }]
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/another-queue/messages/another-queue_subscribe.message"
+        }
+      ]
+    },
+    "example-queue_publish_receiveExamplePayload": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/example-queue"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "sqs": {
+          "queues": [{
+            "name": "another-queue",
+            "fifoQueue": true,
+          }]
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/example-queue/messages/example-queue_publish_receiveExamplePayload.message"
+        }
+      ]
     }
   },
   "components": {
     "schemas": {
       "HeadersNotDocumented": {
         "type": "object",
-        "properties": { },
-        "example": { }
+        "properties": {},
+        "example": {}
       },
       "io.github.stavshamir.springwolf.example.sqs.dtos.AnotherPayloadDto": {
         "required": [
@@ -168,6 +222,5 @@
         }
       }
     }
-  },
-  "tags": [ ]
+  }
 }

--- a/springwolf-plugins/springwolf-amqp-plugin/README.md
+++ b/springwolf-plugins/springwolf-amqp-plugin/README.md
@@ -42,7 +42,7 @@ springwolf.docket.info.title=${spring.application.name}
 springwolf.docket.info.version=1.0.0
 
 springwolf.docket.servers.amqp.protocol=amqp
-springwolf.docket.servers.amqp.url=amqp:5672
+springwolf.docket.servers.amqp.host=amqp:5672
 ```
 
 The basePackage field must be set with the name of the package containing the classes to be scanned for `@RabbitListener`

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/RabbitListenerUtil.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/RabbitListenerUtil.java
@@ -117,7 +117,6 @@ public class RabbitListenerUtil {
                     .build();
         }
 
-        // FIXME: Should be converted to the proper enum
         var type = Stream.of(annotation.bindings())
                 .map(it -> it.exchange().type())
                 .findFirst()

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducer.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducer.java
@@ -33,8 +33,13 @@ public class SpringwolfAmqpProducer {
         AsyncAPI asyncAPI = asyncApiService.getAsyncAPI();
         ChannelObject channelItem = asyncAPI.getChannels().get(channelName);
 
+        Operation operation = null;
+        if (asyncAPI.getOperations() != null) {
+            operation = asyncAPI.getOperations().get("amqp");
+        }
+
         String exchange = getExchangeName(channelItem);
-        String routingKey = getRoutingKey(channelItem);
+        String routingKey = getRoutingKey(operation);
         if (routingKey.isEmpty() && exchange.isEmpty()) {
             routingKey = channelName;
         }
@@ -60,12 +65,8 @@ public class SpringwolfAmqpProducer {
         return exchange;
     }
 
-    private String getRoutingKey(ChannelObject channelItem) {
+    private String getRoutingKey(Operation operation) {
         String routingKey = "";
-        // FIXME
-        //  Operation operation =
-        //          channelItem.getSubscribe() != null ? channelItem.getSubscribe() : channelItem.getPublish();
-        Operation operation = Operation.builder().build();
         if (operation != null
                 && operation.getBindings() != null
                 && operation.getBindings().containsKey("amqp")) {

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducer.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducer.java
@@ -63,8 +63,8 @@ public class SpringwolfAmqpProducer {
     private String getRoutingKey(ChannelObject channelItem) {
         String routingKey = "";
         // FIXME
-        //        Operation operation =
-        //                channelItem.getSubscribe() != null ? channelItem.getSubscribe() : channelItem.getPublish();
+        //  Operation operation =
+        //          channelItem.getSubscribe() != null ? channelItem.getSubscribe() : channelItem.getPublish();
         Operation operation = Operation.builder().build();
         if (operation != null
                 && operation.getBindings() != null

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/bindings/processor/AmqpOperationBindingProcessorTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/bindings/processor/AmqpOperationBindingProcessorTest.java
@@ -6,6 +6,8 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.amqp.AMQPOperationBinding;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AmqpOperationBindingProcessorTest {
@@ -21,9 +23,14 @@ class AmqpOperationBindingProcessorTest {
 
         assertThat(binding.getType()).isEqualTo("amqp");
         assertThat(binding.getBinding())
-                .isEqualTo(AMQPOperationBinding.builder().build());
-        //                        new AMQPOperationBinding(0, null, List.of(), 0, 0, false, null, null, false, false,
-        // "0.2.0")
+                .isEqualTo(AMQPOperationBinding.builder()
+                        .cc(List.of())
+                        .priority(0)
+                        .deliveryMode(0)
+                        .mandatory(false)
+                        .timestamp(false)
+                        .ack(false)
+                        .build());
     }
 
     @AmqpAsyncOperationBinding

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/RabbitListenerUtilTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/RabbitListenerUtilTest.java
@@ -40,7 +40,7 @@ class RabbitListenerUtilTest {
             new RabbitListenerUtil.RabbitListenerUtilContext(emptyMap(), emptyMap(), emptyMap());
 
     @Nested
-    public class QueuesConfiguration {
+    class QueuesConfiguration {
 
         @ParameterizedTest
         @ValueSource(classes = {ClassWithQueuesConfiguration.class, ClassWithQueuesToDeclare.class})
@@ -429,7 +429,7 @@ class RabbitListenerUtilTest {
     }
 
     @Nested
-    public class RabbitListenerUtilContextTest {
+    class RabbitListenerUtilContextTest {
         @Test
         void testEmptyContext() {
             // when

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfAmqpProducerConfigurationIntegrationTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfAmqpProducerConfigurationIntegrationTest.java
@@ -40,7 +40,7 @@ public class SpringwolfAmqpProducerConfigurationIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
                 "springwolf.plugin.amqp.publishing.enabled=true"
             })
     @MockBeans(
@@ -81,7 +81,7 @@ public class SpringwolfAmqpProducerConfigurationIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
                 "springwolf.plugin.amqp.publishing.enabled=false"
             })
     @MockBeans(

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducerTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducerTest.java
@@ -7,8 +7,10 @@ import io.github.stavshamir.springwolf.asyncapi.v3.bindings.amqp.AMQPChannelBind
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.amqp.AMQPChannelExchangeProperties;
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.amqp.AMQPOperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.info.Info;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.OperationAction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -57,17 +59,16 @@ class SpringwolfAmqpProducerTest {
         AMQPChannelExchangeProperties properties = new AMQPChannelExchangeProperties();
         properties.setName("exchange-name");
         ChannelObject channelItem = ChannelObject.builder()
+                .channelId("channel-name")
                 .bindings(Map.of(
                         "amqp",
                         AMQPChannelBinding.builder().exchange(properties).build()))
-                // FIXME
-                //                .publish(Operation.builder()
-                //                        .bindings(Map.of("amqp", new AMQPOperationBinding()))
-                //                        .build())
                 .build();
-        Map<String, ChannelObject> channels = Map.of("channel-name", channelItem);
+        Map<String, ChannelObject> channels = Map.of(channelItem.getChannelId(), channelItem);
         Operation operation = Operation.builder()
+                .action(OperationAction.SEND)
                 .bindings(Map.of("amqp", AMQPOperationBinding.builder().build()))
+                .channel(ChannelReference.fromChannel(channelItem))
                 .build();
         Map<String, Operation> operations = Map.of("amqp", operation);
 
@@ -89,6 +90,7 @@ class SpringwolfAmqpProducerTest {
         AMQPChannelExchangeProperties properties = new AMQPChannelExchangeProperties();
         properties.setName("exchange-name");
         ChannelObject channelItem = ChannelObject.builder()
+                .channelId("channel-name")
                 .bindings(Map.of(
                         "amqp",
                         AMQPChannelBinding.builder().exchange(properties).build()))
@@ -101,7 +103,7 @@ class SpringwolfAmqpProducerTest {
                 //                                        .build()))
                 //                        .build())
                 .build();
-        Map<String, ChannelObject> channels = Map.of("channel-name", channelItem);
+        Map<String, ChannelObject> channels = Map.of(channelItem.getChannelId(), channelItem);
         Operation operation = Operation.builder()
                 .bindings(Map.of(
                         "amqp",

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducerTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/stavshamir/springwolf/producer/SpringwolfAmqpProducerTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +36,7 @@ class SpringwolfAmqpProducerTest {
         asyncApiService = mock(AsyncApiService.class);
         rabbitTemplate = mock(RabbitTemplate.class);
 
-        springwolfAmqpProducer = new SpringwolfAmqpProducer(asyncApiService, Collections.singletonList(rabbitTemplate));
+        springwolfAmqpProducer = new SpringwolfAmqpProducer(asyncApiService, List.of(rabbitTemplate));
     }
 
     @Test

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScanner.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScanner.java
@@ -16,6 +16,7 @@ import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.Message
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.server.Server;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
@@ -40,14 +41,20 @@ public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
     private final FunctionalChannelBeanBuilder functionalChannelBeanBuilder;
 
     @Override
-    public Map<String, ChannelObject> scan() {
+    public Map<String, ChannelObject> scanChannels() {
         Set<Method> beanMethods = beanMethodsScanner.getBeanMethods();
-        return ChannelMerger.merge(beanMethods.stream()
+        return ChannelMerger.mergeChannels(beanMethods.stream()
                 .map(functionalChannelBeanBuilder::fromMethodBean)
                 .flatMap(Set::stream)
                 .filter(this::isChannelBean)
                 .map(this::toChannelEntry)
                 .collect(Collectors.toList()));
+    }
+
+    @Override
+    public Map<String, Operation> scanOperations() {
+        // FIXME
+        return Map.of();
     }
 
     private boolean isChannelBean(FunctionalChannelBeanData beanData) {

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScannerIntegrationTest.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScannerIntegrationTest.java
@@ -66,7 +66,7 @@ import static org.mockito.Mockito.when;
             "springwolf.docket.info.version=1.0.0",
             "springwolf.docket.base-package=io.github.stavshamir.springwolf.asyncapi.scanners.channels.cloudstream",
             "springwolf.docket.servers.kafka.protocol=kafka",
-            "springwolf.docket.servers.kafka.url=kafka:9092",
+            "springwolf.docket.servers.kafka.host=kafka:9092",
         })
 @EnableConfigurationProperties
 @Import(CloudStreamFunctionChannelsScannerIntegrationTest.Configuration.class)

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScannerIntegrationTest.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScannerIntegrationTest.java
@@ -85,7 +85,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
     @Test
     void testNoBindings() {
         when(bindingServiceProperties.getBindings()).thenReturn(Collections.emptyMap());
-        Map<String, ChannelObject> channels = scanner.scan();
+        Map<String, ChannelObject> channels = scanner.scanChannels();
         assertThat(channels).isEmpty();
     }
 
@@ -98,7 +98,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
         when(bindingServiceProperties.getBindings()).thenReturn(Map.of("testConsumer-in-0", testConsumerInBinding));
 
         // When scan is called
-        Map<String, ChannelObject> channels = scanner.scan();
+        Map<String, ChannelObject> channels = scanner.scanChannels();
 
         // Then the returned channels contain a ChannelItem with the correct data
         MessageObject message = MessageObject.builder()
@@ -133,7 +133,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
         when(bindingServiceProperties.getBindings()).thenReturn(Map.of("testSupplier-out-0", testSupplierOutBinding));
 
         // When scan is called
-        Map<String, ChannelObject> channels = scanner.scan();
+        Map<String, ChannelObject> channels = scanner.scanChannels();
 
         // Then the returned channels contain a ChannelItem with the correct data
 
@@ -177,7 +177,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
                         "testFunction-out-0", testFunctionOutBinding));
 
         // When scan is called
-        Map<String, ChannelObject> channels = scanner.scan();
+        Map<String, ChannelObject> channels = scanner.scanChannels();
 
         // Then the returned channels contain a publish ChannelItem and a subscribe ChannelItem
         MessageObject subscribeMessage = MessageObject.builder()
@@ -241,7 +241,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
                         "kStreamTestFunction-out-0", testFunctionOutBinding));
 
         // When scan is called
-        Map<String, ChannelObject> channels = scanner.scan();
+        Map<String, ChannelObject> channels = scanner.scanChannels();
 
         // Then the returned channels contain a publish ChannelItem and a subscribe ChannelItem
         MessageObject subscribeMessage = MessageObject.builder()
@@ -304,7 +304,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
                         "testFunction-out-0", testFunctionOutBinding));
 
         // When scan is called
-        Map<String, ChannelObject> channels = scanner.scan();
+        Map<String, ChannelObject> channels = scanner.scanChannels();
 
         // Then the returned merged channels contain a publish operation and  a subscribe operation
         MessageObject subscribeMessage = MessageObject.builder()

--- a/springwolf-plugins/springwolf-jms-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/SpringwolfJmsControllerIntegrationTest.java
+++ b/springwolf-plugins/springwolf-jms-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/SpringwolfJmsControllerIntegrationTest.java
@@ -53,7 +53,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
             "springwolf.docket.info.title=Title",
             "springwolf.docket.info.version=1.0",
             "springwolf.docket.servers.jms.protocol=jms",
-            "springwolf.docket.servers.jms.url=127.0.0.1",
+            "springwolf.docket.servers.jms.host=127.0.0.1",
             "springwolf.plugin.jms.publishing.enabled=true",
             "springwolf.use-fqn=true"
         })

--- a/springwolf-plugins/springwolf-jms-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfJmsProducerConfigurationIntegrationTest.java
+++ b/springwolf-plugins/springwolf-jms-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfJmsProducerConfigurationIntegrationTest.java
@@ -41,7 +41,7 @@ public class SpringwolfJmsProducerConfigurationIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
                 "springwolf.plugin.jms.publishing.enabled=true"
             })
     @MockBeans(
@@ -82,7 +82,7 @@ public class SpringwolfJmsProducerConfigurationIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
                 "springwolf.plugin.jms.publishing.enabled=false"
             })
     @MockBeans(

--- a/springwolf-plugins/springwolf-kafka-plugin/README.md
+++ b/springwolf-plugins/springwolf-kafka-plugin/README.md
@@ -44,7 +44,7 @@ springwolf.docket.info.title=${spring.application.name}
 springwolf.docket.info.version=1.0.0
 
 springwolf.docket.servers.kafka.protocol=kafka
-springwolf.docket.servers.kafka.url=${kafka.bootstrap.servers:localhost:29092}
+springwolf.docket.servers.kafka.host=${kafka.bootstrap.servers:localhost:29092}
 ```
 
 The basePackage field must be set with the name of the package containing the classes to be scanned for `@KafkaListener`

--- a/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/SpringwolfKafkaControllerIntegrationTest.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/controller/SpringwolfKafkaControllerIntegrationTest.java
@@ -53,7 +53,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
             "springwolf.docket.info.title=Title",
             "springwolf.docket.info.version=1.0",
             "springwolf.docket.servers.kafka.protocol=kafka",
-            "springwolf.docket.servers.kafka.url=127.0.0.1",
+            "springwolf.docket.servers.kafka.host=127.0.0.1",
             "springwolf.plugin.kafka.publishing.enabled=true",
             "springwolf.use-fqn=true"
         })

--- a/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfKafkaProducerConfigurationIntegrationTest.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfKafkaProducerConfigurationIntegrationTest.java
@@ -39,7 +39,7 @@ public class SpringwolfKafkaProducerConfigurationIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
                 "springwolf.plugin.kafka.publishing.enabled=true"
             })
     @MockBeans(
@@ -78,7 +78,7 @@ public class SpringwolfKafkaProducerConfigurationIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
                 "springwolf.plugin.kafka.publishing.enabled=false"
             })
     @MockBeans(

--- a/springwolf-plugins/springwolf-sns-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfSnsProducerConfigurationIntegrationTest.java
+++ b/springwolf-plugins/springwolf-sns-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfSnsProducerConfigurationIntegrationTest.java
@@ -41,7 +41,7 @@ public class SpringwolfSnsProducerConfigurationIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
                 "springwolf.plugin.sns.publishing.enabled=true"
             })
     @MockBeans(
@@ -82,7 +82,7 @@ public class SpringwolfSnsProducerConfigurationIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
                 "springwolf.plugin.sns.publishing.enabled=false"
             })
     @MockBeans(

--- a/springwolf-plugins/springwolf-sqs-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfSqsProducerConfigurationIntegrationTest.java
+++ b/springwolf-plugins/springwolf-sqs-plugin/src/test/java/io/github/stavshamir/springwolf/configuration/SpringwolfSqsProducerConfigurationIntegrationTest.java
@@ -41,7 +41,7 @@ public class SpringwolfSqsProducerConfigurationIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
                 "springwolf.plugin.sqs.publishing.enabled=true"
             })
     @MockBeans(
@@ -82,7 +82,7 @@ public class SpringwolfSqsProducerConfigurationIntegrationTest {
                 "springwolf.docket.info.version=1.0.0",
                 "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
                 "springwolf.docket.servers.test-protocol.protocol=test",
-                "springwolf.docket.servers.test-protocol.url=some-server:1234",
+                "springwolf.docket.servers.test-protocol.host=some-server:1234",
                 "springwolf.plugin.sqs.publishing.enabled=false"
             })
     @MockBeans(


### PR DESCRIPTION
Different fixes related with the migration

* Added Messages support to Channels
* Replace the usage of `url` by `host` in the properties
* Some fixes to AMQP Plugin

Known issues:
* Some tests are failing due to AssertJ unknown issue
* Channel Message Names are still not following the old pattern
* Operations are still not supported