### PR TITLE
(fix) Fixed bug with new SNS Binding

### DIFF
--- a/springwolf-bindings/springwolf-sns-binding/src/main/java/io/github/springwolf/bindings/sns/configuration/SpringwolfSnsBindingAutoConfiguration.java
+++ b/springwolf-bindings/springwolf-sns-binding/src/main/java/io/github/springwolf/bindings/sns/configuration/SpringwolfSnsBindingAutoConfiguration.java
@@ -21,14 +21,14 @@ public class SpringwolfSnsBindingAutoConfiguration {
     @Bean
     @Order(value = BindingProcessorPriority.PROTOCOL_BINDING)
     @ConditionalOnMissingBean
-    public SnsMessageBindingProcessor sqsMessageBindingProcessor() {
+    public SnsMessageBindingProcessor snsMessageBindingProcessor() {
         return new SnsMessageBindingProcessor();
     }
 
     @Bean
     @Order(value = BindingProcessorPriority.PROTOCOL_BINDING)
     @ConditionalOnMissingBean
-    public SnsOperationBindingProcessor sqsOperationBindingProcessor() {
+    public SnsOperationBindingProcessor snsOperationBindingProcessor() {
         return new SnsOperationBindingProcessor();
     }
 }


### PR DESCRIPTION
The new SNS Binding Beans were wrongly named as `sqsMessageBindingProcessor` and `sqsOperationBindingProcessor`

This was causing a "A bean with that name has already been defined in class path resource" when using together the  `springwolf-sns-binding` and the `springwolf-sqs-binding` libraries