### PR TITLE
Add discriminator field support + better integration tests in core

### DIFF
--- a/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/SwaggerSchemaUtil.java
+++ b/springwolf-core/src/main/java/io/github/stavshamir/springwolf/schemas/SwaggerSchemaUtil.java
@@ -25,8 +25,6 @@ public class SwaggerSchemaUtil {
     public SchemaObject mapSchema(Schema value) {
         SchemaObject.SchemaObjectBuilder builder = SchemaObject.builder();
 
-        //          TODO:              .discriminator(value.getDiscriminator())
-
         io.swagger.v3.oas.models.ExternalDocumentation externalDocs = value.getExternalDocs();
         if (externalDocs != null) {
             ExternalDocumentation externalDocumentation = ExternalDocumentation.builder()
@@ -96,6 +94,10 @@ public class SwaggerSchemaUtil {
         }
 
         builder.required(value.getRequired());
+
+        if (value.getDiscriminator() != null) {
+            builder.discriminator(value.getDiscriminator().getPropertyName());
+        }
 
         List<Object> allOf = value.getAllOf();
         if (allOf != null) {

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/SpringContextIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/SpringContextIntegrationTest.java
@@ -28,7 +28,7 @@ class SpringContextIntegrationTest {
         assertThat(asyncApiService.getAsyncAPI()).isNotNull();
         assertThat(asyncApiService.getAsyncAPI().getInfo().getTitle())
                 .isEqualTo("Info title was loaded from spring properties");
-        assertThat(asyncApiService.getAsyncAPI().getDefaultContentType()).isEqualTo("application/yaml");
+        assertThat(asyncApiService.getAsyncAPI().getDefaultContentType()).isEqualTo("application/json");
         assertThat(asyncApiService.getAsyncAPI().getId()).isEqualTo("urn:io:github:stavshamir:springwolf:example");
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/asyncapi/DefaultAsyncApiServiceIntegrationTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
             "springwolf.docket.id=urn:io:github:stavshamir:springwolf:example",
-            "springwolf.docket.default-content-type=application/yaml",
+            "springwolf.docket.default-content-type=application/json",
             "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
             "springwolf.docket.servers.test-protocol.protocol=test",
             "springwolf.docket.servers.test-protocol.host=some-server:1234",

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/fixtures/MinimalIntegrationTestContextConfiguration.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/fixtures/MinimalIntegrationTestContextConfiguration.java
@@ -19,8 +19,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
             "springwolf.docket.info.title=Info title was loaded from spring properties",
             "springwolf.docket.info.version=1.0.0",
             "springwolf.docket.id=urn:io:github:stavshamir:springwolf:example",
-            "springwolf.docket.default-content-type=application/yaml",
-            "springwolf.docket.base-package=io.github.stavshamir.springwolf.example",
+            "springwolf.docket.default-content-type=application/json",
+            "springwolf.docket.base-package=io.github.stavshamir.springwolf.integrationtests.application.basic",
             "springwolf.docket.servers.test-protocol.protocol=test",
             "springwolf.docket.servers.test-protocol.host=some-server:1234",
         })

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/AsyncApiDocumentIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/AsyncApiDocumentIntegrationTest.java
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.integrationtests;
+
+import io.github.stavshamir.springwolf.asyncapi.AsyncApiService;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.AsyncAPI;
+import io.github.stavshamir.springwolf.fixtures.MinimalIntegrationTestContextConfiguration;
+import io.github.stavshamir.springwolf.integrationtests.application.listener.ListenerApplication;
+import io.github.stavshamir.springwolf.integrationtests.application.publisher.PublisherApplication;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AsyncApiDocumentIntegrationTest {
+
+    @Nested
+    @SpringBootTest(classes = ListenerApplication.class)
+    @MinimalIntegrationTestContextConfiguration
+    @TestPropertySource(
+            properties = {
+                "springwolf.docket.base-package=io.github.stavshamir.springwolf.integrationtests.application.listener",
+            })
+    class ListenerAnnotationTest {
+        @Autowired
+        private AsyncApiService asyncApiService;
+
+        @Test
+        void asyncListenerAnnotationIsFound() {
+            AsyncAPI asyncAPI = asyncApiService.getAsyncAPI();
+            assertThat(asyncAPI).isNotNull();
+
+            assertThat(asyncAPI.getChannels()).containsOnlyKeys("listener-channel");
+            assertThat(asyncAPI.getOperations()).containsOnlyKeys("listener-channel_receive_listen");
+            assertThat(asyncAPI.getComponents().getMessages()).containsOnlyKeys("java.lang.String");
+            assertThat(asyncAPI.getComponents().getSchemas()).containsOnlyKeys("HeadersNotDocumented", "String");
+        }
+    }
+
+    @Nested
+    @SpringBootTest(classes = PublisherApplication.class)
+    @MinimalIntegrationTestContextConfiguration
+    @TestPropertySource(
+            properties = {
+                "springwolf.docket.base-package=io.github.stavshamir.springwolf.integrationtests.application.publisher",
+            })
+    class PublisherAnnotationTest {
+        @Autowired
+        private AsyncApiService asyncApiService;
+
+        @Test
+        void asyncPublisherAnnotationIsFound() {
+            AsyncAPI asyncAPI = asyncApiService.getAsyncAPI();
+            assertThat(asyncAPI).isNotNull();
+
+            assertThat(asyncAPI.getChannels()).containsOnlyKeys("publisher-channel");
+            assertThat(asyncAPI.getOperations()).containsOnlyKeys("publisher-channel_send_publish");
+            assertThat(asyncAPI.getComponents().getMessages()).containsOnlyKeys("java.lang.String");
+            assertThat(asyncAPI.getComponents().getSchemas()).containsOnlyKeys("HeadersNotDocumented", "String");
+        }
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/AsyncApiDocumentIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/AsyncApiDocumentIntegrationTest.java
@@ -72,7 +72,7 @@ public class AsyncApiDocumentIntegrationTest {
     @MinimalIntegrationTestContextConfiguration
     @TestPropertySource(
             properties = {
-                    "springwolf.docket.base-package=io.github.stavshamir.springwolf.integrationtests.application.polymorphic",
+                "springwolf.docket.base-package=io.github.stavshamir.springwolf.integrationtests.application.polymorphic",
             })
     class PolymorphicPayloadTest {
         @Autowired
@@ -87,7 +87,7 @@ public class AsyncApiDocumentIntegrationTest {
             Map<String, Message> messages = asyncAPI.getComponents().getMessages();
             assertThat(messages)
                     .containsOnlyKeys(
-                            "io.github.stavshamir.springwolf.integrationtests.application.polymorphic.PolymorphicApplication$Payload");
+                            "io.github.stavshamir.springwolf.integrationtests.application.polymorphic.PolymorphicPayloadApplication$Payload");
             Map<String, SchemaObject> schemas = asyncAPI.getComponents().getSchemas();
             assertThat(schemas).containsOnlyKeys("HeadersNotDocumented", "Payload", "Pet", "Cat", "Dog");
 

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/AsyncApiDocumentIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/AsyncApiDocumentIntegrationTest.java
@@ -3,14 +3,19 @@ package io.github.stavshamir.springwolf.integrationtests;
 
 import io.github.stavshamir.springwolf.asyncapi.AsyncApiService;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.AsyncAPI;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.Message;
+import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaObject;
 import io.github.stavshamir.springwolf.fixtures.MinimalIntegrationTestContextConfiguration;
 import io.github.stavshamir.springwolf.integrationtests.application.listener.ListenerApplication;
+import io.github.stavshamir.springwolf.integrationtests.application.polymorphic.PolymorphicPayloadApplication;
 import io.github.stavshamir.springwolf.integrationtests.application.publisher.PublisherApplication;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
+
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,6 +64,42 @@ public class AsyncApiDocumentIntegrationTest {
             assertThat(asyncAPI.getOperations()).containsOnlyKeys("publisher-channel_send_publish");
             assertThat(asyncAPI.getComponents().getMessages()).containsOnlyKeys("java.lang.String");
             assertThat(asyncAPI.getComponents().getSchemas()).containsOnlyKeys("HeadersNotDocumented", "String");
+        }
+    }
+
+    @Nested
+    @SpringBootTest(classes = PolymorphicPayloadApplication.class)
+    @MinimalIntegrationTestContextConfiguration
+    @TestPropertySource(
+            properties = {
+                    "springwolf.docket.base-package=io.github.stavshamir.springwolf.integrationtests.application.polymorphic",
+            })
+    class PolymorphicPayloadTest {
+        @Autowired
+        private AsyncApiService asyncApiService;
+
+        @Test
+        void polymorphicDiscriminatorFieldIsHandled() {
+            // when
+            AsyncAPI asyncAPI = asyncApiService.getAsyncAPI();
+
+            // then
+            Map<String, Message> messages = asyncAPI.getComponents().getMessages();
+            assertThat(messages)
+                    .containsOnlyKeys(
+                            "io.github.stavshamir.springwolf.integrationtests.application.polymorphic.PolymorphicApplication$Payload");
+            Map<String, SchemaObject> schemas = asyncAPI.getComponents().getSchemas();
+            assertThat(schemas).containsOnlyKeys("HeadersNotDocumented", "Payload", "Pet", "Cat", "Dog");
+
+            assertThat(schemas.get("Pet").getDiscriminator()).isEqualTo("type");
+            assertThat(schemas.get("Cat").getAllOf().get(0).getReference().getRef())
+                    .isEqualTo("#/components/schemas/Pet");
+            assertThat(schemas.get("Cat").getAllOf().get(1).getSchema().getProperties())
+                    .containsOnlyKeys("catSpecificField");
+            assertThat(schemas.get("Dog").getAllOf().get(0).getReference().getRef())
+                    .isEqualTo("#/components/schemas/Pet");
+            assertThat(schemas.get("Dog").getAllOf().get(1).getSchema().getProperties())
+                    .containsOnlyKeys("dogSpecificField");
         }
     }
 }

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/AutoConfigurationIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/AutoConfigurationIntegrationTest.java
@@ -3,6 +3,7 @@ package io.github.stavshamir.springwolf.integrationtests;
 
 import io.github.stavshamir.springwolf.asyncapi.controller.AsyncApiController;
 import io.github.stavshamir.springwolf.fixtures.MinimalIntegrationTestContextConfiguration;
+import io.github.stavshamir.springwolf.integrationtests.application.basic.TestApplication;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/InitModeIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/InitModeIntegrationTest.java
@@ -4,6 +4,7 @@ package io.github.stavshamir.springwolf.integrationtests;
 import io.github.stavshamir.springwolf.asyncapi.DefaultAsyncApiService;
 import io.github.stavshamir.springwolf.asyncapi.controller.AsyncApiController;
 import io.github.stavshamir.springwolf.fixtures.MinimalIntegrationTestContextConfiguration;
+import io.github.stavshamir.springwolf.integrationtests.application.basic.TestApplication;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/application/basic/TestApplication.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/application/basic/TestApplication.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-package io.github.stavshamir.springwolf.integrationtests;
+package io.github.stavshamir.springwolf.integrationtests.application.basic;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-class TestApplication {}
+public class TestApplication {}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/application/listener/ListenerApplication.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/application/listener/ListenerApplication.java
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.integrationtests.application.listener;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncListener;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class ListenerApplication {
+    @Bean
+    public Listener listener() {
+        return new Listener();
+    }
+
+    class Listener {
+        @AsyncListener(operation = @AsyncOperation(channelName = "listener-channel"))
+        public void listen(String payload) {}
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/application/polymorphic/PolymorphicPayloadApplication.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/application/polymorphic/PolymorphicPayloadApplication.java
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.integrationtests.application.polymorphic;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncListener;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class PolymorphicPayloadApplication {
+    @Bean
+    public Listener listener() {
+        return new Listener();
+    }
+
+    class Listener {
+        @AsyncListener(operation = @AsyncOperation(channelName = "listener-channel"))
+        public void listen(Payload payload) {
+        }
+    }
+
+    public record Payload(Pet pet) {
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes(
+            value = {
+                    @JsonSubTypes.Type(value = Dog.class, name = "dog"),
+                    @JsonSubTypes.Type(value = Cat.class, name = "cat"),
+            })
+    public interface Pet {
+        public String getType();
+    }
+
+    public record Dog() implements Pet {
+        @Override
+        public String getType() {
+            return "dog";
+        }
+
+        public String getDogSpecificField() {
+            return "dog-specific-field";
+        }
+    }
+
+    public record Cat() implements Pet {
+        @Override
+        public String getType() {
+            return "cat";
+        }
+
+        public String getCatSpecificField() {
+            return "cat-specific-field";
+        }
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/application/polymorphic/PolymorphicPayloadApplication.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/application/polymorphic/PolymorphicPayloadApplication.java
@@ -17,18 +17,16 @@ public class PolymorphicPayloadApplication {
 
     class Listener {
         @AsyncListener(operation = @AsyncOperation(channelName = "listener-channel"))
-        public void listen(Payload payload) {
-        }
+        public void listen(Payload payload) {}
     }
 
-    public record Payload(Pet pet) {
-    }
+    public record Payload(Pet pet) {}
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
     @JsonSubTypes(
             value = {
-                    @JsonSubTypes.Type(value = Dog.class, name = "dog"),
-                    @JsonSubTypes.Type(value = Cat.class, name = "cat"),
+                @JsonSubTypes.Type(value = Dog.class, name = "dog"),
+                @JsonSubTypes.Type(value = Cat.class, name = "cat"),
             })
     public interface Pet {
         public String getType();

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/application/publisher/PublisherApplication.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/integrationtests/application/publisher/PublisherApplication.java
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.stavshamir.springwolf.integrationtests.application.publisher;
+
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncOperation;
+import io.github.stavshamir.springwolf.asyncapi.scanners.channels.operationdata.annotation.AsyncPublisher;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class PublisherApplication {
+    @Bean
+    public Publisher publisher() {
+        return new Publisher();
+    }
+
+    class Publisher {
+        @AsyncPublisher(operation = @AsyncOperation(channelName = "publisher-channel"))
+        public void publish(String payload) {}
+    }
+}

--- a/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/SwaggerSchemaUtilTest.java
+++ b/springwolf-core/src/test/java/io/github/stavshamir/springwolf/schemas/SwaggerSchemaUtilTest.java
@@ -5,6 +5,7 @@ import io.github.stavshamir.springwolf.asyncapi.v3.model.channel.message.Message
 import io.github.stavshamir.springwolf.asyncapi.v3.model.components.ComponentSchema;
 import io.github.stavshamir.springwolf.asyncapi.v3.model.schema.SchemaObject;
 import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.media.Discriminator;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -345,6 +346,21 @@ class SwaggerSchemaUtilTest {
         }
 
         @Test
+        void mapDiscriminator() {
+            // given
+            ObjectSchema schema = new ObjectSchema();
+            Discriminator discriminator = new Discriminator();
+            discriminator.setPropertyName("propertyName");
+            schema.setDiscriminator(discriminator);
+
+            // when
+            SchemaObject componentSchema = swaggerSchemaUtil.mapSchema(schema);
+
+            // then
+            assertThat(componentSchema.getDiscriminator()).isEqualTo("propertyName");
+        }
+
+        @Test
         void mapAllOf() {
             // given
             ObjectSchema schema = new ObjectSchema();
@@ -356,7 +372,7 @@ class SwaggerSchemaUtilTest {
             SchemaObject componentSchema = swaggerSchemaUtil.mapSchema(schema);
 
             // then
-            assertThat(((SchemaObject) componentSchema.getAllOf().get(0).getSchema()).getType())
+            assertThat((componentSchema.getAllOf().get(0).getSchema()).getType())
                     .isEqualTo(allOf.getType());
         }
 
@@ -372,7 +388,7 @@ class SwaggerSchemaUtilTest {
             SchemaObject componentSchema = swaggerSchemaUtil.mapSchema(schema);
 
             // then
-            assertThat(((SchemaObject) componentSchema.getOneOf().get(0).getSchema()).getType())
+            assertThat((componentSchema.getOneOf().get(0).getSchema()).getType())
                     .isEqualTo(oneOf.getType());
         }
 
@@ -388,7 +404,7 @@ class SwaggerSchemaUtilTest {
             SchemaObject componentSchema = swaggerSchemaUtil.mapSchema(schema);
 
             // then
-            assertThat(((SchemaObject) componentSchema.getAnyOf().get(0).getSchema()).getType())
+            assertThat((componentSchema.getAnyOf().get(0).getSchema()).getType())
                     .isEqualTo(anyOf.getType());
         }
 
@@ -417,8 +433,7 @@ class SwaggerSchemaUtilTest {
             SchemaObject componentSchema = swaggerSchemaUtil.mapSchema(schema);
 
             // then
-            assertThat(((SchemaObject) componentSchema.getNot().getSchema()).getType())
-                    .isEqualTo(not.getType());
+            assertThat((componentSchema.getNot().getSchema()).getType()).isEqualTo(not.getType());
         }
 
         @Test
@@ -434,8 +449,7 @@ class SwaggerSchemaUtilTest {
             SchemaObject componentSchema = swaggerSchemaUtil.mapSchema(schema);
 
             // then
-            assertThat(((SchemaObject) componentSchema.getItems().getSchema()).getType())
-                    .isEqualTo(item.getType());
+            assertThat((componentSchema.getItems().getSchema()).getType()).isEqualTo(item.getType());
         }
 
         @Test


### PR DESCRIPTION
Add support for discriminator field as requested in https://github.com/springwolf/springwolf-core/issues/160

To test, the integration tests in core have been extended to allow multiple Spring Boot test applications (via different packages).
This allows to test springwolf-core using multiple, smaller sized integration tests.
An integration test is used for the discriminator field, since multiple components have to work together to generate the correct AsyncApi document output.