### PR TITLE
feat: Added support for Spring Messaging @Header annotations

### DIFF
--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/channels/annotations/SpringAnnotationMethodLevelChannelsScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/channels/annotations/SpringAnnotationMethodLevelChannelsScanner.java
@@ -6,9 +6,11 @@ import io.github.springwolf.asyncapi.v3.model.channel.ChannelObject;
 import io.github.springwolf.asyncapi.v3.model.channel.message.MessageObject;
 import io.github.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import io.github.springwolf.core.asyncapi.components.ComponentsService;
+import io.github.springwolf.core.asyncapi.components.headers.AsyncHeaders;
 import io.github.springwolf.core.asyncapi.components.headers.AsyncHeadersBuilder;
 import io.github.springwolf.core.asyncapi.scanners.bindings.BindingFactory;
 import io.github.springwolf.core.asyncapi.scanners.common.MethodLevelAnnotationScanner;
+import io.github.springwolf.core.asyncapi.scanners.common.payload.HeaderClassExtractor;
 import io.github.springwolf.core.asyncapi.scanners.common.payload.PayloadClassExtractor;
 import io.github.springwolf.core.asyncapi.scanners.common.utils.AnnotationScannerUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -58,14 +60,15 @@ public class SpringAnnotationMethodLevelChannelsScanner<MethodAnnotation extends
 
         String channelName = bindingFactory.getChannelName(annotation);
         Class<?> payload = payloadClassExtractor.extractFrom(method);
+        AsyncHeaders headers = HeaderClassExtractor.extractFrom(method, payload);
 
-        ChannelObject channelItem = buildChannelItem(annotation, payload);
+        ChannelObject channelItem = buildChannelItem(annotation, payload, headers);
 
         return Map.entry(channelName, channelItem);
     }
 
-    private ChannelObject buildChannelItem(MethodAnnotation annotation, Class<?> payloadType) {
-        MessageObject message = buildMessage(annotation, payloadType);
+    private ChannelObject buildChannelItem(MethodAnnotation annotation, Class<?> payloadType, AsyncHeaders headers) {
+        MessageObject message = buildMessage(annotation, payloadType, headers);
         return buildChannelItem(annotation, message);
     }
 

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/AsyncAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/AsyncAnnotationScanner.java
@@ -94,6 +94,7 @@ public abstract class AsyncAnnotationScanner<A extends Annotation> implements Em
                 payloadType, operationData.message().contentType());
         AsyncHeaders asyncHeaders = AsyncAnnotationUtil.getAsyncHeaders(operationData, resolver);
         String headerModelName = this.componentsService.registerSchema(asyncHeaders);
