### PR TITLE
fix: Sort Messages references

### DIFF
--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationMerger.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationMerger.java
@@ -5,6 +5,7 @@ import io.github.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import io.github.springwolf.asyncapi.v3.model.operation.Operation;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -62,6 +63,9 @@ public class OperationMerger {
         if (otherMessages != null) {
             messageReferences.addAll(otherMessages);
         }
-        return messageReferences.stream().toList();
+
+        return messageReferences.stream()
+                .sorted(Comparator.comparing(MessageReference::getRef))
+                .toList();
     }
 }

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationMergerTest.java
@@ -122,7 +122,7 @@ class OperationMergerTest {
         // then expectedMessage only includes message1 and message2.
         // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
         assertThat(mergedOperations).hasSize(1).hasEntrySatisfying(operationId, it -> {
-            assertThat(it.getMessages()).containsExactlyInAnyOrder(messageRef1, messageRef2);
+            assertThat(it.getMessages()).containsExactly(messageRef2, messageRef1);
         });
     }
 

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -349,10 +349,10 @@
       },
       "messages": [
         {
-          "$ref": "#/channels/multi-payload-queue/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
+          "$ref": "#/channels/multi-payload-queue/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
         },
         {
-          "$ref": "#/channels/multi-payload-queue/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
+          "$ref": "#/channels/multi-payload-queue/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
         }
       ]
     }


### PR DESCRIPTION
Message references are now alphabetically sorted.

When an Operation has multiple messages, the resulting order depends on how the classes are parsed. This can produce slightly different results in different machines, making problematic the comparison for changes.