### PR TITLE
feat: Added support for arrays to the Generic Binding

### DIFF
--- a/springwolf-add-ons/springwolf-generic-binding/build.gradle
+++ b/springwolf-add-ons/springwolf-generic-binding/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 
     testImplementation "org.assertj:assertj-core:${assertjCoreVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
+    testImplementation("org.junit.jupiter:junit-jupiter-params:${junitJupiterVersion}")
     testRuntimeOnly "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
 }
 

--- a/springwolf-add-ons/springwolf-generic-binding/src/main/java/io/github/springwolf/addons/generic_binding/annotation/processor/PropertiesUtil.java
+++ b/springwolf-add-ons/springwolf-generic-binding/src/main/java/io/github/springwolf/addons/generic_binding/annotation/processor/PropertiesUtil.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class PropertiesUtil {
 
-    private static final Pattern ARRAY_PATTERN = Pattern.compile("\\[([^]]+)]");
+    private static final Pattern ARRAY_PATTERN = Pattern.compile("^\\[([^]]+)]$");
 
     private PropertiesUtil() {}
 

--- a/springwolf-add-ons/springwolf-generic-binding/src/main/java/io/github/springwolf/addons/generic_binding/annotation/processor/PropertiesUtil.java
+++ b/springwolf-add-ons/springwolf-generic-binding/src/main/java/io/github/springwolf/addons/generic_binding/annotation/processor/PropertiesUtil.java
@@ -16,7 +16,9 @@ import java.util.regex.Pattern;
 @Slf4j
 public class PropertiesUtil {
 
-    private static final Pattern ARRAY_PATTERN = Pattern.compile("\\[([^\\]]+)\\]");
+    private static final Pattern ARRAY_PATTERN = Pattern.compile("\\[([^]]+)]");
+
+    private PropertiesUtil() {}
 
     public static Map<String, Object> toMap(String[] propertyStrings) {
         return convertPropertiesToNestedMap(buildPropertiesFrom((propertyStrings)));
@@ -63,10 +65,7 @@ public class PropertiesUtil {
             if (matcher.find()) {
                 // Extract the key and values
                 String[] values = matcher.group(1).split(",");
-                for (int i = 0; i < values.length; i++) {
-                    values[i] = values[i].trim();
-                }
-                return Arrays.asList(values);
+                return Arrays.stream(values).map(String::trim).toList();
             }
         }
 

--- a/springwolf-add-ons/springwolf-generic-binding/src/main/java/io/github/springwolf/addons/generic_binding/annotation/processor/PropertiesUtil.java
+++ b/springwolf-add-ons/springwolf-generic-binding/src/main/java/io/github/springwolf/addons/generic_binding/annotation/processor/PropertiesUtil.java
@@ -10,9 +10,13 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 public class PropertiesUtil {
+
+    private static final Pattern ARRAY_PATTERN = Pattern.compile("\\[([^\\]]+)\\]");
 
     public static Map<String, Object> toMap(String[] propertyStrings) {
         return convertPropertiesToNestedMap(buildPropertiesFrom((propertyStrings)));
@@ -39,17 +43,33 @@ public class PropertiesUtil {
             Map<String, Object> mapNode = bindingData;
             while (path.size() > 1) {
                 String pathElement = path.get(0);
-                if (!mapNode.containsKey(pathElement)) {
-                    mapNode.put(pathElement, new HashMap<>());
-                }
-
+                mapNode.computeIfAbsent(pathElement, k -> new HashMap<>());
                 mapNode = (Map<String, Object>) mapNode.get(pathElement);
 
                 path.pop();
             }
 
-            mapNode.put(path.get(0), properties.get(propertyName));
+            var value = parseValue(properties.get(propertyName));
+            mapNode.put(path.get(0), value);
         }
         return bindingData;
+    }
+
+    private static Object parseValue(Object input) {
+        if (input instanceof String inputString) {
+            Matcher matcher = ARRAY_PATTERN.matcher(inputString);
+
+            // Check if the pattern matches the input string
+            if (matcher.find()) {
+                // Extract the key and values
+                String[] values = matcher.group(1).split(",");
+                for (int i = 0; i < values.length; i++) {
+                    values[i] = values[i].trim();
+                }
+                return Arrays.asList(values);
+            }
+        }
+
+        return input;
     }
 }

--- a/springwolf-add-ons/springwolf-generic-binding/src/test/java/io/github/springwolf/addons/generic_binding/annotation/processor/AsyncGenericOperationBindingProcessorTest.java
+++ b/springwolf-add-ons/springwolf-generic-binding/src/test/java/io/github/springwolf/addons/generic_binding/annotation/processor/AsyncGenericOperationBindingProcessorTest.java
@@ -5,6 +5,8 @@ import io.github.springwolf.addons.generic_binding.annotation.AsyncGenericOperat
 import io.github.springwolf.core.asyncapi.scanners.bindings.operations.ProcessedOperationBinding;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.Arrays;
 import java.util.List;
@@ -122,6 +124,19 @@ class AsyncGenericOperationBindingProcessorTest {
 
             // then
             assertThat(result).isEqualTo(Map.of("key", List.of("value1", "value2", "value3 is long")));
+        }
+
+        @CsvSource(value = {"asdf[sdf]", "[sdf][sdf]", "[sd[sdf]]", "[kdkd]dkkd", "[kdkd"})
+        @ParameterizedTest
+        void arrayParsingShouldBeIgnored(String value) {
+            // given
+            String[] strings = {"key=" + value};
+
+            // when
+            Map<String, Object> result = PropertiesUtil.toMap(strings);
+
+            // then value is still a string, ignoring the array conversion
+            assertThat(result).isEqualTo(Map.of("key", value));
         }
 
         @Test

--- a/springwolf-add-ons/springwolf-generic-binding/src/test/java/io/github/springwolf/addons/generic_binding/annotation/processor/AsyncGenericOperationBindingProcessorTest.java
+++ b/springwolf-add-ons/springwolf-generic-binding/src/test/java/io/github/springwolf/addons/generic_binding/annotation/processor/AsyncGenericOperationBindingProcessorTest.java
@@ -89,6 +89,18 @@ class AsyncGenericOperationBindingProcessorTest {
         }
 
         @Test
+        void oneLongPropertyTest() {
+            // given
+            String[] strings = {"key=value is long"};
+
+            // when
+            Map<String, Object> result = PropertiesUtil.toMap(strings);
+
+            // then
+            assertThat(result).isEqualTo(Map.of("key", "value is long"));
+        }
+
+        @Test
         void twoPropertiesTest() {
             // given
             String[] strings = {"key1=value1", "key2=value2"};
@@ -103,13 +115,13 @@ class AsyncGenericOperationBindingProcessorTest {
         @Test
         void arrayPropertyTest() {
             // given
-            String[] strings = {"key=[value1, value2, value3]"};
+            String[] strings = {"key=[value1, value2, value3 is long]"};
 
             // when
             Map<String, Object> result = PropertiesUtil.toMap(strings);
 
             // then
-            assertThat(result).isEqualTo(Map.of("key", List.of("value1", "value2", "value3")));
+            assertThat(result).isEqualTo(Map.of("key", List.of("value1", "value2", "value3 is long")));
         }
 
         @Test
@@ -163,13 +175,13 @@ class AsyncGenericOperationBindingProcessorTest {
         @Test
         void yamlSyntaxArrayPropertyTest() {
             // given
-            String[] strings = {"key: [value1, value2, value3]"};
+            String[] strings = {"key: [value1, value2, value3 is long]"};
 
             // when
             Map<String, Object> result = PropertiesUtil.toMap(strings);
 
             // then
-            assertThat(result).isEqualTo(Map.of("key", List.of("value1", "value2", "value3")));
+            assertThat(result).isEqualTo(Map.of("key", List.of("value1", "value2", "value3 is long")));
         }
     }
 }

--- a/springwolf-add-ons/springwolf-generic-binding/src/test/java/io/github/springwolf/addons/generic_binding/annotation/processor/AsyncGenericOperationBindingProcessorTest.java
+++ b/springwolf-add-ons/springwolf-generic-binding/src/test/java/io/github/springwolf/addons/generic_binding/annotation/processor/AsyncGenericOperationBindingProcessorTest.java
@@ -22,7 +22,7 @@ class AsyncGenericOperationBindingProcessorTest {
         List<ProcessedOperationBinding> result = getProcessedOperationBindings(ClassWithoutAnnotation.class);
 
         // then
-        assertThat(result).hasSize(0);
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -41,12 +41,11 @@ class AsyncGenericOperationBindingProcessorTest {
     }
 
     private List<ProcessedOperationBinding> getProcessedOperationBindings(Class<?> testClass) {
-        List<ProcessedOperationBinding> result = Arrays.stream(testClass.getDeclaredMethods())
+        return Arrays.stream(testClass.getDeclaredMethods())
                 .map((m) -> m.getAnnotationsByType(AsyncGenericOperationBinding.class))
                 .flatMap(Arrays::stream)
                 .map(processor::mapToOperationBinding)
                 .toList();
-        return result;
     }
 
     private static class ClassWithoutAnnotation {
@@ -102,6 +101,30 @@ class AsyncGenericOperationBindingProcessorTest {
         }
 
         @Test
+        void arrayPropertyTest() {
+            // given
+            String[] strings = {"key=[value1, value2, value3]"};
+
+            // when
+            Map<String, Object> result = PropertiesUtil.toMap(strings);
+
+            // then
+            assertThat(result).isEqualTo(Map.of("key", List.of("value1", "value2", "value3")));
+        }
+
+        @Test
+        void simpleMapPropertyTest() {
+            // given
+            String[] strings = {"map.key1=value1", "map.key2=value2", "map.key3=value3"};
+
+            // when
+            Map<String, Object> result = PropertiesUtil.toMap(strings);
+
+            // then
+            assertThat(result).isEqualTo(Map.of("map", Map.of("key1", "value1", "key2", "value2", "key3", "value3")));
+        }
+
+        @Test
         void nestedPropertyTest() {
             // given
             String[] strings = {"nested.key=value"};
@@ -135,6 +158,18 @@ class AsyncGenericOperationBindingProcessorTest {
 
             // then
             assertThat(result).isEqualTo(Map.of("key", "value"));
+        }
+
+        @Test
+        void yamlSyntaxArrayPropertyTest() {
+            // given
+            String[] strings = {"key: [value1, value2, value3]"};
+
+            // when
+            Map<String, Object> result = PropertiesUtil.toMap(strings);
+
+            // then
+            assertThat(result).isEqualTo(Map.of("key", List.of("value1", "value2", "value3")));
         }
     }
 }


### PR DESCRIPTION
When using the Generic Binding, it was not possible to define an array value. Here we add support for it.

Example: "key=[value1, value2, value3]"