+        // FIXME: Add or merge headers
         var headers = MessageHeaders.of(MessageReference.toSchema(headerModelName));
 
         var schema = payloadType.getAnnotation(Schema.class);

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/ClassLevelAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/ClassLevelAnnotationScanner.java
@@ -82,7 +82,10 @@ public abstract class ClassLevelAnnotationScanner<
     protected MessageObject buildMessage(ClassAnnotation classAnnotation, Class<?> payloadType) {
         Map<String, MessageBinding> messageBinding = bindingFactory.buildMessageBinding(classAnnotation);
         String modelName = componentsService.registerSchema(payloadType);
+        // FIXME: Add or merge headers
         String headerModelName = componentsService.registerSchema(asyncHeadersBuilder.buildHeaders(payloadType));
+        MessageHeaders messageHeaders = MessageHeaders.of(MessageReference.toSchema(headerModelName));
+
         MessagePayload payload = MessagePayload.of(MultiFormatSchema.builder()
                 .schema(SchemaReference.fromSchema(modelName))
                 .build());
@@ -93,7 +96,7 @@ public abstract class ClassLevelAnnotationScanner<
                 .title(payloadType.getSimpleName())
                 .description(null)
                 .payload(payload)
-                .headers(MessageHeaders.of(MessageReference.toSchema(headerModelName)))
+                .headers(messageHeaders)
                 .bindings(messageBinding)
                 .build();
 

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/MethodLevelAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/MethodLevelAnnotationScanner.java
@@ -33,7 +33,7 @@ public abstract class MethodLevelAnnotationScanner<MethodAnnotation extends Anno
         MessageHeaders messageHeaders;
         String headerModelName;
 
-        if (headers == null) {
+        if (headers == null || headers.isEmpty()) {
             headerModelName = componentsService.registerSchema(asyncHeadersBuilder.buildHeaders(payloadType));
         } else {
             headerModelName = componentsService.registerSchema(headers);

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/payload/HeaderClassExtractor.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/payload/HeaderClassExtractor.java
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.springwolf.core.asyncapi.scanners.common.payload;
+
+import io.github.springwolf.core.asyncapi.components.headers.AsyncHeaders;
+import io.github.springwolf.core.asyncapi.components.headers.AsyncHeadersNotDocumented;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.MapSchema;
+import io.swagger.v3.oas.models.media.NumberSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Headers;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+@Slf4j
+public class HeaderClassExtractor {
+    private HeaderClassExtractor() {}
+
+    public static AsyncHeaders extractFrom(Method method, Class<?> payload) {
+        String methodName = String.format("%s::%s", method.getDeclaringClass().getSimpleName(), method.getName());
+        log.debug("Finding header types for {}", methodName);
+
+        AsyncHeaders headers = new AsyncHeaders(payload.getName() + "Headers");
+
+        for (Parameter argument : method.getParameters()) {
+            if (argument.isAnnotationPresent(Header.class)) {
+                Header headerAnnotation = argument.getAnnotation(Header.class);
+                var clazz = TypeToClassConverter.extractClass(argument.getType());
+                headers.put(getHeaderAnnotationName(headerAnnotation), getSchema(clazz));
+            } else if (argument.isAnnotationPresent(Headers.class)) {
+                var clazz = TypeToClassConverter.extractClass(argument.getType());
+                headers.put(argument.getName(), getSchema(clazz));
+            }
+        }
+
+        if (headers.isEmpty()) {
+            return AsyncHeadersNotDocumented.NOT_DOCUMENTED;
+        }
+
+        return headers;
+    }
+
+    private static String getHeaderAnnotationName(Header annotation) {
+        if (!annotation.name().isBlank()) {
+            return annotation.name();
+        }
+
+        return annotation.value();
+    }
+
+    private static Schema<?> getSchema(Class<?> clazz) {
+        if (clazz.equals(String.class)) {
+            return new StringSchema();
+        } else if (clazz.equals(Boolean.class)) {
+            return new BooleanSchema();
+        } else if (clazz.equals(Integer.class)) {
+            return new IntegerSchema();
+        } else if (clazz.equals(Number.class)) {
+            return new NumberSchema();
+        }
+        return new MapSchema();
+    }
+
+    private record TypeToClassConverter() {
+
+        private static Class<?> extractClass(Type parameterType) {
+            try {
+                if (parameterType instanceof ParameterizedType parameterizedType) {
+                    Type rawParameterType = parameterizedType.getRawType();
+                    String rawParameterTypeName = rawParameterType.getTypeName();
+
+                    Class<?> actualPayloadClass = extractActualGenericClass(rawParameterTypeName);
+                    if (actualPayloadClass != Void.class) {
+                        return actualPayloadClass;
+                    }
+
+                    // nested generic class - fallback to most outer container
+                    return Class.forName(rawParameterTypeName);
+                }
+
+                // no generics used - just a normal type
+                return Class.forName(parameterType.getTypeName());
+            } catch (Exception ex) {
+                log.info("Unable to extract generic data type of %s".formatted(parameterType), ex);
+            }
+            return Void.class;
+        }
+
+        private static Class<?> extractActualGenericClass(String rawParameterTypeName) {
+
+            try {
+                return Class.forName(rawParameterTypeName);
+            } catch (ClassNotFoundException ex) {
+                log.debug("Unable to find class for type %s".formatted(rawParameterTypeName), ex);
+            }
+
+            return Void.class;
+        }
+    }
+}

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationMethodLevelOperationsScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationMethodLevelOperationsScanner.java
@@ -8,9 +8,11 @@ import io.github.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import io.github.springwolf.asyncapi.v3.model.operation.Operation;
 import io.github.springwolf.asyncapi.v3.model.operation.OperationAction;
 import io.github.springwolf.core.asyncapi.components.ComponentsService;
+import io.github.springwolf.core.asyncapi.components.headers.AsyncHeaders;
 import io.github.springwolf.core.asyncapi.components.headers.AsyncHeadersBuilder;
 import io.github.springwolf.core.asyncapi.scanners.bindings.BindingFactory;
 import io.github.springwolf.core.asyncapi.scanners.common.MethodLevelAnnotationScanner;
+import io.github.springwolf.core.asyncapi.scanners.common.payload.HeaderClassExtractor;
 import io.github.springwolf.core.asyncapi.scanners.common.payload.PayloadClassExtractor;
 import io.github.springwolf.core.asyncapi.scanners.common.utils.AnnotationScannerUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -62,13 +64,14 @@ public class SpringAnnotationMethodLevelOperationsScanner<MethodAnnotation exten
         String channelName = bindingFactory.getChannelName(annotation);
         String operationId = channelName + "_" + OperationAction.RECEIVE + "_" + method.getName();
         Class<?> payload = payloadClassExtractor.extractFrom(method);
+        AsyncHeaders headers = HeaderClassExtractor.extractFrom(method, payload);
 
-        Operation operation = buildOperation(annotation, payload);
+        Operation operation = buildOperation(annotation, payload, headers);
         return Map.entry(operationId, operation);
     }
 
-    private Operation buildOperation(MethodAnnotation annotation, Class<?> payloadType) {
-        MessageObject message = buildMessage(annotation, payloadType);
+    private Operation buildOperation(MethodAnnotation annotation, Class<?> payloadType, AsyncHeaders headers) {
+        MessageObject message = buildMessage(annotation, payloadType, headers);
         return buildOperation(annotation, message);
     }
 

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/common/payload/HeadersClassExtractorTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/common/payload/HeadersClassExtractorTest.java
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.springwolf.core.asyncapi.scanners.common.payload;
+
+import io.github.springwolf.core.asyncapi.components.headers.AsyncHeaders;
+import io.github.springwolf.core.asyncapi.components.headers.AsyncHeadersNotDocumented;
+import io.swagger.v3.oas.models.media.MapSchema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Headers;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HeadersClassExtractorTest {
+
+    @Test
+    void getNoDocumentedHeaders() throws NoSuchMethodException {
+        Method m = TestClass.class.getDeclaredMethod("consumeWithoutHeaders", String.class);
+
+        var result = HeaderClassExtractor.extractFrom(m, String.class);
+
+        // Expected
+        assertEquals(AsyncHeadersNotDocumented.NOT_DOCUMENTED, result);
+    }
+
+    @Test
+    void getHeaderWithSingleHeaderAnnotation() throws NoSuchMethodException {
+        Method m = TestClass.class.getDeclaredMethod("consumeWithSingleHeaderAnnotation", String.class);
+
+        var result = HeaderClassExtractor.extractFrom(m, String.class);
+
+        // Expected
+        AsyncHeaders expectedHeaders = new AsyncHeaders("");
+        expectedHeaders.put("kafka_receivedMessageKey", new StringSchema());
+
+        assertEquals(expectedHeaders, result);
+    }
+
+    @Test
+    void getHeaderWithMultipleHeaderAnnotation() throws NoSuchMethodException {
+        Method m = TestClass.class.getDeclaredMethod("consumeWithMultipleHeaderAnnotation", String.class, String.class);
+
+        var result = HeaderClassExtractor.extractFrom(m, String.class);
+
+        // Expected
+        AsyncHeaders expectedHeaders = new AsyncHeaders("");
+        expectedHeaders.put("kafka_receivedMessageKey", new StringSchema());
+        expectedHeaders.put("non-exist", new StringSchema());
+
+        assertEquals(expectedHeaders, result);
+    }
+
+    @Test
+    void getHeadersWithHeadersAnnotation() throws NoSuchMethodException {
+        Method m = TestClass.class.getDeclaredMethod("consumeWithHeadersAnnotation", MessageHeaders.class);
+
+        var result = HeaderClassExtractor.extractFrom(m, String.class);
+
+        // Expected
+        AsyncHeaders expectedHeaders = new AsyncHeaders("");
+        expectedHeaders.put("headers", new MapSchema());
+
+        assertEquals(expectedHeaders, result);
+    }
+
+    @Test
+    void getHeadersWithAllHeadersAnnotation() throws NoSuchMethodException {
+        Method m = TestClass.class.getDeclaredMethod(
+                "consumeWithAllHeadersAnnotation", String.class, String.class, MessageHeaders.class);
+
+        var result = HeaderClassExtractor.extractFrom(m, String.class);
+
+        // Expected
+        AsyncHeaders expectedHeaders = new AsyncHeaders("");
+        expectedHeaders.put("kafka_receivedMessageKey", new StringSchema());
+        expectedHeaders.put("non-exist", new StringSchema());
+        expectedHeaders.put("headers", new MapSchema());
+
+        assertEquals(expectedHeaders, result);
+    }
+
+    // FIXME: We should have more tests
+    //   Number, Integer, Boolean and Array Header types
+    //   Map type headers can be tricky, since during the parsing process we don't have access to the keys
+
+    public static class TestClass {
+
+        public void consumeWithoutHeaders(String simpleValue) {}
+
+        public void consumeWithSingleHeaderAnnotation(@Header("kafka_receivedMessageKey") String key) {}
+
+        public void consumeWithMultipleHeaderAnnotation(
+                @Header("kafka_receivedMessageKey") String key,
+                @Header(name = "non-exist", defaultValue = "default") String nonExistingHeader) {}
+
+        public void consumeWithHeadersAnnotation(@Headers MessageHeaders headers) {}
+
+        public void consumeWithAllHeadersAnnotation(
+                @Header("kafka_receivedMessageKey") String key,
+                @Header(name = "non-exist", defaultValue = "default") String nonExistingHeader,
+                @Headers MessageHeaders headers) {}
+    }
+}

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/common/payload/HeadersClassExtractorTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/common/payload/HeadersClassExtractorTest.java
@@ -18,7 +18,7 @@ class HeadersClassExtractorTest {
 
     @Test
     void getNoDocumentedHeaders() throws NoSuchMethodException {
-        Method m = TestClass.class.getDeclaredMethod("consumeWithoutHeaders", String.class);
+        Method m = TestClass.class.getDeclaredMethod("consumeWithoutHeadersAnnotation", String.class);
 
         var result = HeaderClassExtractor.extractFrom(m, String.class);
 
@@ -88,7 +88,7 @@ class HeadersClassExtractorTest {
 
     public static class TestClass {
 
-        public void consumeWithoutHeaders(String simpleValue) {}
+        public void consumeWithoutHeadersAnnotation(String simpleValue) {}
 
         public void consumeWithSingleHeaderAnnotation(@Header("kafka_receivedMessageKey") String key) {}
 

--- a/springwolf-examples/springwolf-kafka-example/build.gradle
+++ b/springwolf-examples/springwolf-kafka-example/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     implementation "org.springframework:spring-beans"
     implementation "org.springframework:spring-context"
+    implementation "org.springframework:spring-messaging"
     implementation "org.springframework:spring-web"
 
     implementation "org.springframework.boot:spring-boot"

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/springwolf/examples/kafka/consumers/ExampleClassLevelKafkaListener.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/springwolf/examples/kafka/consumers/ExampleClassLevelKafkaListener.java
@@ -9,6 +9,11 @@ import io.github.springwolf.plugins.kafka.asyncapi.annotations.KafkaAsyncOperati
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaHandler;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 import javax.money.MonetaryAmount;
@@ -24,6 +29,15 @@ public class ExampleClassLevelKafkaListener {
 
     @KafkaHandler
     public void receiveExamplePayload(ExamplePayloadDto payload) {
+        log.info("Received new message in {}: {}", TOPIC, payload.toString());
+    }
+
+    // FIXME: This is still not working
+    @KafkaHandler
+    public void receiveExamplePayloadWithHeaders(
+            @Headers MessageHeaders headers,
+            @Header(KafkaHeaders.RECEIVED_KEY) String key,
+            @Payload(required = false) ExamplePayloadDto payload) {
         log.info("Received new message in {}: {}", TOPIC, payload.toString());
     }
 

--- a/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/springwolf/examples/kafka/consumers/ExampleConsumer.java
+++ b/springwolf-examples/springwolf-kafka-example/src/main/java/io/github/springwolf/examples/kafka/consumers/ExampleConsumer.java
@@ -7,6 +7,11 @@ import io.github.springwolf.examples.kafka.producers.AnotherProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -27,6 +32,14 @@ public class ExampleConsumer {
         example.setFoo("foo");
 
         anotherProducer.sendMessage(example);
+    }
+
+    @KafkaListener(topics = "example-topic")
+    public void receiveExamplePayloadWithHeaders(
+            @Headers MessageHeaders headers,
+            @Header(KafkaHeaders.RECEIVED_KEY) String key,
+            @Payload(required = false) ExamplePayloadDto payload) {
+        log.info("Received new messages in example-topic: {}", payload.toString());
     }
 
     @KafkaListener(topics = "another-topic", groupId = "example-group-id", batch = "true")

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/springwolf/examples/kafka/ApiIntegrationTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/springwolf/examples/kafka/ApiIntegrationTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EmbeddedKafka(partitions = 1)
 @DirtiesContext
-public class ApiIntegrationTest {
+class ApiIntegrationTest {
 
     @Autowired
     private TestRestTemplate restTemplate;

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/springwolf/examples/kafka/ApiIntegrationWithActuatorIntegrationTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/springwolf/examples/kafka/ApiIntegrationWithActuatorIntegrationTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
         })
 @EmbeddedKafka(partitions = 1)
 @DirtiesContext
-public class ApiIntegrationWithActuatorIntegrationTest {
+class ApiIntegrationWithActuatorIntegrationTest {
 
     @Autowired
     private TestRestTemplate restTemplate;


### PR DESCRIPTION
Fixes issue #563

Now, when a method is annotated with the `@Header` or `@Headers` annotation, the payload marked with `@Payload` will also include the defined headers.

Known limitations:
* If a @Payload is indicated in different places, the AsyncAPI specification will include any correlated @Header
* When using `@Headers` we cannot provide further information