### PR TITLE
fix(ui): Make edit header view available by default in ui

### DIFF
--- a/springwolf-ui/src/app/components/channels/channel-main/channel-main.component.html
+++ b/springwolf-ui/src/app/components/channels/channel-main/channel-main.component.html
@@ -35,7 +35,7 @@
             "
           ></textarea>
         </div>
-        <div [hidden]="!(headersExample?.lineCount > 1)" class="flex-column">
+        <div class="flex-column">
           <h4>Header</h4>
           <textarea
             spellcheck="false"


### PR DESCRIPTION
Hello! Thanks for great project!
submitted issue with explaination https://github.com/springwolf/springwolf-core/issues/650

Problem - no schema for headers without schema in Kafka Listeners (HeadersNotDocumented schema).

Scenario - user wants to send custom headers in springwolf kafka ui, headers are not defined in schema and changes in internal implementation.

Now there are two workarounds to this:

1) Define headers for schema using annotations
2) Add example to schema HeadersNotDocumented

<img width="1438" alt="image" src="https://github.com/springwolf/springwolf-core/assets/18309707/86c51807-7344-45c7-9b53-234d81d0fb56">
