### PR TITLE
chore: Split ChannelScanner and OperationScanner

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringwolfAutoConfiguration.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringwolfAutoConfiguration.java
@@ -6,8 +6,11 @@ import io.github.stavshamir.springwolf.asyncapi.AsyncApiService;
 import io.github.stavshamir.springwolf.asyncapi.ChannelsService;
 import io.github.stavshamir.springwolf.asyncapi.DefaultAsyncApiService;
 import io.github.stavshamir.springwolf.asyncapi.DefaultChannelsService;
+import io.github.stavshamir.springwolf.asyncapi.DefaultOperationsService;
+import io.github.stavshamir.springwolf.asyncapi.OperationsService;
 import io.github.stavshamir.springwolf.asyncapi.SpringwolfInitApplicationListener;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.OperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.configuration.DefaultAsyncApiDocketService;
@@ -58,15 +61,23 @@ public class SpringwolfAutoConfiguration {
     public AsyncApiService asyncApiService(
             AsyncApiDocketService asyncApiDocketService,
             ChannelsService channelsService,
+            OperationsService operationsService,
             SchemasService schemasService,
             List<AsyncApiCustomizer> customizers) {
-        return new DefaultAsyncApiService(asyncApiDocketService, channelsService, schemasService, customizers);
+        return new DefaultAsyncApiService(
+                asyncApiDocketService, channelsService, operationsService, schemasService, customizers);
     }
 
     @Bean
     @ConditionalOnMissingBean
     public ChannelsService channelsService(List<? extends ChannelsScanner> channelsScanners) {
         return new DefaultChannelsService(channelsScanners);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public OperationsService operationsService(List<? extends OperationsScanner> operationsScanners) {
+        return new DefaultOperationsService(operationsScanners);
     }
 
     @Bean

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringwolfScannerConfiguration.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/SpringwolfScannerConfiguration.java
@@ -8,6 +8,7 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.OperationBindi
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.AsyncAnnotationChannelsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.AsyncAnnotationOperationsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.AsyncAnnotationScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncListener;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
@@ -76,7 +77,7 @@ public class SpringwolfScannerConfiguration {
             List<OperationBindingProcessor> operationBindingProcessors,
             List<MessageBindingProcessor> messageBindingProcessors) {
         return new AsyncAnnotationChannelsScanner<>(
-                buildAsyncListenerChannelAnnotationProvider(),
+                buildAsyncListenerAnnotationProvider(),
                 springwolfClassScanner,
                 schemasService,
                 asyncApiDocketService,
@@ -98,7 +99,7 @@ public class SpringwolfScannerConfiguration {
             List<OperationBindingProcessor> operationBindingProcessors,
             List<MessageBindingProcessor> messageBindingProcessors) {
         return new AsyncAnnotationOperationsScanner<>(
-                buildAsyncListenerOperationAnnotationProvider(),
+                buildAsyncListenerAnnotationProvider(),
                 springwolfClassScanner,
                 schemasService,
                 payloadClassExtractor,
@@ -120,7 +121,7 @@ public class SpringwolfScannerConfiguration {
             List<OperationBindingProcessor> operationBindingProcessors,
             List<MessageBindingProcessor> messageBindingProcessors) {
         return new AsyncAnnotationChannelsScanner<>(
-                buildAsyncPublisherChannelAnnotationProvider(),
+                buildAsyncPublisherAnnotationProvider(),
                 springwolfClassScanner,
                 schemasService,
                 asyncApiDocketService,
@@ -142,7 +143,7 @@ public class SpringwolfScannerConfiguration {
             List<OperationBindingProcessor> operationBindingProcessors,
             List<MessageBindingProcessor> messageBindingProcessors) {
         return new AsyncAnnotationOperationsScanner<>(
-                buildAsyncPublisherOperationAnnotationProvider(),
+                buildAsyncPublisherAnnotationProvider(),
                 springwolfClassScanner,
                 schemasService,
                 payloadClassExtractor,
@@ -150,9 +151,9 @@ public class SpringwolfScannerConfiguration {
                 messageBindingProcessors);
     }
 
-    private static AsyncAnnotationChannelsScanner.AsyncAnnotationProvider<AsyncListener>
-            buildAsyncListenerChannelAnnotationProvider() {
-        return new AsyncAnnotationChannelsScanner.AsyncAnnotationProvider<>() {
+    private static AsyncAnnotationScanner.AsyncAnnotationProvider<AsyncListener>
+            buildAsyncListenerAnnotationProvider() {
+        return new AsyncAnnotationScanner.AsyncAnnotationProvider<>() {
             @Override
             public Class<AsyncListener> getAnnotation() {
                 return AsyncListener.class;
@@ -170,49 +171,9 @@ public class SpringwolfScannerConfiguration {
         };
     }
 
-    private static AsyncAnnotationOperationsScanner.AsyncAnnotationProvider<AsyncListener>
-            buildAsyncListenerOperationAnnotationProvider() {
-        return new AsyncAnnotationOperationsScanner.AsyncAnnotationProvider<>() {
-            @Override
-            public Class<AsyncListener> getAnnotation() {
-                return AsyncListener.class;
-            }
-
-            @Override
-            public AsyncOperation getAsyncOperation(AsyncListener annotation) {
-                return annotation.operation();
-            }
-
-            @Override
-            public OperationAction getOperationType() {
-                return OperationAction.RECEIVE;
-            }
-        };
-    }
-
-    private static AsyncAnnotationChannelsScanner.AsyncAnnotationProvider<AsyncPublisher>
-            buildAsyncPublisherChannelAnnotationProvider() {
-        return new AsyncAnnotationChannelsScanner.AsyncAnnotationProvider<>() {
-            @Override
-            public Class<AsyncPublisher> getAnnotation() {
-                return AsyncPublisher.class;
-            }
-
-            @Override
-            public AsyncOperation getAsyncOperation(AsyncPublisher annotation) {
-                return annotation.operation();
-            }
-
-            @Override
-            public OperationAction getOperationType() {
-                return OperationAction.SEND;
-            }
-        };
-    }
-
-    private static AsyncAnnotationOperationsScanner.AsyncAnnotationProvider<AsyncPublisher>
-            buildAsyncPublisherOperationAnnotationProvider() {
-        return new AsyncAnnotationOperationsScanner.AsyncAnnotationProvider<>() {
+    private static AsyncAnnotationScanner.AsyncAnnotationProvider<AsyncPublisher>
+            buildAsyncPublisherAnnotationProvider() {
+        return new AsyncAnnotationScanner.AsyncAnnotationProvider<>() {
             @Override
             public Class<AsyncPublisher> getAnnotation() {
                 return AsyncPublisher.class;

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/ChannelsService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/ChannelsService.java
@@ -2,7 +2,6 @@
 package io.github.stavshamir.springwolf.asyncapi;
 
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 
 import java.util.Map;
 
@@ -17,11 +16,4 @@ public interface ChannelsService {
      * @return Map of channel names mapping to detected ChannelItems
      */
     Map<String, ChannelObject> findChannels();
-
-    /**
-     * Detects all available AsyncAPI Operation in the spring context.
-     *
-     * @return Map of operation names mapping to detected Operations
-     */
-    Map<String, Operation> findOperations();
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiService.java
@@ -28,6 +28,7 @@ public class DefaultAsyncApiService implements AsyncApiService {
 
     private final AsyncApiDocketService asyncApiDocketService;
     private final ChannelsService channelsService;
+    private final OperationsService operationsService;
     private final SchemasService schemasService;
     private final List<AsyncApiCustomizer> customizers;
 
@@ -65,7 +66,7 @@ public class DefaultAsyncApiService implements AsyncApiService {
             // SchemasService.
             Map<String, ChannelObject> channels = channelsService.findChannels();
 
-            Map<String, Operation> operations = channelsService.findOperations();
+            Map<String, Operation> operations = operationsService.findOperations();
 
             Components components = Components.builder()
                     .schemas(schemasService.getSchemas())

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsService.java
@@ -4,7 +4,6 @@ package io.github.stavshamir.springwolf.asyncapi;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelMerger;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,32 +31,12 @@ public class DefaultChannelsService implements ChannelsService {
 
         for (ChannelsScanner scanner : channelsScanners) {
             try {
-                Map<String, ChannelObject> channels = scanner.scanChannels();
+                Map<String, ChannelObject> channels = scanner.scan();
                 foundChannelItems.addAll(channels.entrySet());
             } catch (Exception e) {
                 log.error("An error was encountered during channel scanning with {}: {}", scanner, e.getMessage(), e);
             }
         }
         return ChannelMerger.mergeChannels(foundChannelItems);
-    }
-
-    /**
-     * Collects all AsyncAPI Operation using the available {@link ChannelsScanner}
-     * beans.
-     * @return Map of operation names mapping to detected Operation
-     */
-    @Override
-    public Map<String, Operation> findOperations() {
-        List<Map.Entry<String, Operation>> foundOperations = new ArrayList<>();
-        for (ChannelsScanner scanner : channelsScanners) {
-            try {
-                Map<String, Operation> channels = scanner.scanOperations();
-                foundOperations.addAll(channels.entrySet());
-            } catch (Exception e) {
-                log.error("An error was encountered during operation scanning with {}: {}", scanner, e.getMessage(), e);
-            }
-        }
-
-        return ChannelMerger.mergeOperations(foundOperations);
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultOperationsService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/DefaultOperationsService.java
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.asyncapi;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.OperationMerger;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.OperationsScanner;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service to detect AsyncAPI operations in the current spring context.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class DefaultOperationsService implements OperationsService {
+
+    private final List<? extends OperationsScanner> operationScanners;
+
+    /**
+     * Collects all AsyncAPI Operation using the available {@link OperationsScanner}
+     * beans.
+     * @return Map of operation names mapping to detected Operation
+     */
+    @Override
+    public Map<String, Operation> findOperations() {
+        List<Map.Entry<String, Operation>> foundOperations = new ArrayList<>();
+
+        for (OperationsScanner scanner : operationScanners) {
+            try {
+                Map<String, Operation> channels = scanner.scan();
+                foundOperations.addAll(channels.entrySet());
+            } catch (Exception e) {
+                log.error("An error was encountered during operation scanning with {}: {}", scanner, e.getMessage(), e);
+            }
+        }
+        return OperationMerger.mergeOperations(foundOperations);
+    }
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/OperationsService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/OperationsService.java
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.asyncapi;
+
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+
+import java.util.Map;
+
+/**
+ * Service to detect AsyncAPI channels in the current spring context.
+ */
+public interface OperationsService {
+
+    /**
+     * Detects all available AsyncAPI Operation in the spring context.
+     *
+     * @return Map of operation names mapping to detected Operations
+     */
+    Map<String, Operation> findOperations();
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMerger.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMerger.java
@@ -4,12 +4,8 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.Channel;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.Message;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -44,31 +40,6 @@ public class ChannelMerger {
         return mergedChannels;
     }
 
-    /**
-     * Merges multiple operations by operation name
-     * <p>
-     * Given two operations for the same operation name, the first seen Operation is used
-     * If an operation is null, the next non-null operation is used
-     * Messages within operations are merged
-     *
-     * @param operationEntries Ordered pairs of operation name to Operation
-     * @return A map of operationId to a single Operation
-     */
-    public static Map<String, Operation> mergeOperations(List<Map.Entry<String, Operation>> operationEntries) {
-        Map<String, Operation> mergedOperations = new HashMap<>();
-
-        for (Map.Entry<String, Operation> entry : operationEntries) {
-            if (!mergedOperations.containsKey(entry.getKey())) {
-                mergedOperations.put(entry.getKey(), entry.getValue());
-            } else {
-                Operation operation = mergeOperation(mergedOperations.get(entry.getKey()), entry.getValue());
-                mergedOperations.put(entry.getKey(), operation);
-            }
-        }
-
-        return mergedOperations;
-    }
-
     private static ChannelObject mergeChannel(ChannelObject channel, ChannelObject otherChannel) {
         ChannelObject mergedChannel = channel != null ? channel : otherChannel;
 
@@ -88,28 +59,5 @@ public class ChannelMerger {
         }
 
         return mergedChannel;
-    }
-
-    private static Operation mergeOperation(Operation operation, Operation otherOperation) {
-        Operation mergedOperation = operation != null ? operation : otherOperation;
-
-        List<MessageReference> mergedMessages =
-                mergeMessageReferences(operation.getMessages(), otherOperation.getMessages());
-        if (!mergedMessages.isEmpty()) {
-            mergedOperation.setMessages(mergedMessages);
-        }
-        return mergedOperation;
-    }
-
-    private static List<MessageReference> mergeMessageReferences(
-            Collection<MessageReference> messages, Collection<MessageReference> otherMessages) {
-        var messageReferences = new HashSet<MessageReference>();
-        if (messages != null) {
-            messageReferences.addAll(messages);
-        }
-        if (otherMessages != null) {
-            messageReferences.addAll(otherMessages);
-        }
-        return messageReferences.stream().toList();
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelsScanner.java
@@ -2,7 +2,6 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
 
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 
 import java.util.Map;
 
@@ -11,10 +10,5 @@ public interface ChannelsScanner {
     /**
      * @return A mapping of channel names to their respective channel object for a given protocol.
      */
-    Map<String, ChannelObject> scanChannels();
-
-    /**
-     * @return A mapping of operation names to their respective operation object for a given protocol.
-     */
-    Map<String, Operation> scanOperations();
+    Map<String, ChannelObject> scan();
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/OperationMerger.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/OperationMerger.java
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
+
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.Channel;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Util to merge multiple {@link Channel}s
+ */
+public class OperationMerger {
+
+    private OperationMerger() {}
+
+    /**
+     * Merges multiple operations by operation name
+     * <p>
+     * Given two operations for the same operation name, the first seen Operation is used
+     * If an operation is null, the next non-null operation is used
+     * Messages within operations are merged
+     *
+     * @param operationEntries Ordered pairs of operation name to Operation
+     * @return A map of operationId to a single Operation
+     */
+    public static Map<String, Operation> mergeOperations(List<Map.Entry<String, Operation>> operationEntries) {
+        Map<String, Operation> mergedOperations = new HashMap<>();
+
+        for (Map.Entry<String, Operation> entry : operationEntries) {
+            if (!mergedOperations.containsKey(entry.getKey())) {
+                mergedOperations.put(entry.getKey(), entry.getValue());
+            } else {
+                Operation operation = mergeOperation(mergedOperations.get(entry.getKey()), entry.getValue());
+                mergedOperations.put(entry.getKey(), operation);
+            }
+        }
+
+        return mergedOperations;
+    }
+
+    private static Operation mergeOperation(Operation operation, Operation otherOperation) {
+        Operation mergedOperation = operation != null ? operation : otherOperation;
+
+        List<MessageReference> mergedMessages =
+                mergeMessageReferences(operation.getMessages(), otherOperation.getMessages());
+        if (!mergedMessages.isEmpty()) {
+            mergedOperation.setMessages(mergedMessages);
+        }
+        return mergedOperation;
+    }
+
+    private static List<MessageReference> mergeMessageReferences(
+            Collection<MessageReference> messages, Collection<MessageReference> otherMessages) {
+        var messageReferences = new HashSet<MessageReference>();
+        if (messages != null) {
+            messageReferences.addAll(messages);
+        }
+        if (otherMessages != null) {
+            messageReferences.addAll(otherMessages);
+        }
+        return messageReferences.stream().toList();
+    }
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/OperationsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/OperationsScanner.java
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
+
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+
+import java.util.Map;
+
+public interface OperationsScanner {
+
+    /**
+     * @return A mapping of operation names to their respective operation object for a given protocol.
+     */
+    Map<String, Operation> scan();
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/SimpleOperationsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/SimpleOperationsScanner.java
@@ -2,7 +2,7 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
 
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ClassScanner;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -11,26 +11,26 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 @RequiredArgsConstructor
-public class SimpleChannelsScanner implements ChannelsScanner {
+public class SimpleOperationsScanner implements OperationsScanner {
 
     private final ClassScanner classScanner;
 
     private final ClassProcessor classProcessor;
 
     @Override
-    public Map<String, ChannelObject> scan() {
+    public Map<String, Operation> scan() {
         Set<Class<?>> components = classScanner.scan();
 
-        List<Map.Entry<String, ChannelObject>> channels = mapToChannels(components);
+        List<Map.Entry<String, Operation>> operations = mapToOperations(components);
 
-        return ChannelMerger.mergeChannels(channels);
+        return OperationMerger.mergeOperations(operations);
     }
 
-    private List<Map.Entry<String, ChannelObject>> mapToChannels(Set<Class<?>> components) {
+    private List<Map.Entry<String, Operation>> mapToOperations(Set<Class<?>> components) {
         return components.stream().flatMap(classProcessor::process).toList();
     }
 
     public interface ClassProcessor {
-        Stream<Map.Entry<String, ChannelObject>> process(Class<?> clazz);
+        Stream<Map.Entry<String, Operation>> process(Class<?> clazz);
     }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationChannelsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationChannelsScanner.java
@@ -8,55 +8,43 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanne
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ClassScanner;
-import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
-import io.github.stavshamir.springwolf.asyncapi.v3.bindings.MessageBinding;
-import io.github.stavshamir.springwolf.asyncapi.v3.bindings.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ServerReference;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.OperationAction;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.server.Server;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.EmbeddedValueResolverAware;
-import org.springframework.util.StringUtils;
-import org.springframework.util.StringValueResolver;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 @Slf4j
-@RequiredArgsConstructor
-public class AsyncAnnotationChannelsScanner<A extends Annotation>
-        implements ChannelsScanner, EmbeddedValueResolverAware {
+public class AsyncAnnotationChannelsScanner<A extends Annotation> extends AsyncAnnotationScanner<A>
+        implements ChannelsScanner {
 
-    private final AsyncAnnotationProvider<A> asyncAnnotationProvider;
     private final ClassScanner classScanner;
-    private final SchemasService schemasService;
     private final AsyncApiDocketService asyncApiDocketService;
-    private final PayloadClassExtractor payloadClassExtractor;
-    private final List<OperationBindingProcessor> operationBindingProcessors;
-    private final List<MessageBindingProcessor> messageBindingProcessors;
-    private StringValueResolver resolver;
 
-    @Override
-    public void setEmbeddedValueResolver(StringValueResolver resolver) {
-        this.resolver = resolver;
+    public AsyncAnnotationChannelsScanner(
+            AsyncAnnotationProvider<A> asyncAnnotationProvider,
+            ClassScanner classScanner,
+            SchemasService schemasService,
+            AsyncApiDocketService asyncApiDocketService,
+            PayloadClassExtractor payloadClassExtractor,
+            List<OperationBindingProcessor> operationBindingProcessors,
+            List<MessageBindingProcessor> messageBindingProcessors) {
+        super(
+                asyncAnnotationProvider,
+                payloadClassExtractor,
+                schemasService,
+                operationBindingProcessors,
+                messageBindingProcessors);
+        this.classScanner = classScanner;
+        this.asyncApiDocketService = asyncApiDocketService;
     }
 
     @Override
@@ -67,18 +55,6 @@ public class AsyncAnnotationChannelsScanner<A extends Annotation>
                 .toList();
 
         return ChannelMerger.mergeChannels(channels);
-    }
-
-    private Stream<MethodAndAnnotation<A>> getAnnotatedMethods(Class<?> type) {
-        Class<A> annotationClass = this.asyncAnnotationProvider.getAnnotation();
-        log.debug("Scanning class \"{}\" for @\"{}\" annotated methods", type.getName(), annotationClass.getName());
-
-        return Arrays.stream(type.getDeclaredMethods())
-                .filter(method -> !method.isBridge())
-                .filter(method -> AnnotationUtil.findAnnotation(annotationClass, method) != null)
-                .peek(method -> log.debug("Mapping method \"{}\" to channels", method.getName()))
-                .flatMap(method -> AnnotationUtil.findAnnotations(annotationClass, method).stream()
-                        .map(annotation -> new MethodAndAnnotation<>(method, annotation)));
     }
 
     private Map.Entry<String, ChannelObject> buildChannel(MethodAndAnnotation<A> methodAndAnnotation) {
@@ -103,66 +79,6 @@ public class AsyncAnnotationChannelsScanner<A extends Annotation>
                 .messages(Map.of(message.getName(), MessageReference.toComponentMessage(message)))
                 .build();
         return Map.entry(channelName, channelItem);
-    }
-
-    private Operation buildOperation(AsyncOperation asyncOperation, Method method, String channelName) {
-        String description = this.resolver.resolveStringValue(asyncOperation.description());
-        if (!StringUtils.hasText(description)) {
-            description = "Auto-generated description";
-        }
-
-        String operationTitle = channelName + "_" + this.asyncAnnotationProvider.getOperationType().type;
-
-        Map<String, OperationBinding> operationBinding =
-                AsyncAnnotationScannerUtil.processOperationBindingFromAnnotation(method, operationBindingProcessors);
-        Map<String, OperationBinding> opBinding = operationBinding != null ? new HashMap<>(operationBinding) : null;
-        MessageObject message = buildMessage(asyncOperation, method);
-
-        return Operation.builder()
-                .channel(ChannelReference.fromChannel(channelName))
-                .description(description)
-                .title(operationTitle)
-                .messages(List.of(MessageReference.toChannelMessage(channelName, message)))
-                .bindings(opBinding)
-                .build();
-    }
-
-    private MessageObject buildMessage(AsyncOperation operationData, Method method) {
-        Class<?> payloadType = operationData.payloadType() != Object.class
-                ? operationData.payloadType()
-                : payloadClassExtractor.extractFrom(method);
-
-        String modelName = this.schemasService.registerSchema(payloadType);
-        AsyncHeaders asyncHeaders = AsyncAnnotationScannerUtil.getAsyncHeaders(operationData, resolver);
-        String headerModelName = this.schemasService.registerSchema(asyncHeaders);
-        var headers = MessageHeaders.of(MessageReference.toSchema(headerModelName));
-
-        var schema = payloadType.getAnnotation(Schema.class);
-        String description = schema != null ? schema.description() : null;
-
-        Map<String, MessageBinding> messageBinding =
-                AsyncAnnotationScannerUtil.processMessageBindingFromAnnotation(method, messageBindingProcessors);
-
-        var messagePayload = MessagePayload.of(MultiFormatSchema.builder()
-                .schema(SchemaReference.fromSchema(modelName))
-                .build());
-
-        var builder = MessageObject.builder()
-                .messageId(payloadType.getName())
-                .name(payloadType.getName())
-                .title(payloadType.getSimpleName())
-                .description(description)
-                .payload(messagePayload)
-                .headers(headers)
-                .bindings(messageBinding);
-
-        // Retrieve the Message information obtained from the @AsyncMessage annotation. These values have higher
-        // priority so if we find them, we need to override the default values.
-        AsyncAnnotationScannerUtil.processAsyncMessageAnnotation(builder, operationData.message(), this.resolver);
-
-        MessageObject message = builder.build();
-        this.schemasService.registerMessage(message);
-        return message;
     }
 
     /**
@@ -191,14 +107,4 @@ public class AsyncAnnotationChannelsScanner<A extends Annotation>
             }
         }
     }
-
-    public interface AsyncAnnotationProvider<A> {
-        Class<A> getAnnotation();
-
-        AsyncOperation getAsyncOperation(A annotation);
-
-        OperationAction getOperationType();
-    }
-
-    private record MethodAndAnnotation<A>(Method method, A annotation) {}
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationOperationsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationOperationsScanner.java
@@ -8,50 +8,34 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.channels.OperationsScan
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ClassScanner;
-import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
-import io.github.stavshamir.springwolf.asyncapi.v3.bindings.MessageBinding;
-import io.github.stavshamir.springwolf.asyncapi.v3.bindings.OperationBinding;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelReference;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.OperationAction;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.EmbeddedValueResolverAware;
-import org.springframework.util.StringUtils;
-import org.springframework.util.StringValueResolver;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 @Slf4j
-@RequiredArgsConstructor
-public class AsyncAnnotationOperationsScanner<A extends Annotation>
-        implements OperationsScanner, EmbeddedValueResolverAware {
+public class AsyncAnnotationOperationsScanner<A extends Annotation> extends AsyncAnnotationScanner<A>
+        implements OperationsScanner {
 
-    private final AsyncAnnotationProvider<A> asyncAnnotationProvider;
     private final ClassScanner classScanner;
-    private final SchemasService schemasService;
-    private final PayloadClassExtractor payloadClassExtractor;
-    private final List<OperationBindingProcessor> operationBindingProcessors;
-    private final List<MessageBindingProcessor> messageBindingProcessors;
-    private StringValueResolver resolver;
 
-    @Override
-    public void setEmbeddedValueResolver(StringValueResolver resolver) {
-        this.resolver = resolver;
+    public AsyncAnnotationOperationsScanner(
+            AsyncAnnotationProvider<A> asyncAnnotationProvider,
+            ClassScanner classScanner,
+            SchemasService schemasService,
+            PayloadClassExtractor payloadClassExtractor,
+            List<OperationBindingProcessor> operationBindingProcessors,
+            List<MessageBindingProcessor> messageBindingProcessors) {
+        super(
+                asyncAnnotationProvider,
+                payloadClassExtractor,
+                schemasService,
+                operationBindingProcessors,
+                messageBindingProcessors);
+        this.classScanner = classScanner;
     }
 
     @Override
@@ -64,98 +48,16 @@ public class AsyncAnnotationOperationsScanner<A extends Annotation>
         return OperationMerger.mergeOperations(operations);
     }
 
-    private Stream<MethodAndAnnotation<A>> getAnnotatedMethods(Class<?> type) {
-        Class<A> annotationClass = this.asyncAnnotationProvider.getAnnotation();
-        log.debug("Scanning class \"{}\" for @\"{}\" annotated methods", type.getName(), annotationClass.getName());
-
-        return Arrays.stream(type.getDeclaredMethods())
-                .filter(method -> !method.isBridge())
-                .filter(method -> AnnotationUtil.findAnnotation(annotationClass, method) != null)
-                .peek(method -> log.debug("Mapping method \"{}\" to channels", method.getName()))
-                .flatMap(method -> AnnotationUtil.findAnnotations(annotationClass, method).stream()
-                        .map(annotation -> new MethodAndAnnotation<>(method, annotation)));
-    }
-
     private Map.Entry<String, Operation> buildOperation(MethodAndAnnotation<A> methodAndAnnotation) {
         AsyncOperation operationAnnotation =
                 this.asyncAnnotationProvider.getAsyncOperation(methodAndAnnotation.annotation());
         String channelName = resolver.resolveStringValue(operationAnnotation.channelName());
         String operationId = channelName + "_" + this.asyncAnnotationProvider.getOperationType().type + "_"
-                + methodAndAnnotation.method.getName();
+                + methodAndAnnotation.method().getName();
 
         Operation operation = buildOperation(operationAnnotation, methodAndAnnotation.method(), channelName);
         operation.setAction(this.asyncAnnotationProvider.getOperationType());
 
         return Map.entry(operationId, operation);
     }
-
-    private Operation buildOperation(AsyncOperation asyncOperation, Method method, String channelName) {
-        String description = this.resolver.resolveStringValue(asyncOperation.description());
-        if (!StringUtils.hasText(description)) {
-            description = "Auto-generated description";
-        }
-
-        String operationTitle = channelName + "_" + this.asyncAnnotationProvider.getOperationType().type;
-
-        Map<String, OperationBinding> operationBinding =
-                AsyncAnnotationScannerUtil.processOperationBindingFromAnnotation(method, operationBindingProcessors);
-        Map<String, OperationBinding> opBinding = operationBinding != null ? new HashMap<>(operationBinding) : null;
-        MessageObject message = buildMessage(asyncOperation, method);
-
-        return Operation.builder()
-                .channel(ChannelReference.fromChannel(channelName))
-                .description(description)
-                .title(operationTitle)
-                .messages(List.of(MessageReference.toChannelMessage(channelName, message)))
-                .bindings(opBinding)
-                .build();
-    }
-
-    private MessageObject buildMessage(AsyncOperation operationData, Method method) {
-        Class<?> payloadType = operationData.payloadType() != Object.class
-                ? operationData.payloadType()
-                : payloadClassExtractor.extractFrom(method);
-
-        String modelName = this.schemasService.registerSchema(payloadType);
-        AsyncHeaders asyncHeaders = AsyncAnnotationScannerUtil.getAsyncHeaders(operationData, resolver);
-        String headerModelName = this.schemasService.registerSchema(asyncHeaders);
-        var headers = MessageHeaders.of(MessageReference.toSchema(headerModelName));
-
-        var schema = payloadType.getAnnotation(Schema.class);
-        String description = schema != null ? schema.description() : null;
-
-        Map<String, MessageBinding> messageBinding =
-                AsyncAnnotationScannerUtil.processMessageBindingFromAnnotation(method, messageBindingProcessors);
-
-        var messagePayload = MessagePayload.of(MultiFormatSchema.builder()
-                .schema(SchemaReference.fromSchema(modelName))
-                .build());
-
-        var builder = MessageObject.builder()
-                .messageId(payloadType.getName())
-                .name(payloadType.getName())
-                .title(payloadType.getSimpleName())
-                .description(description)
-                .payload(messagePayload)
-                .headers(headers)
-                .bindings(messageBinding);
-
-        // Retrieve the Message information obtained from the @AsyncMessage annotation. These values have higher
-        // priority so if we find them, we need to override the default values.
-        AsyncAnnotationScannerUtil.processAsyncMessageAnnotation(builder, operationData.message(), this.resolver);
-
-        MessageObject message = builder.build();
-        this.schemasService.registerMessage(message);
-        return message;
-    }
-
-    public interface AsyncAnnotationProvider<A> {
-        Class<A> getAnnotation();
-
-        AsyncOperation getAsyncOperation(A annotation);
-
-        OperationAction getOperationType();
-    }
-
-    private record MethodAndAnnotation<A>(Method method, A annotation) {}
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationScanner.java
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.MessageBindingProcessor;
+import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.OperationBindingProcessor;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
+import io.github.stavshamir.springwolf.asyncapi.v3.bindings.MessageBinding;
+import io.github.stavshamir.springwolf.asyncapi.v3.bindings.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelReference;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.OperationAction;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
+import io.github.stavshamir.springwolf.schemas.SchemasService;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.util.StringUtils;
+import org.springframework.util.StringValueResolver;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AsyncAnnotationScanner<A extends Annotation> implements EmbeddedValueResolverAware {
+
+    protected final AsyncAnnotationProvider<A> asyncAnnotationProvider;
+    protected final PayloadClassExtractor payloadClassExtractor;
+    protected final SchemasService schemasService;
+    protected final List<OperationBindingProcessor> operationBindingProcessors;
+    protected final List<MessageBindingProcessor> messageBindingProcessors;
+    protected StringValueResolver resolver;
+
+    @Override
+    public void setEmbeddedValueResolver(StringValueResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    protected Stream<MethodAndAnnotation<A>> getAnnotatedMethods(Class<?> type) {
+        Class<A> annotationClass = this.asyncAnnotationProvider.getAnnotation();
+        log.debug("Scanning class \"{}\" for @\"{}\" annotated methods", type.getName(), annotationClass.getName());
+
+        return Arrays.stream(type.getDeclaredMethods())
+                .filter(method -> !method.isBridge())
+                .filter(method -> AnnotationUtil.findAnnotation(annotationClass, method) != null)
+                .peek(method -> log.debug("Mapping method \"{}\" to channels", method.getName()))
+                .flatMap(method -> AnnotationUtil.findAnnotations(annotationClass, method).stream()
+                        .map(annotation -> new MethodAndAnnotation<>(method, annotation)));
+    }
+
+    protected Operation buildOperation(AsyncOperation asyncOperation, Method method, String channelName) {
+        String description = this.resolver.resolveStringValue(asyncOperation.description());
+        if (!StringUtils.hasText(description)) {
+            description = "Auto-generated description";
+        }
+
+        String operationTitle = channelName + "_" + this.asyncAnnotationProvider.getOperationType().type;
+
+        Map<String, OperationBinding> operationBinding =
+                AsyncAnnotationScannerUtil.processOperationBindingFromAnnotation(method, operationBindingProcessors);
+        Map<String, OperationBinding> opBinding = operationBinding != null ? new HashMap<>(operationBinding) : null;
+        MessageObject message = buildMessage(asyncOperation, method);
+
+        return Operation.builder()
+                .channel(ChannelReference.fromChannel(channelName))
+                .description(description)
+                .title(operationTitle)
+                .messages(List.of(MessageReference.toChannelMessage(channelName, message)))
+                .bindings(opBinding)
+                .build();
+    }
+
+    protected MessageObject buildMessage(AsyncOperation operationData, Method method) {
+        Class<?> payloadType = operationData.payloadType() != Object.class
+                ? operationData.payloadType()
+                : payloadClassExtractor.extractFrom(method);
+
+        String modelName = this.schemasService.registerSchema(payloadType);
+        AsyncHeaders asyncHeaders = AsyncAnnotationScannerUtil.getAsyncHeaders(operationData, resolver);
+        String headerModelName = this.schemasService.registerSchema(asyncHeaders);
+        var headers = MessageHeaders.of(MessageReference.toSchema(headerModelName));
+
+        var schema = payloadType.getAnnotation(Schema.class);
+        String description = schema != null ? schema.description() : null;
+
+        Map<String, MessageBinding> messageBinding =
+                AsyncAnnotationScannerUtil.processMessageBindingFromAnnotation(method, messageBindingProcessors);
+
+        var messagePayload = MessagePayload.of(MultiFormatSchema.builder()
+                .schema(SchemaReference.fromSchema(modelName))
+                .build());
+
+        var builder = MessageObject.builder()
+                .messageId(payloadType.getName())
+                .name(payloadType.getName())
+                .title(payloadType.getSimpleName())
+                .description(description)
+                .payload(messagePayload)
+                .headers(headers)
+                .bindings(messageBinding);
+
+        // Retrieve the Message information obtained from the @AsyncMessage annotation. These values have higher
+        // priority so if we find them, we need to override the default values.
+        AsyncAnnotationScannerUtil.processAsyncMessageAnnotation(builder, operationData.message(), this.resolver);
+
+        MessageObject message = builder.build();
+        this.schemasService.registerMessage(message);
+        return message;
+    }
+
+    public interface AsyncAnnotationProvider<A> {
+        Class<A> getAnnotation();
+
+        AsyncOperation getAsyncOperation(A annotation);
+
+        OperationAction getOperationType();
+    }
+
+    protected record MethodAndAnnotation<A>(Method method, A annotation) {}
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationOperationsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationOperationsScanner.java
@@ -5,50 +5,41 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.BindingFactory
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.SimpleOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeadersBuilder;
-import io.github.stavshamir.springwolf.asyncapi.v3.bindings.MessageBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelReference;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.OperationAction;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.annotation.AnnotationUtils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.toMessagesMap;
-import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.toOperationsMessagesMap;
-import static java.util.stream.Collectors.toSet;
-
-@RequiredArgsConstructor
 @Slf4j
 public class ClassLevelAnnotationOperationsScanner<
                 ClassAnnotation extends Annotation, MethodAnnotation extends Annotation>
+        extends ClassLevelAnnotationScanner<ClassAnnotation, MethodAnnotation>
         implements SimpleOperationsScanner.ClassProcessor {
 
-    private final Class<ClassAnnotation> classAnnotationClass;
-    private final Class<MethodAnnotation> methodAnnotationClass;
-    private final BindingFactory<ClassAnnotation> bindingFactory;
-    private final AsyncHeadersBuilder asyncHeadersBuilder;
-    private final PayloadClassExtractor payloadClassExtractor;
-    private final SchemasService schemasService;
-
-    private enum MessageType {
-        CHANNEL,
-        OPERATION;
+    public ClassLevelAnnotationOperationsScanner(
+            Class<ClassAnnotation> classAnnotationClass,
+            Class<MethodAnnotation> methodAnnotationClass,
+            BindingFactory<ClassAnnotation> bindingFactory,
+            AsyncHeadersBuilder asyncHeadersBuilder,
+            PayloadClassExtractor payloadClassExtractor,
+            SchemasService schemasService) {
+        super(
+                classAnnotationClass,
+                methodAnnotationClass,
+                bindingFactory,
+                asyncHeadersBuilder,
+                payloadClassExtractor,
+                schemasService);
     }
 
     @Override
@@ -57,22 +48,6 @@ public class ClassLevelAnnotationOperationsScanner<
                 "Scanning class \"{}\" for @\"{}\" annotated methods", clazz.getName(), classAnnotationClass.getName());
 
         return Stream.of(clazz).filter(this::isClassAnnotated).flatMap(this::mapClassToOperation);
-    }
-
-    private boolean isClassAnnotated(Class<?> component) {
-        return AnnotationUtil.findAnnotation(classAnnotationClass, component) != null;
-    }
-
-    private Set<Method> getAnnotatedMethods(Class<?> clazz) {
-        log.debug(
-                "Scanning class \"{}\" for @\"{}\" annotated methods",
-                clazz.getName(),
-                methodAnnotationClass.getName());
-
-        return Arrays.stream(clazz.getDeclaredMethods())
-                .filter(method -> !method.isBridge())
-                .filter(method -> AnnotationUtils.findAnnotation(method, methodAnnotationClass) != null)
-                .collect(toSet());
     }
 
     private Stream<Map.Entry<String, Operation>> mapClassToOperation(Class<?> component) {
@@ -96,45 +71,6 @@ public class ClassLevelAnnotationOperationsScanner<
     private Operation buildOperation(ClassAnnotation classAnnotation, Set<Method> methods) {
         var messages = buildMessages(classAnnotation, methods, MessageType.OPERATION);
         return buildOperation(classAnnotation, messages);
-    }
-
-    private Map<String, MessageReference> buildMessages(
-            ClassAnnotation classAnnotation, Set<Method> methods, MessageType messageType) {
-        Set<MessageObject> messages = methods.stream()
-                .map((Method method) -> {
-                    Class<?> payloadType = payloadClassExtractor.extractFrom(method);
-                    return buildMessage(classAnnotation, payloadType);
-                })
-                .collect(toSet());
-
-        if (messageType == MessageType.OPERATION) {
-            String channelName = bindingFactory.getChannelName(classAnnotation);
-            return toOperationsMessagesMap(channelName, messages);
-        }
-        return toMessagesMap(messages);
-    }
-
-    private MessageObject buildMessage(ClassAnnotation classAnnotation, Class<?> payloadType) {
-        Map<String, MessageBinding> messageBinding = bindingFactory.buildMessageBinding(classAnnotation);
-        String modelName = schemasService.registerSchema(payloadType);
-        String headerModelName = schemasService.registerSchema(asyncHeadersBuilder.buildHeaders(payloadType));
-
-        MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
-                .schema(SchemaReference.fromSchema(modelName))
-                .build());
-
-        MessageObject message = MessageObject.builder()
-                .messageId(payloadType.getName())
-                .name(payloadType.getName())
-                .title(payloadType.getSimpleName())
-                .description(null)
-                .payload(payload)
-                .headers(MessageHeaders.of(MessageReference.toSchema(headerModelName)))
-                .bindings(messageBinding)
-                .build();
-
-        this.schemasService.registerMessage(message);
-        return message;
     }
 
     private Operation buildOperation(ClassAnnotation classAnnotation, Map<String, MessageReference> messages) {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationScanner.java
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.BindingFactory;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeadersBuilder;
+import io.github.stavshamir.springwolf.asyncapi.v3.bindings.MessageBinding;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
+import io.github.stavshamir.springwolf.schemas.SchemasService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.toMessagesMap;
+import static io.github.stavshamir.springwolf.asyncapi.MessageHelper.toOperationsMessagesMap;
+import static java.util.stream.Collectors.toSet;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class ClassLevelAnnotationScanner<
+        ClassAnnotation extends Annotation, MethodAnnotation extends Annotation> {
+
+    protected final Class<ClassAnnotation> classAnnotationClass;
+    protected final Class<MethodAnnotation> methodAnnotationClass;
+    protected final BindingFactory<ClassAnnotation> bindingFactory;
+    protected final AsyncHeadersBuilder asyncHeadersBuilder;
+    protected final PayloadClassExtractor payloadClassExtractor;
+    protected final SchemasService schemasService;
+
+    protected enum MessageType {
+        CHANNEL,
+        OPERATION;
+    }
+
+    protected boolean isClassAnnotated(Class<?> component) {
+        return AnnotationUtil.findAnnotation(classAnnotationClass, component) != null;
+    }
+
+    protected Set<Method> getAnnotatedMethods(Class<?> clazz) {
+        log.debug(
+                "Scanning class \"{}\" for @\"{}\" annotated methods",
+                clazz.getName(),
+                methodAnnotationClass.getName());
+
+        return Arrays.stream(clazz.getDeclaredMethods())
+                .filter(method -> !method.isBridge())
+                .filter(method -> AnnotationUtils.findAnnotation(method, methodAnnotationClass) != null)
+                .collect(toSet());
+    }
+
+    protected Map<String, MessageReference> buildMessages(
+            ClassAnnotation classAnnotation,
+            Set<Method> methods,
+            ClassLevelAnnotationOperationsScanner.MessageType messageType) {
+        Set<MessageObject> messages = methods.stream()
+                .map((Method method) -> {
+                    Class<?> payloadType = payloadClassExtractor.extractFrom(method);
+                    return buildMessage(classAnnotation, payloadType);
+                })
+                .collect(toSet());
+
+        if (messageType == MessageType.OPERATION) {
+            String channelName = bindingFactory.getChannelName(classAnnotation);
+            return toOperationsMessagesMap(channelName, messages);
+        }
+        return toMessagesMap(messages);
+    }
+
+    protected MessageObject buildMessage(ClassAnnotation classAnnotation, Class<?> payloadType) {
+        Map<String, MessageBinding> messageBinding = bindingFactory.buildMessageBinding(classAnnotation);
+        String modelName = schemasService.registerSchema(payloadType);
+        String headerModelName = schemasService.registerSchema(asyncHeadersBuilder.buildHeaders(payloadType));
+
+        MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
+                .schema(SchemaReference.fromSchema(modelName))
+                .build());
+
+        MessageObject message = MessageObject.builder()
+                .messageId(payloadType.getName())
+                .name(payloadType.getName())
+                .title(payloadType.getSimpleName())
+                .description(null)
+                .payload(payload)
+                .headers(MessageHeaders.of(MessageReference.toSchema(headerModelName)))
+                .bindings(messageBinding)
+                .build();
+
+        this.schemasService.registerMessage(message);
+        return message;
+    }
+}

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationOperationsScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationOperationsScanner.java
@@ -4,20 +4,13 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
 import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.BindingFactory;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.SimpleOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
-import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
-import io.github.stavshamir.springwolf.asyncapi.v3.bindings.MessageBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.OperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelReference;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.OperationAction;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.annotation.Annotation;
@@ -28,15 +21,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-@RequiredArgsConstructor
 @Slf4j
 public class MethodLevelAnnotationOperationsScanner<MethodAnnotation extends Annotation>
-        implements SimpleOperationsScanner.ClassProcessor {
+        extends MethodLevelAnnotationScanner<MethodAnnotation> implements SimpleOperationsScanner.ClassProcessor {
 
     private final Class<MethodAnnotation> methodAnnotationClass;
-    private final BindingFactory<MethodAnnotation> bindingFactory;
     private final PayloadClassExtractor payloadClassExtractor;
-    private final SchemasService schemasService;
+
+    public MethodLevelAnnotationOperationsScanner(
+            Class<MethodAnnotation> methodAnnotationClass,
+            BindingFactory<MethodAnnotation> bindingFactory,
+            PayloadClassExtractor payloadClassExtractor,
+            SchemasService schemasService) {
+        super(bindingFactory, schemasService);
+        this.methodAnnotationClass = methodAnnotationClass;
+        this.payloadClassExtractor = payloadClassExtractor;
+    }
 
     @Override
     public Stream<Map.Entry<String, Operation>> process(Class<?> clazz) {
@@ -67,28 +67,6 @@ public class MethodLevelAnnotationOperationsScanner<MethodAnnotation extends Ann
     private Operation buildOperation(MethodAnnotation annotation, Class<?> payloadType) {
         MessageObject message = buildMessage(annotation, payloadType);
         return buildOperation(annotation, message);
-    }
-
-    private MessageObject buildMessage(MethodAnnotation annotation, Class<?> payloadType) {
-        Map<String, MessageBinding> messageBinding = bindingFactory.buildMessageBinding(annotation);
-        String modelName = schemasService.registerSchema(payloadType);
-        String headerModelName = schemasService.registerSchema(AsyncHeaders.NOT_DOCUMENTED);
-        MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
-                .schema(SchemaReference.fromSchema(modelName))
-                .build());
-
-        MessageObject message = MessageObject.builder()
-                .messageId(payloadType.getName())
-                .name(payloadType.getName())
-                .title(payloadType.getSimpleName())
-                .description(null)
-                .payload(payload)
-                .headers(MessageHeaders.of(MessageReference.toSchema(headerModelName)))
-                .bindings(messageBinding)
-                .build();
-
-        this.schemasService.registerMessage(message);
-        return message;
     }
 
     private Operation buildOperation(MethodAnnotation annotation, MessageObject message) {

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationScanner.java
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.BindingFactory;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
+import io.github.stavshamir.springwolf.asyncapi.v3.bindings.MessageBinding;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
+import io.github.stavshamir.springwolf.schemas.SchemasService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Slf4j
+public abstract class MethodLevelAnnotationScanner<MethodAnnotation extends Annotation> {
+
+    protected final BindingFactory<MethodAnnotation> bindingFactory;
+    protected final SchemasService schemasService;
+
+    protected MessageObject buildMessage(MethodAnnotation annotation, Class<?> payloadType) {
+        Map<String, MessageBinding> messageBinding = bindingFactory.buildMessageBinding(annotation);
+        String modelName = schemasService.registerSchema(payloadType);
+        String headerModelName = schemasService.registerSchema(AsyncHeaders.NOT_DOCUMENTED);
+        MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
+                .schema(SchemaReference.fromSchema(modelName))
+                .build());
+
+        MessageObject message = MessageObject.builder()
+                .messageId(payloadType.getName())
+                .name(payloadType.getName())
+                .title(payloadType.getSimpleName())
+                .description(null)
+                .payload(payload)
+                .headers(MessageHeaders.of(MessageReference.toSchema(headerModelName)))
+                .bindings(messageBinding)
+                .build();
+
+        this.schemasService.registerMessage(message);
+        return message;
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceIntegrationTest.java
@@ -56,6 +56,9 @@ class DefaultAsyncApiServiceIntegrationTest {
     private ChannelsService channelsService;
 
     @MockBean
+    private OperationsService operationsService;
+
+    @MockBean
     private SchemasService schemasService;
 
     @Autowired

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceTest.java
@@ -26,6 +26,7 @@ class DefaultAsyncApiServiceTest {
     private DefaultAsyncApiService defaultAsyncApiService;
     private AsyncApiDocketService asyncApiDocketService;
     private ChannelsService channelsService;
+    private OperationsService operationsService;
     private SchemasService schemasService;
     private List<AsyncApiCustomizer> customizers = new ArrayList<>();
 
@@ -33,13 +34,14 @@ class DefaultAsyncApiServiceTest {
     public void setup() {
         asyncApiDocketService = mock(AsyncApiDocketService.class);
         channelsService = mock(ChannelsService.class);
+        operationsService = mock(OperationsService.class);
         schemasService = mock(SchemasService.class);
 
         when(channelsService.findChannels()).thenReturn(Map.of());
         when(schemasService.getSchemas()).thenReturn(Map.of());
 
-        defaultAsyncApiService =
-                new DefaultAsyncApiService(asyncApiDocketService, channelsService, schemasService, customizers);
+        defaultAsyncApiService = new DefaultAsyncApiService(
+                asyncApiDocketService, channelsService, operationsService, schemasService, customizers);
     }
 
     @Test

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsServiceIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultChannelsServiceIntegrationTest.java
@@ -39,35 +39,15 @@ class DefaultChannelsServiceIntegrationTest {
         Map<String, ChannelObject> actualChannels = defaultChannelsService.findChannels();
 
         assertThat(actualChannels)
-                .containsAllEntriesOf(simpleChannelScanner.scanChannels())
+                .containsAllEntriesOf(simpleChannelScanner.scan())
                 .containsEntry(SameTopic.topicName, SameTopic.expectedMergedChannel);
-    }
-
-    @Test
-    void getOperations() {
-        Map<String, Operation> actualChannels = defaultChannelsService.findOperations();
-
-        assertThat(actualChannels)
-                .containsAllEntriesOf(simpleChannelScanner.scanOperations())
-                .containsEntry("receive", SameTopic.ReceiveChannelScanner.receiveOperation)
-                .containsEntry("send", SameTopic.SendChannelScanner.sentOperation);
     }
 
     @Component
     static class SimpleChannelScanner implements ChannelsScanner {
         @Override
-        public Map<String, ChannelObject> scanChannels() {
+        public Map<String, ChannelObject> scan() {
             return Map.of("foo", new ChannelObject());
-        }
-
-        @Override
-        public Map<String, Operation> scanOperations() {
-            return Map.of(
-                    "foo",
-                    Operation.builder()
-                            .channel(ChannelReference.fromChannel("foo"))
-                            .action(OperationAction.RECEIVE)
-                            .build());
         }
     }
 
@@ -89,17 +69,12 @@ class DefaultChannelsServiceIntegrationTest {
                     .build();
 
             @Override
-            public Map<String, ChannelObject> scanChannels() {
+            public Map<String, ChannelObject> scan() {
                 return Map.of(
                         topicName,
                         ChannelObject.builder()
                                 .messages(Map.of("sendMessage", MessageReference.toComponentMessage("sendMessage")))
                                 .build());
-            }
-
-            @Override
-            public Map<String, Operation> scanOperations() {
-                return Map.of("send", sentOperation);
             }
         }
 
@@ -111,18 +86,13 @@ class DefaultChannelsServiceIntegrationTest {
                     .build();
 
             @Override
-            public Map<String, ChannelObject> scanChannels() {
+            public Map<String, ChannelObject> scan() {
                 return Map.of(
                         topicName,
                         ChannelObject.builder()
                                 .messages(
                                         Map.of("receiveMessage", MessageReference.toComponentMessage("receiveMessage")))
                                 .build());
-            }
-
-            @Override
-            public Map<String, Operation> scanOperations() {
-                return Map.of("receive", receiveOperation);
             }
         }
     }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultOperationsServiceIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultOperationsServiceIntegrationTest.java
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.asyncapi;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.OperationsScanner;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelReference;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.OperationAction;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+        classes = {
+            DefaultOperationsService.class,
+            DefaultOperationsServiceIntegrationTest.SimpleOperationScanner.class,
+            DefaultOperationsServiceIntegrationTest.SameTopic.ReceiveOperationScanner.class,
+            DefaultOperationsServiceIntegrationTest.SameTopic.SendOperationScanner.class
+        })
+class DefaultOperationsServiceIntegrationTest {
+
+    @Autowired
+    private DefaultOperationsService defaultOperationsService;
+
+    @Autowired
+    private SimpleOperationScanner simpleOperationsScanner;
+
+    @Test
+    void getOperations() {
+        Map<String, Operation> actualChannels = defaultOperationsService.findOperations();
+
+        assertThat(actualChannels)
+                .containsAllEntriesOf(simpleOperationsScanner.scan())
+                .containsEntry("receive", SameTopic.ReceiveOperationScanner.receiveOperation)
+                .containsEntry("send", SameTopic.SendOperationScanner.sentOperation);
+    }
+
+    @Component
+    static class SimpleOperationScanner implements OperationsScanner {
+        @Override
+        public Map<String, Operation> scan() {
+            return Map.of(
+                    "foo",
+                    Operation.builder()
+                            .channel(ChannelReference.fromChannel("foo"))
+                            .action(OperationAction.RECEIVE)
+                            .build());
+        }
+    }
+
+    static class SameTopic {
+        static final String topicName = "receiveSendTopic";
+
+        @Component
+        static class SendOperationScanner implements OperationsScanner {
+            static final Operation sentOperation = Operation.builder()
+                    .channel(ChannelReference.fromChannel(topicName))
+                    .action(OperationAction.SEND)
+                    .build();
+
+            @Override
+            public Map<String, Operation> scan() {
+                return Map.of("send", sentOperation);
+            }
+        }
+
+        @Component
+        static class ReceiveOperationScanner implements OperationsScanner {
+            static final Operation receiveOperation = Operation.builder()
+                    .channel(ChannelReference.fromChannel(topicName))
+                    .action(OperationAction.RECEIVE)
+                    .build();
+
+            @Override
+            public Map<String, Operation> scan() {
+                return Map.of("receive", receiveOperation);
+            }
+        }
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/ChannelMergerTest.java
@@ -5,12 +5,9 @@ import io.github.stavshamir.springwolf.asyncapi.MessageHelper;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.OperationAction;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -35,22 +32,6 @@ class ChannelMergerTest {
     }
 
     @Test
-    void shouldNotMergeDifferentoperationIds() {
-        // given
-        String operationId1 = "operation1";
-        String operationId2 = "operation2";
-        Operation publisherOperation = Operation.builder().build();
-        Operation subscriberOperation = Operation.builder().build();
-
-        // when
-        Map<String, Operation> mergedOperations = ChannelMerger.mergeOperations(Arrays.asList(
-                Map.entry(operationId1, publisherOperation), Map.entry(operationId2, subscriberOperation)));
-
-        // then
-        assertThat(mergedOperations).hasSize(2);
-    }
-
-    @Test
     void shouldMergeEqualChannelNamesIntoOneChannel() {
         // given
         String channelName = "channel";
@@ -63,27 +44,6 @@ class ChannelMergerTest {
 
         // then
         assertThat(mergedChannels).hasSize(1);
-    }
-
-    @Test
-    void shouldMergeEqualoperationIdsIntoOneOperation() {
-        // given
-        String operationId = "operation";
-        Operation publishOperation = Operation.builder()
-                .action(OperationAction.SEND)
-                .title("publisher")
-                .build();
-        Operation subscribeOperation = Operation.builder()
-                .action(OperationAction.RECEIVE)
-                .title("subscribe")
-                .build();
-
-        // when
-        Map<String, Operation> mergedOperations = ChannelMerger.mergeOperations(
-                Arrays.asList(Map.entry(operationId, publishOperation), Map.entry(operationId, subscribeOperation)));
-
-        // then
-        assertThat(mergedOperations).hasSize(1);
     }
 
     @Test
@@ -102,25 +62,6 @@ class ChannelMergerTest {
         // then
         assertThat(mergedChannels).hasSize(1).hasEntrySatisfying(channelName, it -> {
             assertThat(it.getTitle()).isEqualTo("channel1");
-        });
-    }
-
-    @Test
-    void shouldUseFirstOperationFound() {
-        // given
-        String operationId = "operation";
-        Operation senderOperation =
-                Operation.builder().action(OperationAction.SEND).build();
-        Operation receiverOperation =
-                Operation.builder().action(OperationAction.RECEIVE).build();
-
-        // when
-        Map<String, Operation> mergedOperations = ChannelMerger.mergeOperations(
-                Arrays.asList(Map.entry(operationId, senderOperation), Map.entry(operationId, receiverOperation)));
-
-        // then
-        assertThat(mergedOperations).hasSize(1).hasEntrySatisfying(operationId, it -> {
-            assertThat(it.getAction()).isEqualTo(OperationAction.SEND);
         });
     }
 
@@ -168,59 +109,6 @@ class ChannelMergerTest {
     }
 
     @Test
-    void shouldMergeDifferentMessageForSameOperation() {
-        // given
-        String channelName = "channel";
-        String operationId = "operation";
-        MessageObject message1 = MessageObject.builder()
-                .messageId("message1")
-                .name(String.class.getCanonicalName())
-                .description("This is a string")
-                .build();
-        MessageObject message2 = MessageObject.builder()
-                .messageId("message2")
-                .name(Integer.class.getCanonicalName())
-                .description("This is an integer")
-                .build();
-        MessageObject message3 = MessageObject.builder()
-                .messageId("message3")
-                .name(Integer.class.getCanonicalName())
-                .description("This is also an integer, but in essence the same payload type")
-                .build();
-        MessageReference messageRef1 = MessageReference.toChannelMessage(channelName, message1);
-        MessageReference messageRef2 = MessageReference.toChannelMessage(channelName, message2);
-        MessageReference messageRef3 = MessageReference.toChannelMessage(channelName, message3);
-
-        Operation senderOperation1 = Operation.builder()
-                .action(OperationAction.SEND)
-                .title("sender1")
-                .messages(List.of(messageRef1))
-                .build();
-        Operation senderOperation2 = Operation.builder()
-                .action(OperationAction.SEND)
-                .title("sender2")
-                .messages(List.of(messageRef2))
-                .build();
-        Operation senderOperation3 = Operation.builder()
-                .action(OperationAction.SEND)
-                .title("sender3")
-                .messages(List.of(messageRef3))
-                .build();
-
-        // when
-        Map<String, Operation> mergedOperations = ChannelMerger.mergeOperations(List.of(
-                Map.entry(operationId, senderOperation1),
-                Map.entry(operationId, senderOperation2),
-                Map.entry(operationId, senderOperation3)));
-
-        // then expectedMessage only includes message1 and message2.
-        // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
-        assertThat(mergedOperations).hasSize(1).hasEntrySatisfying(operationId, it -> {
-            assertThat(it.getMessages()).containsExactlyInAnyOrder(messageRef1, messageRef2);
-        });
-    }
-
-    @Test
     void shouldUseOtherMessageIfFirstMessageIsMissingForChannels() {
         // given
         String channelName = "channel";
@@ -244,37 +132,6 @@ class ChannelMergerTest {
         assertThat(mergedChannels).hasSize(1).hasEntrySatisfying(channelName, it -> {
             assertThat(it.getMessages()).hasSize(1);
             assertThat(it.getMessages()).containsExactlyInAnyOrderEntriesOf(expectedMessages);
-        });
-    }
-
-    @Test
-    void shouldUseOtherMessageIfFirstMessageIsMissingForOperations() {
-        // given
-        String channelName = "channel-name";
-        MessageObject message2 = MessageObject.builder()
-                .messageId(String.class.getCanonicalName())
-                .name(String.class.getCanonicalName())
-                .description("This is a string")
-                .build();
-        Operation publishOperation1 = Operation.builder()
-                .action(OperationAction.SEND)
-                .title("publisher1")
-                .build();
-        Operation publishOperation2 = Operation.builder()
-                .action(OperationAction.SEND)
-                .title("publisher2")
-                .messages(List.of(MessageReference.toChannelMessage(channelName, message2)))
-                .build();
-
-        // when
-        Map<String, Operation> mergedOperations = ChannelMerger.mergeOperations(
-                Arrays.asList(Map.entry("publisher1", publishOperation1), Map.entry("publisher1", publishOperation2)));
-        // then expectedMessage message2
-        var expectedMessage = MessageReference.toChannelMessage(channelName, message2);
-
-        assertThat(mergedOperations).hasSize(1).hasEntrySatisfying("publisher1", it -> {
-            assertThat(it.getMessages()).hasSize(1);
-            assertThat(it.getMessages()).containsExactlyInAnyOrder(expectedMessage);
         });
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/OperationMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/OperationMergerTest.java
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
+
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.OperationAction;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OperationMergerTest {
+
+    @Test
+    void shouldNotMergeDifferentoperationIds() {
+        // given
+        String operationId1 = "operation1";
+        String operationId2 = "operation2";
+        Operation publisherOperation = Operation.builder().build();
+        Operation subscriberOperation = Operation.builder().build();
+
+        // when
+        Map<String, Operation> mergedOperations = OperationMerger.mergeOperations(Arrays.asList(
+                Map.entry(operationId1, publisherOperation), Map.entry(operationId2, subscriberOperation)));
+
+        // then
+        assertThat(mergedOperations).hasSize(2);
+    }
+
+    @Test
+    void shouldMergeEqualoperationIdsIntoOneOperation() {
+        // given
+        String operationId = "operation";
+        Operation publishOperation = Operation.builder()
+                .action(OperationAction.SEND)
+                .title("publisher")
+                .build();
+        Operation subscribeOperation = Operation.builder()
+                .action(OperationAction.RECEIVE)
+                .title("subscribe")
+                .build();
+
+        // when
+        Map<String, Operation> mergedOperations = OperationMerger.mergeOperations(
+                Arrays.asList(Map.entry(operationId, publishOperation), Map.entry(operationId, subscribeOperation)));
+
+        // then
+        assertThat(mergedOperations).hasSize(1);
+    }
+
+    @Test
+    void shouldUseFirstOperationFound() {
+        // given
+        String operationId = "operation";
+        Operation senderOperation =
+                Operation.builder().action(OperationAction.SEND).build();
+        Operation receiverOperation =
+                Operation.builder().action(OperationAction.RECEIVE).build();
+
+        // when
+        Map<String, Operation> mergedOperations = OperationMerger.mergeOperations(
+                Arrays.asList(Map.entry(operationId, senderOperation), Map.entry(operationId, receiverOperation)));
+
+        // then
+        assertThat(mergedOperations).hasSize(1).hasEntrySatisfying(operationId, it -> {
+            assertThat(it.getAction()).isEqualTo(OperationAction.SEND);
+        });
+    }
+
+    @Test
+    void shouldMergeDifferentMessageForSameOperation() {
+        // given
+        String channelName = "channel";
+        String operationId = "operation";
+        MessageObject message1 = MessageObject.builder()
+                .messageId("message1")
+                .name(String.class.getCanonicalName())
+                .description("This is a string")
+                .build();
+        MessageObject message2 = MessageObject.builder()
+                .messageId("message2")
+                .name(Integer.class.getCanonicalName())
+                .description("This is an integer")
+                .build();
+        MessageObject message3 = MessageObject.builder()
+                .messageId("message3")
+                .name(Integer.class.getCanonicalName())
+                .description("This is also an integer, but in essence the same payload type")
+                .build();
+        MessageReference messageRef1 = MessageReference.toChannelMessage(channelName, message1);
+        MessageReference messageRef2 = MessageReference.toChannelMessage(channelName, message2);
+        MessageReference messageRef3 = MessageReference.toChannelMessage(channelName, message3);
+
+        Operation senderOperation1 = Operation.builder()
+                .action(OperationAction.SEND)
+                .title("sender1")
+                .messages(List.of(messageRef1))
+                .build();
+        Operation senderOperation2 = Operation.builder()
+                .action(OperationAction.SEND)
+                .title("sender2")
+                .messages(List.of(messageRef2))
+                .build();
+        Operation senderOperation3 = Operation.builder()
+                .action(OperationAction.SEND)
+                .title("sender3")
+                .messages(List.of(messageRef3))
+                .build();
+
+        // when
+        Map<String, Operation> mergedOperations = OperationMerger.mergeOperations(List.of(
+                Map.entry(operationId, senderOperation1),
+                Map.entry(operationId, senderOperation2),
+                Map.entry(operationId, senderOperation3)));
+
+        // then expectedMessage only includes message1 and message2.
+        // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
+        assertThat(mergedOperations).hasSize(1).hasEntrySatisfying(operationId, it -> {
+            assertThat(it.getMessages()).containsExactlyInAnyOrder(messageRef1, messageRef2);
+        });
+    }
+
+    @Test
+    void shouldUseOtherMessageIfFirstMessageIsMissingForChannels() {
+        // given
+        String channelName = "channel";
+        MessageObject message2 = MessageObject.builder()
+                .messageId(String.class.getCanonicalName())
+                .name(String.class.getCanonicalName())
+                .description("This is a string")
+                .build();
+        ChannelObject publisherChannel1 = ChannelObject.builder().build();
+        ChannelObject publisherChannel2 = ChannelObject.builder()
+                .messages(Map.of(message2.getName(), message2))
+                .build();
+
+        // when
+        Map<String, ChannelObject> mergedChannels = ChannelMerger.mergeChannels(
+                Arrays.asList(Map.entry(channelName, publisherChannel1), Map.entry(channelName, publisherChannel2)));
+
+        // then expectedMessage message2
+        var expectedMessages = Map.of(message2.getName(), message2);
+
+        assertThat(mergedChannels).hasSize(1).hasEntrySatisfying(channelName, it -> {
+            assertThat(it.getMessages()).hasSize(1);
+            assertThat(it.getMessages()).containsExactlyInAnyOrderEntriesOf(expectedMessages);
+        });
+    }
+
+    @Test
+    void shouldUseOtherMessageIfFirstMessageIsMissingForOperations() {
+        // given
+        String channelName = "channel-name";
+        MessageObject message2 = MessageObject.builder()
+                .messageId(String.class.getCanonicalName())
+                .name(String.class.getCanonicalName())
+                .description("This is a string")
+                .build();
+        Operation publishOperation1 = Operation.builder()
+                .action(OperationAction.SEND)
+                .title("publisher1")
+                .build();
+        Operation publishOperation2 = Operation.builder()
+                .action(OperationAction.SEND)
+                .title("publisher2")
+                .messages(List.of(MessageReference.toChannelMessage(channelName, message2)))
+                .build();
+
+        // when
+        Map<String, Operation> mergedOperations = OperationMerger.mergeOperations(
+                Arrays.asList(Map.entry("publisher1", publishOperation1), Map.entry("publisher1", publishOperation2)));
+        // then expectedMessage message2
+        var expectedMessage = MessageReference.toChannelMessage(channelName, message2);
+
+        assertThat(mergedOperations).hasSize(1).hasEntrySatisfying("publisher1", it -> {
+            assertThat(it.getMessages()).hasSize(1);
+            assertThat(it.getMessages()).containsExactlyInAnyOrder(expectedMessage);
+        });
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/SimpleChannelsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/SimpleChannelsScannerTest.java
@@ -3,7 +3,6 @@ package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
 
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -26,12 +25,10 @@ class SimpleChannelsScannerTest {
     @Test
     void noClassFoundTest() {
         // when
-        Map<String, ChannelObject> channels = simpleChannelsScanner.scanChannels();
-        Map<String, Operation> operations = simpleChannelsScanner.scanOperations();
+        Map<String, ChannelObject> channels = simpleChannelsScanner.scan();
 
         // then
         assertThat(channels).isEmpty();
-        assertThat(operations).isEmpty();
     }
 
     @Test
@@ -42,10 +39,10 @@ class SimpleChannelsScannerTest {
                 Map.entry("channel1", ChannelObject.builder().build());
         Map.Entry<String, ChannelObject> channel2 =
                 Map.entry("channel2", ChannelObject.builder().build());
-        when(classProcessor.processChannels(any())).thenReturn(Stream.of(channel1, channel2));
+        when(classProcessor.process(any())).thenReturn(Stream.of(channel1, channel2));
 
         // when
-        Map<String, ChannelObject> channels = simpleChannelsScanner.scanChannels();
+        Map<String, ChannelObject> channels = simpleChannelsScanner.scan();
 
         // then
         assertThat(channels).containsExactly(channel1, channel2);
@@ -59,10 +56,10 @@ class SimpleChannelsScannerTest {
                 Map.entry("channel1", ChannelObject.builder().build());
         Map.Entry<String, ChannelObject> channel2 =
                 Map.entry("channel1", ChannelObject.builder().build());
-        when(classProcessor.processChannels(any())).thenReturn(Stream.of(channel1, channel2));
+        when(classProcessor.process(any())).thenReturn(Stream.of(channel1, channel2));
 
         // when
-        Map<String, ChannelObject> channels = simpleChannelsScanner.scanChannels();
+        Map<String, ChannelObject> channels = simpleChannelsScanner.scan();
 
         // then
         assertThat(channels)
@@ -73,10 +70,10 @@ class SimpleChannelsScannerTest {
     void processEmptyClassTest() {
         // given
         when(classScanner.scan()).thenReturn(Set.of(String.class));
-        when(classProcessor.processChannels(any())).thenReturn(Stream.of());
+        when(classProcessor.process(any())).thenReturn(Stream.of());
 
         // when
-        Map<String, ChannelObject> channels = simpleChannelsScanner.scanChannels();
+        Map<String, ChannelObject> channels = simpleChannelsScanner.scan();
 
         // then
         assertThat(channels).isEmpty();

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/SimpleOperationsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/SimpleOperationsScannerTest.java
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.asyncapi.scanners.channels;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.classes.ClassScanner;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SimpleOperationsScannerTest {
+
+    private final ClassScanner classScanner = mock(ClassScanner.class);
+    private final SimpleOperationsScanner.ClassProcessor classProcessor =
+            mock(SimpleOperationsScanner.ClassProcessor.class);
+
+    private final SimpleOperationsScanner simpleOperationsScanner =
+            new SimpleOperationsScanner(classScanner, classProcessor);
+
+    @Test
+    void noClassFoundTest() {
+        // when
+        Map<String, Operation> operations = simpleOperationsScanner.scan();
+
+        // then
+        assertThat(operations).isEmpty();
+    }
+
+    @Test
+    void processClassTest() {
+        // given
+        when(classScanner.scan()).thenReturn(Set.of(String.class));
+        Map.Entry<String, Operation> operation1 =
+                Map.entry("operation1", Operation.builder().build());
+        Map.Entry<String, Operation> operation2 =
+                Map.entry("operation2", Operation.builder().build());
+        when(classProcessor.process(any())).thenReturn(Stream.of(operation1, operation2));
+
+        // when
+        Map<String, Operation> operations = simpleOperationsScanner.scan();
+
+        // then
+        assertThat(operations).containsExactly(operation2, operation1);
+    }
+
+    @Test
+    void sameOperationsAreMergedTest() {
+        // given
+        when(classScanner.scan()).thenReturn(Set.of(String.class));
+        Map.Entry<String, Operation> operation1 =
+                Map.entry("operation1", Operation.builder().build());
+        Map.Entry<String, Operation> operation2 =
+                Map.entry("operation1", Operation.builder().build());
+        when(classProcessor.process(any())).thenReturn(Stream.of(operation1, operation2));
+
+        // when
+        Map<String, Operation> operations = simpleOperationsScanner.scan();
+
+        // then
+        assertThat(operations)
+                .containsExactly(Map.entry("operation1", Operation.builder().build()));
+    }
+
+    @Test
+    void processEmptyClassTest() {
+        // given
+        when(classScanner.scan()).thenReturn(Set.of(String.class));
+        when(classProcessor.process(any())).thenReturn(Stream.of());
+
+        // when
+        Map<String, Operation> operations = simpleOperationsScanner.scan();
+
+        // then
+        assertThat(operations).isEmpty();
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationChannelsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationChannelsScannerTest.java
@@ -58,8 +58,8 @@ import static org.mockito.Mockito.when;
 
 class AsyncAnnotationChannelsScannerTest {
 
-    private AsyncAnnotationChannelsScanner.AsyncAnnotationProvider<AsyncListener> asyncAnnotationProvider =
-            new AsyncAnnotationChannelsScanner.AsyncAnnotationProvider<>() {
+    private final AsyncAnnotationScanner.AsyncAnnotationProvider<AsyncListener> asyncAnnotationProvider =
+            new AsyncAnnotationScanner.AsyncAnnotationProvider<>() {
                 @Override
                 public Class<AsyncListener> getAnnotation() {
                     return AsyncListener.class;

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationOperationsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/AsyncAnnotationOperationsScannerTest.java
@@ -57,8 +57,8 @@ import static org.mockito.Mockito.when;
 
 class AsyncAnnotationOperationsScannerTest {
 
-    private final AsyncAnnotationOperationsScanner.AsyncAnnotationProvider<AsyncListener> asyncAnnotationProvider =
-            new AsyncAnnotationOperationsScanner.AsyncAnnotationProvider<>() {
+    private final AsyncAnnotationScanner.AsyncAnnotationProvider<AsyncListener> asyncAnnotationProvider =
+            new AsyncAnnotationScanner.AsyncAnnotationProvider<>() {
                 @Override
                 public Class<AsyncListener> getAnnotation() {
                     return AsyncListener.class;

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScannerIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScannerIntegrationTest.java
@@ -78,7 +78,7 @@ class ClassLevelAnnotationChannelsScannerIntegrationTest {
         void scan_componentHasNoClassLevelRabbitListenerAnnotation() {
             // when
             List<Map.Entry<String, ChannelObject>> channels =
-                    scanner.processChannels(ClassWithoutClassListener.class).toList();
+                    scanner.process(ClassWithoutClassListener.class).toList();
 
             // then
             assertThat(channels).isEmpty();
@@ -97,7 +97,7 @@ class ClassLevelAnnotationChannelsScannerIntegrationTest {
         void scan_componentHasNoClassLevelRabbitListenerAnnotation() {
             // when
             List<Map.Entry<String, ChannelObject>> channels =
-                    scanner.processChannels(ClassWithoutMethodListener.class).toList();
+                    scanner.process(ClassWithoutMethodListener.class).toList();
 
             // then
             assertThat(channels).isEmpty();
@@ -115,9 +115,8 @@ class ClassLevelAnnotationChannelsScannerIntegrationTest {
         @Test
         void scan_componentWithOneMethodLevelAnnotation() {
             // when
-            List<Map.Entry<String, ChannelObject>> actualChannels = scanner.processChannels(
-                            ClassWithOneMethodLevelHandler.class)
-                    .toList();
+            List<Map.Entry<String, ChannelObject>> actualChannels =
+                    scanner.process(ClassWithOneMethodLevelHandler.class).toList();
 
             // then
             MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
@@ -158,9 +157,8 @@ class ClassLevelAnnotationChannelsScannerIntegrationTest {
         @Test
         void scan_componentWithMultipleRabbitHandlerMethods() {
             // when
-            List<Map.Entry<String, ChannelObject>> actualChannels = scanner.processChannels(
-                            ClassWithMultipleMethodLevelHandlers.class)
-                    .toList();
+            List<Map.Entry<String, ChannelObject>> actualChannels =
+                    scanner.process(ClassWithMultipleMethodLevelHandlers.class).toList();
 
             // Then the returned collection contains the channel with message set to oneOf
             MessagePayload simpleFooPayload = MessagePayload.of(MultiFormatSchema.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/ClassLevelAnnotationChannelsScannerTest.java
@@ -28,7 +28,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -81,7 +80,7 @@ class ClassLevelAnnotationChannelsScannerTest {
     void scan_componentHasTestListenerMethods() {
         // when
         List<Map.Entry<String, ChannelObject>> channels =
-                scanner.processChannels(ClassWithTestListenerAnnotation.class).collect(Collectors.toList());
+                scanner.process(ClassWithTestListenerAnnotation.class).toList();
 
         // then
         MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationChannelsScannerIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/annotation/MethodLevelAnnotationChannelsScannerIntegrationTest.java
@@ -73,9 +73,8 @@ class MethodLevelAnnotationChannelsScannerIntegrationTest {
         @Test
         void scan_componentHasNoListenerMethods() {
             // when
-            List<Map.Entry<String, ChannelObject>> channels = scanner.processChannels(
-                            ClassWithoutListenerAnnotation.class)
-                    .toList();
+            List<Map.Entry<String, ChannelObject>> channels =
+                    scanner.process(ClassWithoutListenerAnnotation.class).toList();
 
             // then
             assertThat(channels).isEmpty();
@@ -92,7 +91,7 @@ class MethodLevelAnnotationChannelsScannerIntegrationTest {
         void scan_componentHasListenerMethod() {
             // when
             List<Map.Entry<String, ChannelObject>> actualChannels =
-                    scanner.processChannels(ClassWithListenerAnnotation.class).toList();
+                    scanner.process(ClassWithListenerAnnotation.class).toList();
 
             // then
             MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
@@ -130,7 +129,7 @@ class MethodLevelAnnotationChannelsScannerIntegrationTest {
         @Test
         void scan_componentHasTestListenerMethods_multiplePayloads() {
             // when
-            List<Map.Entry<String, ChannelObject>> channels = scanner.processChannels(
+            List<Map.Entry<String, ChannelObject>> channels = scanner.process(
                             ClassWithTestListenerAnnotationMultiplePayloads.class)
                     .toList();
 
@@ -191,9 +190,8 @@ class MethodLevelAnnotationChannelsScannerIntegrationTest {
         @Test
         void scan_componentHasListenerMetaMethod() {
             // when
-            List<Map.Entry<String, ChannelObject>> actualChannels = scanner.processChannels(
-                            ClassWithListenerMetaAnnotation.class)
-                    .toList();
+            List<Map.Entry<String, ChannelObject>> actualChannels =
+                    scanner.process(ClassWithListenerMetaAnnotation.class).toList();
 
             // then
             MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()

--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/amqp/ApiIntegrationTest.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/stavshamir/springwolf/example/amqp/ApiIntegrationTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SpringBootTest(
         classes = {SpringwolfAmqpExampleApplication.class},
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class ApiIntegrationTest {
+class ApiIntegrationTest {
 
     @Autowired
     private TestRestTemplate restTemplate;

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/amqp/SpringwolfAmqpScannerConfiguration.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/amqp/SpringwolfAmqpScannerConfiguration.java
@@ -7,8 +7,11 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.processor.Amqp
 import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.processor.AmqpOperationBindingProcessor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.SimpleChannelsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.SimpleOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.ClassLevelAnnotationChannelsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.ClassLevelAnnotationOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelAnnotationChannelsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelAnnotationOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.SpringwolfClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeadersForAmqpBuilder;
@@ -82,6 +85,30 @@ public class SpringwolfAmqpScannerConfiguration {
             havingValue = "true",
             matchIfMissing = true)
     @Order(value = ChannelPriority.AUTO_DISCOVERED)
+    public SimpleOperationsScanner simpleRabbitClassLevelListenerAnnotationOperationsScanner(
+            SpringwolfClassScanner classScanner,
+            AmqpBindingFactory amqpBindingBuilder,
+            AsyncHeadersForAmqpBuilder asyncHeadersForAmqpBuilder,
+            PayloadClassExtractor payloadClassExtractor,
+            SchemasService schemasService) {
+        ClassLevelAnnotationOperationsScanner<RabbitListener, RabbitHandler> strategy =
+                new ClassLevelAnnotationOperationsScanner<>(
+                        RabbitListener.class,
+                        RabbitHandler.class,
+                        amqpBindingBuilder,
+                        asyncHeadersForAmqpBuilder,
+                        payloadClassExtractor,
+                        schemasService);
+
+        return new SimpleOperationsScanner(classScanner, strategy);
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+            name = SPRINGWOLF_SCANNER_RABBIT_LISTENER_ENABLED,
+            havingValue = "true",
+            matchIfMissing = true)
+    @Order(value = ChannelPriority.AUTO_DISCOVERED)
     public SimpleChannelsScanner simpleRabbitMethodLevelListenerAnnotationChannelsScanner(
             SpringwolfClassScanner classScanner,
             AmqpBindingFactory amqpBindingBuilder,
@@ -91,6 +118,23 @@ public class SpringwolfAmqpScannerConfiguration {
                 RabbitListener.class, amqpBindingBuilder, payloadClassExtractor, schemasService);
 
         return new SimpleChannelsScanner(classScanner, strategy);
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+            name = SPRINGWOLF_SCANNER_RABBIT_LISTENER_ENABLED,
+            havingValue = "true",
+            matchIfMissing = true)
+    @Order(value = ChannelPriority.AUTO_DISCOVERED)
+    public SimpleOperationsScanner simpleRabbitMethodLevelListenerAnnotationOperationsScanner(
+            SpringwolfClassScanner classScanner,
+            AmqpBindingFactory amqpBindingBuilder,
+            PayloadClassExtractor payloadClassExtractor,
+            SchemasService schemasService) {
+        MethodLevelAnnotationOperationsScanner<RabbitListener> strategy = new MethodLevelAnnotationOperationsScanner<>(
+                RabbitListener.class, amqpBindingBuilder, payloadClassExtractor, schemasService);
+
+        return new SimpleOperationsScanner(classScanner, strategy);
     }
 
     @Bean

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/cloudstream/SpringwolfCloudStreamAutoConfiguration.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/cloudstream/SpringwolfCloudStreamAutoConfiguration.java
@@ -3,6 +3,7 @@ package io.github.stavshamir.springwolf.asyncapi.cloudstream;
 
 import io.github.stavshamir.springwolf.asyncapi.scanners.beans.BeanMethodsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.cloudstream.CloudStreamFunctionChannelsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.cloudstream.CloudStreamFunctionOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.cloudstream.FunctionalChannelBeanBuilder;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
@@ -28,6 +29,21 @@ public class SpringwolfCloudStreamAutoConfiguration {
             BindingServiceProperties cloudstreamBindingServiceProperties,
             FunctionalChannelBeanBuilder functionalChannelBeanBuilder) {
         return new CloudStreamFunctionChannelsScanner(
+                asyncApiDocketService,
+                beanMethodsScanner,
+                schemasService,
+                cloudstreamBindingServiceProperties,
+                functionalChannelBeanBuilder);
+    }
+
+    @Bean
+    public CloudStreamFunctionOperationsScanner cloudStreamFunctionOperationsScanner(
+            AsyncApiDocketService asyncApiDocketService,
+            BeanMethodsScanner beanMethodsScanner,
+            SchemasService schemasService,
+            BindingServiceProperties cloudstreamBindingServiceProperties,
+            FunctionalChannelBeanBuilder functionalChannelBeanBuilder) {
+        return new CloudStreamFunctionOperationsScanner(
                 asyncApiDocketService,
                 beanMethodsScanner,
                 schemasService,

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScanner.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScanner.java
@@ -45,7 +45,7 @@ public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
     private final FunctionalChannelBeanBuilder functionalChannelBeanBuilder;
 
     @Override
-    public Map<String, ChannelObject> scanChannels() {
+    public Map<String, ChannelObject> scan() {
         Set<Method> beanMethods = beanMethodsScanner.getBeanMethods();
         return ChannelMerger.mergeChannels(beanMethods.stream()
                 .map(functionalChannelBeanBuilder::fromMethodBean)

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionOperationsScanner.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionOperationsScanner.java
@@ -2,20 +2,20 @@
 package io.github.stavshamir.springwolf.asyncapi.scanners.channels.cloudstream;
 
 import io.github.stavshamir.springwolf.asyncapi.scanners.beans.BeanMethodsScanner;
-import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelMerger;
-import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelsScanner;
-import io.github.stavshamir.springwolf.asyncapi.types.channel.bindings.EmptyChannelBinding;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.OperationMerger;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.OperationsScanner;
+import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.bindings.EmptyOperationBinding;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.bindings.EmptyMessageBinding;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeaders;
-import io.github.stavshamir.springwolf.asyncapi.v3.bindings.ChannelBinding;
 import io.github.stavshamir.springwolf.asyncapi.v3.bindings.MessageBinding;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelObject;
+import io.github.stavshamir.springwolf.asyncapi.v3.bindings.OperationBinding;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.ChannelReference;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageHeaders;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageObject;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessagePayload;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.MessageReference;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.MultiFormatSchema;
-import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaReference;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.Operation;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.operation.OperationAction;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.server.Server;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocket;
 import io.github.stavshamir.springwolf.configuration.AsyncApiDocketService;
@@ -25,12 +25,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 @Slf4j
 @RequiredArgsConstructor
-public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
+public class CloudStreamFunctionOperationsScanner implements OperationsScanner {
 
     private final AsyncApiDocketService asyncApiDocketService;
     private final BeanMethodsScanner beanMethodsScanner;
@@ -39,13 +40,13 @@ public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
     private final FunctionalChannelBeanBuilder functionalChannelBeanBuilder;
 
     @Override
-    public Map<String, ChannelObject> scan() {
+    public Map<String, Operation> scan() {
         Set<Method> beanMethods = beanMethodsScanner.getBeanMethods();
-        return ChannelMerger.mergeChannels(beanMethods.stream()
+        return OperationMerger.mergeOperations(beanMethods.stream()
                 .map(functionalChannelBeanBuilder::fromMethodBean)
                 .flatMap(Set::stream)
                 .filter(this::isChannelBean)
-                .map(this::toChannelEntry)
+                .map(this::toOperationEntry)
                 .toList());
     }
 
@@ -53,40 +54,43 @@ public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
         return cloudStreamBindingsProperties.getBindings().containsKey(beanData.cloudStreamBinding());
     }
 
-    private Map.Entry<String, ChannelObject> toChannelEntry(FunctionalChannelBeanData beanData) {
+    private Map.Entry<String, Operation> toOperationEntry(FunctionalChannelBeanData beanData) {
         String channelName = cloudStreamBindingsProperties
                 .getBindings()
                 .get(beanData.cloudStreamBinding())
                 .getDestination();
 
-        ChannelObject channelItem = buildChannel(beanData);
+        String operationId = buildOperationId(beanData, channelName);
+        Operation operation = buildOperation(beanData, channelName);
 
-        return Map.entry(channelName, channelItem);
+        return Map.entry(operationId, operation);
     }
 
-    private ChannelObject buildChannel(FunctionalChannelBeanData beanData) {
+    private Operation buildOperation(FunctionalChannelBeanData beanData, String channelName) {
         Class<?> payloadType = beanData.payloadType();
         String modelName = schemasService.registerSchema(payloadType);
         String headerModelName = schemasService.registerSchema(AsyncHeaders.NOT_DOCUMENTED);
 
-        var messagePayload = MessagePayload.of(MultiFormatSchema.builder()
-                .schema(SchemaReference.fromSchema(modelName))
-                .build());
-
         MessageObject message = MessageObject.builder()
                 .name(payloadType.getName())
                 .title(modelName)
-                .payload(messagePayload)
+                .payload(MessagePayload.of(MessageReference.toSchema(modelName)))
                 .headers(MessageHeaders.of(MessageReference.toSchema(headerModelName)))
                 .bindings(buildMessageBinding())
                 .build();
-        this.schemasService.registerMessage(message);
 
-        Map<String, ChannelBinding> channelBinding = buildChannelBinding();
-        return ChannelObject.builder()
-                .bindings(channelBinding)
-                .messages(Map.of(message.getName(), MessageReference.toComponentMessage(message)))
-                .build();
+        var builder = Operation.builder()
+                .description("Auto-generated description")
+                .channel(ChannelReference.fromChannel(channelName))
+                .messages(List.of(MessageReference.toChannelMessage(channelName, message)))
+                .bindings(buildOperationBinding());
+        if (beanData.beanType() == FunctionalChannelBeanData.BeanType.CONSUMER) {
+            builder.action(OperationAction.RECEIVE);
+        } else {
+            builder.action(OperationAction.SEND);
+        }
+
+        return builder.build();
     }
 
     private Map<String, MessageBinding> buildMessageBinding() {
@@ -94,9 +98,9 @@ public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
         return Map.of(protocolName, new EmptyMessageBinding());
     }
 
-    private Map<String, ChannelBinding> buildChannelBinding() {
+    private Map<String, OperationBinding> buildOperationBinding() {
         String protocolName = getProtocolName();
-        return Map.of(protocolName, new EmptyChannelBinding());
+        return Map.of(protocolName, new EmptyOperationBinding());
     }
 
     private String getProtocolName() {
@@ -112,5 +116,12 @@ public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
                 .map(Server::getProtocol)
                 .orElseThrow(() ->
                         new IllegalStateException("There must be at least one server define in the AsyncApiDocker"));
+    }
+
+    private String buildOperationId(FunctionalChannelBeanData beanData, String channelName) {
+        String operationName =
+                beanData.beanType() == FunctionalChannelBeanData.BeanType.CONSUMER ? "publish" : "subscribe";
+
+        return String.format("%s_%s_%s", channelName, operationName, beanData.beanName());
     }
 }

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScannerIntegrationTest.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScannerIntegrationTest.java
@@ -62,6 +62,7 @@ import static org.mockito.Mockito.when;
             ExampleJsonGenerator.class,
             DefaultAsyncApiDocketService.class,
             CloudStreamFunctionChannelsScanner.class,
+            CloudStreamFunctionOperationsScanner.class,
             FunctionalChannelBeanBuilder.class,
             SpringwolfConfigProperties.class
         })
@@ -82,7 +83,10 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
     private BindingServiceProperties bindingServiceProperties;
 
     @Autowired
-    private CloudStreamFunctionChannelsScanner scanner;
+    private CloudStreamFunctionChannelsScanner channelsScanner;
+
+    @Autowired
+    private CloudStreamFunctionOperationsScanner operationsScanner;
 
     @Autowired
     private SchemasService schemasService;
@@ -94,7 +98,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
     @Test
     void testNoBindings() {
         when(bindingServiceProperties.getBindings()).thenReturn(Collections.emptyMap());
-        Map<String, ChannelObject> channels = scanner.scan();
+        Map<String, ChannelObject> channels = channelsScanner.scan();
         assertThat(channels).isEmpty();
     }
 
@@ -107,8 +111,8 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
         when(bindingServiceProperties.getBindings()).thenReturn(Map.of("testConsumer-in-0", testConsumerInBinding));
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = scanner.scan();
-        Map<String, Operation> actualOperations = scanner.scanOperations();
+        Map<String, ChannelObject> actualChannels = channelsScanner.scan();
+        Map<String, Operation> actualOperations = operationsScanner.scan();
 
         // Then the returned channels contain a ChannelItem with the correct data
         MessageObject message = MessageObject.builder()
@@ -149,8 +153,8 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
         when(bindingServiceProperties.getBindings()).thenReturn(Map.of("testSupplier-out-0", testSupplierOutBinding));
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = scanner.scan();
-        Map<String, Operation> actualOperations = scanner.scanOperations();
+        Map<String, ChannelObject> actualChannels = channelsScanner.scan();
+        Map<String, Operation> actualOperations = operationsScanner.scan();
 
         // Then the returned channels contain a ChannelItem with the correct data
 
@@ -201,8 +205,8 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
                         "testFunction-out-0", testFunctionOutBinding));
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = scanner.scan();
-        Map<String, Operation> actualOperations = scanner.scanOperations();
+        Map<String, ChannelObject> actualChannels = channelsScanner.scan();
+        Map<String, Operation> actualOperations = operationsScanner.scan();
 
         // Then the returned channels contain a publish ChannelItem and a subscribe ChannelItem
         MessageObject subscribeMessage = MessageObject.builder()
@@ -278,8 +282,8 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
                         "kStreamTestFunction-out-0", testFunctionOutBinding));
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = scanner.scan();
-        Map<String, Operation> actualOperations = scanner.scanOperations();
+        Map<String, ChannelObject> actualChannels = channelsScanner.scan();
+        Map<String, Operation> actualOperations = operationsScanner.scan();
 
         // Then the returned channels contain a publish ChannelItem and a subscribe ChannelItem
         MessageObject subscribeMessage = MessageObject.builder()
@@ -356,8 +360,8 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
                         "testFunction-out-0", testFunctionOutBinding));
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = scanner.scan();
-        Map<String, Operation> actualOperations = scanner.scanOperations();
+        Map<String, ChannelObject> actualChannels = channelsScanner.scan();
+        Map<String, Operation> actualOperations = operationsScanner.scan();
 
         // Then the returned merged channels contain a publish operation and  a subscribe operation
         MessageObject subscribeMessage = MessageObject.builder()

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScannerIntegrationTest.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/stavshamir/springwolf/asyncapi/scanners/channels/cloudstream/CloudStreamFunctionChannelsScannerIntegrationTest.java
@@ -94,7 +94,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
     @Test
     void testNoBindings() {
         when(bindingServiceProperties.getBindings()).thenReturn(Collections.emptyMap());
-        Map<String, ChannelObject> channels = scanner.scanChannels();
+        Map<String, ChannelObject> channels = scanner.scan();
         assertThat(channels).isEmpty();
     }
 
@@ -107,7 +107,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
         when(bindingServiceProperties.getBindings()).thenReturn(Map.of("testConsumer-in-0", testConsumerInBinding));
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = scanner.scanChannels();
+        Map<String, ChannelObject> actualChannels = scanner.scan();
         Map<String, Operation> actualOperations = scanner.scanOperations();
 
         // Then the returned channels contain a ChannelItem with the correct data
@@ -149,7 +149,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
         when(bindingServiceProperties.getBindings()).thenReturn(Map.of("testSupplier-out-0", testSupplierOutBinding));
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = scanner.scanChannels();
+        Map<String, ChannelObject> actualChannels = scanner.scan();
         Map<String, Operation> actualOperations = scanner.scanOperations();
 
         // Then the returned channels contain a ChannelItem with the correct data
@@ -201,7 +201,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
                         "testFunction-out-0", testFunctionOutBinding));
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = scanner.scanChannels();
+        Map<String, ChannelObject> actualChannels = scanner.scan();
         Map<String, Operation> actualOperations = scanner.scanOperations();
 
         // Then the returned channels contain a publish ChannelItem and a subscribe ChannelItem
@@ -278,7 +278,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
                         "kStreamTestFunction-out-0", testFunctionOutBinding));
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = scanner.scanChannels();
+        Map<String, ChannelObject> actualChannels = scanner.scan();
         Map<String, Operation> actualOperations = scanner.scanOperations();
 
         // Then the returned channels contain a publish ChannelItem and a subscribe ChannelItem
@@ -356,7 +356,7 @@ class CloudStreamFunctionChannelsScannerIntegrationTest {
                         "testFunction-out-0", testFunctionOutBinding));
 
         // When scan is called
-        Map<String, ChannelObject> actualChannels = scanner.scanChannels();
+        Map<String, ChannelObject> actualChannels = scanner.scan();
         Map<String, Operation> actualOperations = scanner.scanOperations();
 
         // Then the returned merged channels contain a publish operation and  a subscribe operation

--- a/springwolf-plugins/springwolf-jms-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/jms/SpringwolfJmsScannerConfiguration.java
+++ b/springwolf-plugins/springwolf-jms-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/jms/SpringwolfJmsScannerConfiguration.java
@@ -7,7 +7,9 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.processor.JmsM
 import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.processor.JmsOperationBindingProcessor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.SimpleChannelsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.SimpleOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelAnnotationChannelsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelAnnotationOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.SpringwolfClassScanner;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
@@ -44,6 +46,20 @@ public class SpringwolfJmsScannerConfiguration {
                 JmsListener.class, jmsBindingBuilder, payloadClassExtractor, schemasService);
 
         return new SimpleChannelsScanner(classScanner, strategy);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = SPRINGWOLF_SCANNER_JMS_LISTENER_ENABLED, havingValue = "true", matchIfMissing = true)
+    @Order(value = ChannelPriority.AUTO_DISCOVERED)
+    public SimpleOperationsScanner simpleJmsMethodLevelListenerAnnotationOperationsScanner(
+            SpringwolfClassScanner classScanner,
+            JmsBindingFactory jmsBindingBuilder,
+            PayloadClassExtractor payloadClassExtractor,
+            SchemasService schemasService) {
+        MethodLevelAnnotationOperationsScanner<JmsListener> strategy = new MethodLevelAnnotationOperationsScanner<>(
+                JmsListener.class, jmsBindingBuilder, payloadClassExtractor, schemasService);
+
+        return new SimpleOperationsScanner(classScanner, strategy);
     }
 
     @Bean

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/kafka/SpringwolfKafkaScannerConfiguration.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/kafka/SpringwolfKafkaScannerConfiguration.java
@@ -7,8 +7,11 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.processor.Kafk
 import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.processor.KafkaOperationBindingProcessor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.SimpleChannelsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.SimpleOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.ClassLevelAnnotationChannelsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.ClassLevelAnnotationOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelAnnotationChannelsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelAnnotationOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.SpringwolfClassScanner;
 import io.github.stavshamir.springwolf.asyncapi.types.channel.operation.message.header.AsyncHeadersForKafkaBuilder;
@@ -77,6 +80,30 @@ public class SpringwolfKafkaScannerConfiguration {
             havingValue = "true",
             matchIfMissing = true)
     @Order(value = ChannelPriority.AUTO_DISCOVERED)
+    public SimpleOperationsScanner simpleKafkaClassLevelListenerAnnotationOperationScanner(
+            SpringwolfClassScanner classScanner,
+            KafkaBindingFactory kafkaBindingBuilder,
+            AsyncHeadersForKafkaBuilder asyncHeadersForKafkaBuilder,
+            PayloadClassExtractor payloadClassExtractor,
+            SchemasService schemasService) {
+        ClassLevelAnnotationOperationsScanner<KafkaListener, KafkaHandler> strategy =
+                new ClassLevelAnnotationOperationsScanner<>(
+                        KafkaListener.class,
+                        KafkaHandler.class,
+                        kafkaBindingBuilder,
+                        asyncHeadersForKafkaBuilder,
+                        payloadClassExtractor,
+                        schemasService);
+
+        return new SimpleOperationsScanner(classScanner, strategy);
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+            name = SPRINGWOLF_SCANNER_KAFKA_LISTENER_ENABLED,
+            havingValue = "true",
+            matchIfMissing = true)
+    @Order(value = ChannelPriority.AUTO_DISCOVERED)
     public SimpleChannelsScanner simpleKafkaMethodLevelListenerAnnotationChannelsScanner(
             SpringwolfClassScanner classScanner,
             KafkaBindingFactory kafkaBindingBuilder,
@@ -86,6 +113,23 @@ public class SpringwolfKafkaScannerConfiguration {
                 KafkaListener.class, kafkaBindingBuilder, payloadClassExtractor, schemasService);
 
         return new SimpleChannelsScanner(classScanner, strategy);
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+            name = SPRINGWOLF_SCANNER_KAFKA_LISTENER_ENABLED,
+            havingValue = "true",
+            matchIfMissing = true)
+    @Order(value = ChannelPriority.AUTO_DISCOVERED)
+    public SimpleOperationsScanner simpleKafkaMethodLevelListenerAnnotationOperationsScanner(
+            SpringwolfClassScanner classScanner,
+            KafkaBindingFactory kafkaBindingBuilder,
+            PayloadClassExtractor payloadClassExtractor,
+            SchemasService schemasService) {
+        MethodLevelAnnotationOperationsScanner<KafkaListener> strategy = new MethodLevelAnnotationOperationsScanner<>(
+                KafkaListener.class, kafkaBindingBuilder, payloadClassExtractor, schemasService);
+
+        return new SimpleOperationsScanner(classScanner, strategy);
     }
 
     @Bean

--- a/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/sqs/SpringwolfSqsScannerConfiguration.java
+++ b/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/stavshamir/springwolf/asyncapi/sqs/SpringwolfSqsScannerConfiguration.java
@@ -8,7 +8,9 @@ import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.processor.SqsM
 import io.github.stavshamir.springwolf.asyncapi.scanners.bindings.processor.SqsOperationBindingProcessor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.ChannelPriority;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.SimpleChannelsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.SimpleOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelAnnotationChannelsScanner;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.annotation.MethodLevelAnnotationOperationsScanner;
 import io.github.stavshamir.springwolf.asyncapi.scanners.channels.payload.PayloadClassExtractor;
 import io.github.stavshamir.springwolf.asyncapi.scanners.classes.SpringwolfClassScanner;
 import io.github.stavshamir.springwolf.schemas.SchemasService;
@@ -44,6 +46,20 @@ public class SpringwolfSqsScannerConfiguration {
                 SqsListener.class, sqsBindingBuilder, payloadClassExtractor, schemasService);
 
         return new SimpleChannelsScanner(classScanner, strategy);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = SPRINGWOLF_SCANNER_SQS_LISTENER_ENABLED, havingValue = "true", matchIfMissing = true)
+    @Order(value = ChannelPriority.AUTO_DISCOVERED)
+    public SimpleOperationsScanner simpleSqsMethodLevelListenerAnnotationOperationsScanner(
+            SpringwolfClassScanner classScanner,
+            SqsBindingFactory sqsBindingBuilder,
+            PayloadClassExtractor payloadClassExtractor,
+            SchemasService schemasService) {
+        MethodLevelAnnotationOperationsScanner<SqsListener> strategy = new MethodLevelAnnotationOperationsScanner<>(
+                SqsListener.class, sqsBindingBuilder, payloadClassExtractor, schemasService);
+
+        return new SimpleOperationsScanner(classScanner, strategy);
     }
 
     @Bean


### PR DESCRIPTION
chore: Split ChannelScanner and OperationScanner

Channel and Operation are 2 different concepts and AsyncAPI v3 differentiated them even more.

This PR modifies the code to split the responsibilities in their own classes.