### PR TITLE
feat(core): Skip schema post processor when previous post-processor r…

### DIFF
--- a/springwolf-asyncapi/src/main/java/io/github/stavshamir/springwolf/asyncapi/v3/model/channel/message/MessageReference.java
+++ b/springwolf-asyncapi/src/main/java/io/github/stavshamir/springwolf/asyncapi/v3/model/channel/message/MessageReference.java
@@ -50,6 +50,9 @@ public class MessageReference implements Message, Reference {
     }
 
     public static String extractRefName(String ref) {
-        return ref.substring(ref.lastIndexOf('/') + 1);
+        if(ref.contains("/")) {
+            return ref.substring(ref.lastIndexOf('/') + 1);
+        }
+        return ref;
     }
 }

--- a/springwolf-asyncapi/src/main/java/io/github/stavshamir/springwolf/asyncapi/v3/model/channel/message/MessageReference.java
+++ b/springwolf-asyncapi/src/main/java/io/github/stavshamir/springwolf/asyncapi/v3/model/channel/message/MessageReference.java
@@ -48,4 +48,8 @@ public class MessageReference implements Message, Reference {
     public static MessageReference toSchema(String schemaName) {
         return new MessageReference("#/components/schemas/" + schemaName);
     }
+
+    public static String extractRefName(String ref) {
+        return ref.substring(ref.lastIndexOf('/') + 1);
+    }
 }

--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultComponentsService.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/DefaultComponentsService.java
@@ -170,6 +170,12 @@ public class DefaultComponentsService implements ComponentsService {
     }
 
     private void postProcessSchema(Schema schema) {
-        schemaPostProcessors.forEach(processor -> processor.process(schema, schemas));
+        for (SchemasPostProcessor processor : schemaPostProcessors) {
+            processor.process(schema, schemas);
+
+            if (!schemas.containsValue(schema)) {
+                break;
+            }
+        }
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/postprocessor/AvroSchemaPostProcessorTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/postprocessor/AvroSchemaPostProcessorTest.java
@@ -26,6 +26,7 @@ class AvroSchemaPostProcessorTest {
                 Map.of("foo", new StringSchema(), "schema", avroSchema, "specificData", avroSpecificData)));
 
         var definitions = new HashMap<String, io.swagger.v3.oas.models.media.Schema>();
+        definitions.put("schema", schema);
         definitions.put("customClassRefUnusedInThisTest", new StringSchema());
         definitions.put("org.apache.avro.Schema", new io.swagger.v3.oas.models.media.Schema());
         definitions.put("org.apache.avro.ConversionJava.lang.Object", new io.swagger.v3.oas.models.media.Schema());
@@ -35,6 +36,48 @@ class AvroSchemaPostProcessorTest {
 
         // then
         assertThat(schema.getProperties()).isEqualTo(Map.of("foo", new StringSchema()));
-        assertThat(definitions).isEqualTo(Map.of("customClassRefUnusedInThisTest", new StringSchema()));
+        assertThat(definitions)
+                .isEqualTo(Map.of("schema", schema, "customClassRefUnusedInThisTest", new StringSchema()));
+    }
+
+    @Test
+    void avroSchemasAreRemovedInRefsTest() {
+        // given
+        var avroSchema = new io.swagger.v3.oas.models.media.Schema();
+        avroSchema.set$ref("#/components/schemas/org.apache.avro.Schema");
+
+        var avroSpecificData = new io.swagger.v3.oas.models.media.Schema();
+        avroSpecificData.set$ref("#/components/schemas/org.apache.avro.specific.SpecificData");
+
+        var refSchema = new io.swagger.v3.oas.models.media.Schema();
+        refSchema.setProperties(new HashMap<>(
+                Map.of("foo", new StringSchema(), "schema", avroSchema, "specificData", avroSpecificData)));
+
+        var refProperty = new io.swagger.v3.oas.models.media.Schema();
+        refProperty.set$ref("#/components/schemas/refSchema");
+        var schema = new io.swagger.v3.oas.models.media.Schema();
+        schema.setProperties(new HashMap<>(Map.of("ref", refProperty)));
+
+        var definitions = new HashMap<String, io.swagger.v3.oas.models.media.Schema>();
+        definitions.put("schema", schema);
+        definitions.put("refSchema", refSchema);
+        definitions.put("customClassRefUnusedInThisTest", new StringSchema());
+        definitions.put("org.apache.avro.Schema", new io.swagger.v3.oas.models.media.Schema());
+        definitions.put("org.apache.avro.ConversionJava.lang.Object", new io.swagger.v3.oas.models.media.Schema());
+
+        // when
+        processor.process(schema, definitions);
+
+        // then
+        assertThat(schema.getProperties()).isEqualTo(Map.of("ref", refProperty));
+        assertThat(refSchema.getProperties()).isEqualTo(Map.of("foo", new StringSchema()));
+        assertThat(definitions)
+                .isEqualTo(Map.of(
+                        "schema",
+                        schema,
+                        "refSchema",
+                        refSchema,
+                        "customClassRefUnusedInThisTest",
+                        new StringSchema()));
     }
 }


### PR DESCRIPTION
…emoved the current schema

Example: an avro schema is removed. Then the next post-processor (example generator) does not need to be called. Also, it avoids the error message due to unresolvable avro schemas