### PR TITLE
Add support for Component classes for spring cloud stream plugin (#684)

### DIFF
--- a/springwolf-bindings/springwolf-googlepubsub-binding/src/main/java/io/github/springwolf/bindings/googlepubsub/scanners/channels/GooglePubSubChannelBindingProcessor.java
+++ b/springwolf-bindings/springwolf-googlepubsub-binding/src/main/java/io/github/springwolf/bindings/googlepubsub/scanners/channels/GooglePubSubChannelBindingProcessor.java
@@ -11,7 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.util.StringValueResolver;
 
-import java.lang.reflect.Method;
+import java.lang.reflect.AnnotatedElement;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -24,8 +24,8 @@ public class GooglePubSubChannelBindingProcessor implements ChannelBindingProces
     }
 
     @Override
-    public Optional<ProcessedChannelBinding> process(Method method) {
-        return Arrays.stream(method.getAnnotations())
+    public Optional<ProcessedChannelBinding> process(AnnotatedElement annotatedElement) {
+        return Arrays.stream(annotatedElement.getAnnotations())
                 .filter(GooglePubSubAsyncChannelBinding.class::isInstance)
                 .map(GooglePubSubAsyncChannelBinding.class::cast)
                 .findAny()

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/bindings/channels/ChannelBindingProcessor.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/bindings/channels/ChannelBindingProcessor.java
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.springwolf.core.asyncapi.scanners.bindings.channels;
 
-import java.lang.reflect.Method;
+import java.lang.reflect.AnnotatedElement;
 import java.util.Optional;
 
 public interface ChannelBindingProcessor {
 
     /**
-     * Process the methods annotated with Channel Binding Annotation
+     * Process the elements annotated with Channel Binding Annotation
      * for protocol specific channelBinding annotations, method parameters, etc
      *
-     * @param method The method being annotated
+     * @param annotatedElement The element being annotated
      * @return A message binding, if found
      */
-    Optional<ProcessedChannelBinding> process(Method method);
+    Optional<ProcessedChannelBinding> process(AnnotatedElement annotatedElement);
 }

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/utils/AsyncAnnotationUtil.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/utils/AsyncAnnotationUtil.java
@@ -20,6 +20,7 @@ import io.github.springwolf.core.asyncapi.scanners.bindings.operations.Processed
 import org.springframework.util.StringUtils;
 import org.springframework.util.StringValueResolver;
 
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -149,9 +150,9 @@ public class AsyncAnnotationUtil {
     }
 
     public static Map<String, ChannelBinding> processChannelBindingFromAnnotation(
-            Method method, List<ChannelBindingProcessor> channelBindingProcessors) {
+            AnnotatedElement annotatedElement, List<ChannelBindingProcessor> channelBindingProcessors) {
         return channelBindingProcessors.stream()
-                .map(channelBindingProcessor -> channelBindingProcessor.process(method))
+                .map(channelBindingProcessor -> channelBindingProcessor.process(annotatedElement))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toMap(

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/bindings/processor/TestChannelBindingProcessor.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/bindings/processor/TestChannelBindingProcessor.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.reflect.Method;
+import java.lang.reflect.AnnotatedElement;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -24,8 +24,8 @@ public class TestChannelBindingProcessor implements ChannelBindingProcessor {
     public static final ChannelBinding BINDING = new EmptyChannelBinding();
 
     @Override
-    public Optional<ProcessedChannelBinding> process(Method method) {
-        return Arrays.stream(method.getAnnotations())
+    public Optional<ProcessedChannelBinding> process(AnnotatedElement annotatedElement) {
+        return Arrays.stream(annotatedElement.getAnnotations())
                 .filter(annotation -> annotation instanceof TestChannelBindingProcessor.TestChannelBinding)
                 .map(annotation -> (TestChannelBindingProcessor.TestChannelBinding) annotation)
                 .findAny()

--- a/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/springwolf/examples/cloudstream/configuration/ConsumerClass.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/main/java/io/github/springwolf/examples/cloudstream/configuration/ConsumerClass.java
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.springwolf.examples.cloudstream.configuration;
+
+import io.github.springwolf.examples.cloudstream.dtos.ExamplePayloadDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Consumer;
+
+@Slf4j
+@Component
+public class ConsumerClass implements Consumer<ExamplePayloadDto> {
+
+    @Override
+    public void accept(ExamplePayloadDto payload) {
+        log.info("Called with payload: {}", payload);
+    }
+}

--- a/springwolf-examples/springwolf-cloud-stream-example/src/main/resources/application.properties
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/main/resources/application.properties
@@ -10,6 +10,7 @@ spring.kafka.bootstrap-servers=${BOOTSTRAP_SERVER:localhost:29092}
 spring.cloud.stream.bindings.process-in-0.destination=example-topic
 spring.cloud.stream.bindings.process-out-0.destination=another-topic
 spring.cloud.stream.bindings.consumerMethod-in-0.destination=another-topic
+spring.cloud.stream.bindings.consumerClass-in-0.destination=consumer-class-topic
 spring.cloud.stream.bindings.googlePubSubConsumerMethod-in-0.destination=google-pubsub-topic
 
 

--- a/springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/test/resources/asyncapi.json
@@ -32,6 +32,16 @@
         "kafka": { }
       }
     },
+    "consumer-class-topic": {
+      "messages": {
+        "io.github.springwolf.examples.cloudstream.dtos.ExamplePayloadDto": {
+          "$ref": "#/components/messages/io.github.springwolf.examples.cloudstream.dtos.ExamplePayloadDto"
+        }
+      },
+      "bindings": {
+        "kafka": { }
+      }
+    },
     "example-topic": {
       "messages": {
         "io.github.springwolf.examples.cloudstream.dtos.ExamplePayloadDto": {
@@ -253,6 +263,21 @@
       "messages": [
         {
           "$ref": "#/channels/another-topic/messages/io.github.springwolf.examples.cloudstream.dtos.AnotherPayloadDto"
+        }
+      ]
+    },
+    "consumer-class-topic_publish_ConsumerClass": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/consumer-class-topic"
+      },
+      "description": "Auto-generated description",
+      "bindings": {
+        "kafka": { }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/consumer-class-topic/messages/io.github.springwolf.examples.cloudstream.dtos.ExamplePayloadDto"
         }
       ]
     },

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/channels/CloudStreamFunctionChannelsScanner.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/channels/CloudStreamFunctionChannelsScanner.java
@@ -19,6 +19,7 @@ import io.github.springwolf.core.asyncapi.scanners.ChannelsScanner;
 import io.github.springwolf.core.asyncapi.scanners.beans.BeanMethodsScanner;
 import io.github.springwolf.core.asyncapi.scanners.bindings.channels.ChannelBindingProcessor;
 import io.github.springwolf.core.asyncapi.scanners.channels.ChannelMerger;
+import io.github.springwolf.core.asyncapi.scanners.classes.spring.ComponentClassScanner;
 import io.github.springwolf.core.asyncapi.scanners.common.utils.AsyncAnnotationUtil;
 import io.github.springwolf.core.configuration.docket.AsyncApiDocket;
 import io.github.springwolf.core.configuration.docket.AsyncApiDocketService;
@@ -28,7 +29,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 
-import java.lang.reflect.Method;
+import java.lang.reflect.AnnotatedElement;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -39,6 +41,7 @@ public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
 
     private final AsyncApiDocketService asyncApiDocketService;
     private final BeanMethodsScanner beanMethodsScanner;
+    private final ComponentClassScanner componentClassScanner;
     private final ComponentsService componentsService;
     private final BindingServiceProperties cloudStreamBindingsProperties;
     private final FunctionalChannelBeanBuilder functionalChannelBeanBuilder;
@@ -46,13 +49,18 @@ public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
 
     @Override
     public Map<String, ChannelObject> scan() {
-        Set<Method> beanMethods = beanMethodsScanner.getBeanMethods();
-        return ChannelMerger.mergeChannels(beanMethods.stream()
-                .map(functionalChannelBeanBuilder::fromMethodBean)
+        Set<AnnotatedElement> elements = new HashSet<>();
+        elements.addAll(componentClassScanner.scan());
+        elements.addAll(beanMethodsScanner.getBeanMethods());
+
+        List<Map.Entry<String, ChannelObject>> channels = elements.stream()
+                .map(functionalChannelBeanBuilder::build)
                 .flatMap(Set::stream)
                 .filter(this::isChannelBean)
                 .map(this::toChannelEntry)
-                .toList());
+                .toList();
+
+        return ChannelMerger.mergeChannels(channels);
     }
 
     private boolean isChannelBean(FunctionalChannelBeanData beanData) {
@@ -88,7 +96,7 @@ public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
                 .build();
         this.componentsService.registerMessage(message);
 
-        Map<String, ChannelBinding> channelBinding = buildChannelBinding(beanData.method());
+        Map<String, ChannelBinding> channelBinding = buildChannelBinding(beanData.annotatedElement());
         return ChannelObject.builder()
                 .bindings(channelBinding)
                 .messages(Map.of(message.getName(), MessageReference.toComponentMessage(message)))
@@ -101,9 +109,9 @@ public class CloudStreamFunctionChannelsScanner implements ChannelsScanner {
         return Map.of(protocolName, new EmptyMessageBinding());
     }
 
-    private Map<String, ChannelBinding> buildChannelBinding(Method method) {
+    private Map<String, ChannelBinding> buildChannelBinding(AnnotatedElement annotatedElement) {
         Map<String, ChannelBinding> channelBindingMap =
-                AsyncAnnotationUtil.processChannelBindingFromAnnotation(method, channelBindingProcessors);
+                AsyncAnnotationUtil.processChannelBindingFromAnnotation(annotatedElement, channelBindingProcessors);
         if (!channelBindingMap.isEmpty()) {
             return channelBindingMap;
         }

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/common/FunctionalChannelBeanBuilder.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/common/FunctionalChannelBeanBuilder.java
@@ -4,6 +4,7 @@ package io.github.springwolf.plugins.cloudstream.asyncapi.scanners.common;
 import io.github.springwolf.core.asyncapi.scanners.common.payload.PayloadClassExtractor;
 import lombok.RequiredArgsConstructor;
 
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
@@ -12,6 +13,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static java.util.stream.Collectors.toList;
@@ -20,41 +22,103 @@ import static java.util.stream.Collectors.toList;
 public class FunctionalChannelBeanBuilder {
     private final PayloadClassExtractor extractor;
 
-    public Set<FunctionalChannelBeanData> fromMethodBean(Method methodBean) {
-        Class<?> returnType = methodBean.getReturnType();
-        if (Consumer.class.isAssignableFrom(returnType)) {
-            Class<?> payloadType = getReturnTypeGenerics(methodBean).get(0);
-            return Set.of(ofConsumer(methodBean, payloadType));
+    public Set<FunctionalChannelBeanData> build(AnnotatedElement element) {
+        Class<?> type = getRawType(element);
+
+        if (Consumer.class.isAssignableFrom(type)) {
+            Class<?> payloadType = getTypeGenerics(element).get(0);
+            return Set.of(ofConsumer(element, payloadType));
         }
 
-        if (Supplier.class.isAssignableFrom(returnType)) {
-            Class<?> payloadType = getReturnTypeGenerics(methodBean).get(0);
-            return Set.of(ofSupplier(methodBean, payloadType));
+        if (Supplier.class.isAssignableFrom(type)) {
+            Class<?> payloadType = getTypeGenerics(element).get(0);
+            return Set.of(ofSupplier(element, payloadType));
         }
 
-        if (Function.class.isAssignableFrom(returnType)) {
-            Class<?> inputType = getReturnTypeGenerics(methodBean).get(0);
-            Class<?> outputType = getReturnTypeGenerics(methodBean).get(1);
+        if (Function.class.isAssignableFrom(type)) {
+            Class<?> inputType = getTypeGenerics(element).get(0);
+            Class<?> outputType = getTypeGenerics(element).get(1);
 
-            return Set.of(ofConsumer(methodBean, inputType), ofSupplier(methodBean, outputType));
+            return Set.of(ofConsumer(element, inputType), ofSupplier(element, outputType));
         }
 
         return Collections.emptySet();
     }
 
-    private static FunctionalChannelBeanData ofConsumer(Method method, Class<?> payloadType) {
-        return new FunctionalChannelBeanData(
-                method, payloadType, FunctionalChannelBeanData.BeanType.CONSUMER, method.getName() + "-in-0");
+    private static Class<?> getRawType(AnnotatedElement element) {
+        if (element instanceof Method m) {
+            return m.getReturnType();
+        }
+
+        if (element instanceof Class<?> c) {
+            return c;
+        }
+
+        throw new IllegalArgumentException("Must be a Method or Class");
     }
 
-    private static FunctionalChannelBeanData ofSupplier(Method method, Class<?> payloadType) {
+    private static FunctionalChannelBeanData ofConsumer(AnnotatedElement element, Class<?> payloadType) {
+        String name = getElementName(element);
+        String cloudStreamBinding = firstCharToLowerCase(name) + "-in-0";
         return new FunctionalChannelBeanData(
-                method, payloadType, FunctionalChannelBeanData.BeanType.SUPPLIER, method.getName() + "-out-0");
+                name, element, payloadType, FunctionalChannelBeanData.BeanType.CONSUMER, cloudStreamBinding);
     }
 
-    private List<Class<?>> getReturnTypeGenerics(Method methodBean) {
-        ParameterizedType genericReturnType = (ParameterizedType) methodBean.getGenericReturnType();
-        return Arrays.stream(genericReturnType.getActualTypeArguments())
+    private static FunctionalChannelBeanData ofSupplier(AnnotatedElement element, Class<?> payloadType) {
+        String name = getElementName(element);
+        String cloudStreamBinding = firstCharToLowerCase(name) + "-out-0";
+        return new FunctionalChannelBeanData(
+                name, element, payloadType, FunctionalChannelBeanData.BeanType.SUPPLIER, cloudStreamBinding);
+    }
+
+    private static String firstCharToLowerCase(String name) {
+        return name.substring(0, 1).toLowerCase() + name.substring(1);
+    }
+
+    private static String getElementName(AnnotatedElement element) {
+        if (element instanceof Method m) {
+            return m.getName();
+        }
+
+        if (element instanceof Class<?> c) {
+            return c.getSimpleName();
+        }
+
+        throw new IllegalArgumentException("Must be a Method or Class");
+    }
+
+    private List<Class<?>> getTypeGenerics(AnnotatedElement element) {
+        if (element instanceof Method m) {
+            ParameterizedType genericReturnType = (ParameterizedType) m.getGenericReturnType();
+            return getTypeGenerics(genericReturnType);
+        }
+
+        if (element instanceof Class<?> c) {
+            return getTypeGenerics(c);
+        }
+
+        throw new IllegalArgumentException("Must be a Method or Class");
+    }
+
+    private List<Class<?>> getTypeGenerics(Class<?> c) {
+        Predicate<Class<?>> isConsumerPredicate = Consumer.class::isAssignableFrom;
+        Predicate<Class<?>> isSupplierPredicate = Supplier.class::isAssignableFrom;
+        Predicate<Class<?>> isFunctionPredicate = Function.class::isAssignableFrom;
+        Predicate<Class<?>> hasFunctionalInterfacePredicate =
+                isConsumerPredicate.or(isSupplierPredicate).or(isFunctionPredicate);
+
+        return Arrays.stream(c.getGenericInterfaces())
+                .filter(type -> type instanceof ParameterizedType)
+                .map(type -> (ParameterizedType) type)
+                .filter(type -> type.getRawType() instanceof Class<?>)
+                .filter(type -> hasFunctionalInterfacePredicate.test((Class<?>) type.getRawType()))
+                .map(this::getTypeGenerics)
+                .findFirst()
+                .orElse(Collections.emptyList());
+    }
+
+    private List<Class<?>> getTypeGenerics(ParameterizedType parameterizedType) {
+        return Arrays.stream(parameterizedType.getActualTypeArguments())
                 .map(extractor::typeToClass)
                 .collect(toList());
     }

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/common/FunctionalChannelBeanData.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/common/FunctionalChannelBeanData.java
@@ -1,10 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.springwolf.plugins.cloudstream.asyncapi.scanners.common;
 
-import java.lang.reflect.Method;
+import java.lang.reflect.AnnotatedElement;
 
+/**
+ * @param elementName        The simple name of the element (Method or Class).
+ * @param annotatedElement   The element (Method or Class) from which this instance has been processed.
+ * @param payloadType        The payload type of the Channel this bean is bound to.
+ * @param beanType           Consumer or Supplier.
+ * @param cloudStreamBinding The expected binding string of this bean.
+ */
 public record FunctionalChannelBeanData(
-        Method method, Class<?> payloadType, BeanType beanType, String cloudStreamBinding) {
+        String elementName,
+        AnnotatedElement annotatedElement,
+        Class<?> payloadType,
+        BeanType beanType,
+        String cloudStreamBinding) {
 
     public enum BeanType {
         CONSUMER,

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/springwolf/plugins/cloudstream/configuration/SpringwolfCloudStreamAutoConfiguration.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/springwolf/plugins/cloudstream/configuration/SpringwolfCloudStreamAutoConfiguration.java
@@ -4,6 +4,7 @@ package io.github.springwolf.plugins.cloudstream.configuration;
 import io.github.springwolf.core.asyncapi.components.ComponentsService;
 import io.github.springwolf.core.asyncapi.scanners.beans.BeanMethodsScanner;
 import io.github.springwolf.core.asyncapi.scanners.bindings.channels.ChannelBindingProcessor;
+import io.github.springwolf.core.asyncapi.scanners.classes.spring.ComponentClassScanner;
 import io.github.springwolf.core.asyncapi.scanners.common.payload.PayloadClassExtractor;
 import io.github.springwolf.core.configuration.docket.AsyncApiDocketService;
 import io.github.springwolf.core.configuration.properties.SpringwolfConfigConstants;
@@ -28,6 +29,7 @@ public class SpringwolfCloudStreamAutoConfiguration {
     public CloudStreamFunctionChannelsScanner cloudStreamFunctionChannelsScanner(
             AsyncApiDocketService asyncApiDocketService,
             BeanMethodsScanner beanMethodsScanner,
+            ComponentClassScanner componentClassScanner,
             ComponentsService componentsService,
             BindingServiceProperties cloudstreamBindingServiceProperties,
             FunctionalChannelBeanBuilder functionalChannelBeanBuilder,
@@ -35,6 +37,7 @@ public class SpringwolfCloudStreamAutoConfiguration {
         return new CloudStreamFunctionChannelsScanner(
                 asyncApiDocketService,
                 beanMethodsScanner,
+                componentClassScanner,
                 componentsService,
                 cloudstreamBindingServiceProperties,
                 functionalChannelBeanBuilder,
@@ -45,12 +48,14 @@ public class SpringwolfCloudStreamAutoConfiguration {
     public CloudStreamFunctionOperationsScanner cloudStreamFunctionOperationsScanner(
             AsyncApiDocketService asyncApiDocketService,
             BeanMethodsScanner beanMethodsScanner,
+            ComponentClassScanner componentClassScanner,
             ComponentsService componentsService,
             BindingServiceProperties cloudstreamBindingServiceProperties,
             FunctionalChannelBeanBuilder functionalChannelBeanBuilder) {
         return new CloudStreamFunctionOperationsScanner(
                 asyncApiDocketService,
                 beanMethodsScanner,
+                componentClassScanner,
                 componentsService,
                 cloudstreamBindingServiceProperties,
                 functionalChannelBeanBuilder);

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/common/FunctionalChannelBeanBuilderTest.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/common/FunctionalChannelBeanBuilderTest.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.Message;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -25,123 +26,269 @@ class FunctionalChannelBeanBuilderTest {
             new FunctionalChannelBeanBuilder(new PayloadClassExtractor(properties));
 
     @Nested
-    class NoBean {
-        @Test
-        void testNotAFunctionalChannelBean() throws NoSuchMethodException {
-            Method method = getMethod(this.getClass(), "notAFunctionalChannelBean");
+    class FromMethod {
 
-            Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.fromMethodBean(method);
+        @Nested
+        class NotAFunctionalBean {
+            @Test
+            void testNotAFunctionalChannelBean() throws NoSuchMethodException {
+                Method method = getMethod(this.getClass(), "notAFunctionalChannelBean");
 
-            Assertions.assertThat(data).isEmpty();
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data).isEmpty();
+            }
+
+            @Bean
+            private String notAFunctionalChannelBean() {
+                return "foo";
+            }
         }
 
-        @Bean
-        private String notAFunctionalChannelBean() {
-            return "foo";
+        @Nested
+        class ConsumerBean {
+            @Test
+            void testConsumerBean() throws NoSuchMethodException {
+                Method method = getMethod(this.getClass(), "consumerBean");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data)
+                        .containsExactly(new FunctionalChannelBeanData(
+                                "consumerBean", method, String.class, CONSUMER, "consumerBean-in-0"));
+            }
+
+            @Bean
+            private Consumer<String> consumerBean() {
+                return System.out::println;
+            }
+        }
+
+        @Nested
+        class SupplierBean {
+            @Test
+            void testSupplierBean() throws NoSuchMethodException {
+                Method method = getMethod(this.getClass(), "supplierBean");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data)
+                        .containsExactly(new FunctionalChannelBeanData(
+                                "supplierBean", method, String.class, SUPPLIER, "supplierBean-out-0"));
+            }
+
+            @Bean
+            private Supplier<String> supplierBean() {
+                return () -> "foo";
+            }
+        }
+
+        @Nested
+        class FunctionBean {
+            @Test
+            void testFunctionBean() throws NoSuchMethodException {
+                Method method = getMethod(this.getClass(), "functionBean");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data)
+                        .containsExactlyInAnyOrder(
+                                new FunctionalChannelBeanData(
+                                        "functionBean", method, String.class, CONSUMER, "functionBean-in-0"),
+                                new FunctionalChannelBeanData(
+                                        "functionBean", method, Integer.class, SUPPLIER, "functionBean-out-0"));
+            }
+
+            @Bean
+            private Function<String, Integer> functionBean() {
+                return s -> 1;
+            }
+        }
+
+        @Nested
+        class ConsumerBeanWithGenericPayload {
+
+            @Test
+            void testConsumerBeanWithGenericPayload() throws NoSuchMethodException {
+                String methodName = "consumerBeanWithGenericPayload";
+                Method method = getMethod(this.getClass(), methodName);
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data)
+                        .containsExactly(new FunctionalChannelBeanData(
+                                "consumerBeanWithGenericPayload",
+                                method,
+                                String.class,
+                                CONSUMER,
+                                methodName + "-in-0"));
+            }
+
+            @Bean
+            private Consumer<Message<String>> consumerBeanWithGenericPayload() {
+                return System.out::println;
+            }
+        }
+
+        @Nested
+        class KStreamBean {
+
+            @Test
+            void testKafkaStreamsConsumerBean() throws NoSuchMethodException {
+                String methodName = "kafkaStreamsConsumerBean";
+                Method method = getMethod(this.getClass(), methodName);
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data)
+                        .containsExactly(new FunctionalChannelBeanData(
+                                "kafkaStreamsConsumerBean", method, String.class, CONSUMER, methodName + "-in-0"));
+            }
+
+            @Bean
+            private Consumer<KStream<Void, String>> kafkaStreamsConsumerBean() {
+                return System.out::println;
+            }
         }
     }
 
     @Nested
-    class ConsumerBean {
-        @Test
-        void testConsumerBean() throws NoSuchMethodException {
-            Method method = getMethod(this.getClass(), "consumerBean");
+    class FromClass {
 
-            Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.fromMethodBean(method);
+        @Nested
+        class NotAFunctionalClass {
+            @Test
+            void testNotAFunctionalChannelBean() {
+                Class<?> testClass = getClassObject(this.getClass(), "TestClass");
 
-            Assertions.assertThat(data)
-                    .containsExactly(
-                            new FunctionalChannelBeanData(method, String.class, CONSUMER, "consumerBean-in-0"));
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(testClass);
+
+                Assertions.assertThat(data).isEmpty();
+            }
+
+            private static class TestClass {
+            }
         }
 
-        @Bean
-        private Consumer<String> consumerBean() {
-            return System.out::println;
-        }
-    }
+        @Nested
+        class ConsumerClass {
+            @Test
+            void testConsumerClass() {
+                Class<?> testClass = getClassObject(this.getClass(), "TestClass");
 
-    @Nested
-    class SupplierBean {
-        @Test
-        void testSupplierBean() throws NoSuchMethodException {
-            Method method = getMethod(this.getClass(), "supplierBean");
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(testClass);
 
-            Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.fromMethodBean(method);
+                Assertions.assertThat(data)
+                        .containsExactly(new FunctionalChannelBeanData(
+                                "TestClass", testClass, String.class, CONSUMER, "testClass-in-0"));
+            }
 
-            Assertions.assertThat(data)
-                    .containsExactly(
-                            new FunctionalChannelBeanData(method, String.class, SUPPLIER, "supplierBean-out-0"));
-        }
-
-        @Bean
-        private Supplier<String> supplierBean() {
-            return () -> "foo";
-        }
-    }
-
-    @Nested
-    class FunctionBean {
-        @Test
-        void testFunctionBean() throws NoSuchMethodException {
-            Method method = getMethod(this.getClass(), "functionBean");
-
-            Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.fromMethodBean(method);
-
-            Assertions.assertThat(data)
-                    .containsExactlyInAnyOrder(
-                            new FunctionalChannelBeanData(method, String.class, CONSUMER, "functionBean-in-0"),
-                            new FunctionalChannelBeanData(method, Integer.class, SUPPLIER, "functionBean-out-0"));
+            private static class TestClass implements Consumer<String> {
+                @Override
+                public void accept(String s) {
+                }
+            }
         }
 
-        @Bean
-        private Function<String, Integer> functionBean() {
-            return s -> 1;
-        }
-    }
+        @Nested
+        class SupplierClass {
+            @Test
+            void testSupplierClass() {
+                Class<?> testClass = getClassObject(this.getClass(), "TestClass");
 
-    @Nested
-    class ConsumerBeanWithGenericPayload {
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(testClass);
 
-        @Test
-        void testConsumerBeanWithGenericPayload() throws NoSuchMethodException {
-            String methodName = "consumerBeanWithGenericPayload";
-            Method method = getMethod(this.getClass(), methodName);
+                Assertions.assertThat(data)
+                        .containsExactly(new FunctionalChannelBeanData(
+                                "TestClass", testClass, String.class, SUPPLIER, "testClass-out-0"));
+            }
 
-            Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.fromMethodBean(method);
+            private static class TestClass implements Supplier<String> {
 
-            Assertions.assertThat(data)
-                    .containsExactly(
-                            new FunctionalChannelBeanData(method, String.class, CONSUMER, methodName + "-in-0"));
-        }
-
-        @Bean
-        private Consumer<Message<String>> consumerBeanWithGenericPayload() {
-            return System.out::println;
-        }
-    }
-
-    @Nested
-    class KStreamBean {
-
-        @Test
-        void testKafkaStreamsConsumerBean() throws NoSuchMethodException {
-            String methodName = "kafkaStreamsConsumerBean";
-            Method method = getMethod(this.getClass(), methodName);
-
-            Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.fromMethodBean(method);
-
-            Assertions.assertThat(data)
-                    .containsExactly(
-                            new FunctionalChannelBeanData(method, String.class, CONSUMER, methodName + "-in-0"));
+                @Override
+                public String get() {
+                    return "foo";
+                }
+            }
         }
 
-        @Bean
-        private Consumer<KStream<Void, String>> kafkaStreamsConsumerBean() {
-            return System.out::println;
+        @Nested
+        class FunctionClass {
+            @Test
+            void testFunctionClass() {
+                Class<?> testClass = getClassObject(this.getClass(), "TestClass");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(testClass);
+
+                Assertions.assertThat(data)
+                        .containsExactlyInAnyOrder(
+                                new FunctionalChannelBeanData(
+                                        "TestClass", testClass, String.class, CONSUMER, "testClass-in-0"),
+                                new FunctionalChannelBeanData(
+                                        "TestClass", testClass, Integer.class, SUPPLIER, "testClass-out-0"));
+            }
+
+            private static class TestClass implements Function<String, Integer> {
+                @Override
+                public Integer apply(String s) {
+                    return null;
+                }
+            }
+        }
+
+        @Nested
+        class ConsumerClassWithGenericPayload {
+
+            @Test
+            void testConsumerClassWithGenericPayload() {
+                Class<?> testClass = getClassObject(this.getClass(), "TestClass");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(testClass);
+
+                Assertions.assertThat(data)
+                        .containsExactly(new FunctionalChannelBeanData(
+                                "TestClass", testClass, String.class, CONSUMER, "testClass-in-0"));
+            }
+
+            static class TestClass implements Consumer<Message<String>> {
+
+                @Override
+                public void accept(Message<String> stringMessage) {
+                }
+            }
+        }
+
+        @Nested
+        class KStreamClass {
+
+            @Test
+            void testKafkaStreamsConsumerClass() {
+                Class<?> testClass = getClassObject(this.getClass(), "TestClass");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(testClass);
+
+                Assertions.assertThat(data)
+                        .containsExactly(new FunctionalChannelBeanData(
+                                "TestClass", testClass, String.class, CONSUMER, "testClass-in-0"));
+            }
+
+            static class TestClass implements Consumer<KStream<Void, String>> {
+                @Override
+                public void accept(KStream<Void, String> voidStringKStream) {
+
+                }
+            }
         }
     }
 
     private static Method getMethod(Class<?> clazz, String methodName) throws NoSuchMethodException {
         return clazz.getDeclaredMethod(methodName);
+    }
+
+    private static Class<?> getClassObject(Class<?> clazz, String className) {
+        return Arrays.stream(clazz.getDeclaredClasses())
+                .filter(c -> c.getSimpleName().equals(className))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Could not find class with name " + className));
     }
 }

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/common/FunctionalChannelBeanBuilderTest.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/common/FunctionalChannelBeanBuilderTest.java
@@ -166,8 +166,7 @@ class FunctionalChannelBeanBuilderTest {
                 Assertions.assertThat(data).isEmpty();
             }
 
-            private static class TestClass {
-            }
+            private static class TestClass {}
         }
 
         @Nested
@@ -185,8 +184,7 @@ class FunctionalChannelBeanBuilderTest {
 
             private static class TestClass implements Consumer<String> {
                 @Override
-                public void accept(String s) {
-                }
+                public void accept(String s) {}
             }
         }
 
@@ -253,8 +251,7 @@ class FunctionalChannelBeanBuilderTest {
             static class TestClass implements Consumer<Message<String>> {
 
                 @Override
-                public void accept(Message<String> stringMessage) {
-                }
+                public void accept(Message<String> stringMessage) {}
             }
         }
 
@@ -274,9 +271,7 @@ class FunctionalChannelBeanBuilderTest {
 
             static class TestClass implements Consumer<KStream<Void, String>> {
                 @Override
-                public void accept(KStream<Void, String> voidStringKStream) {
-
-                }
+                public void accept(KStream<Void, String> voidStringKStream) {}
             }
         }
     }


### PR DESCRIPTION
Until now, cloud stream plugin could auto detect Consumer/Supplier/Function bean methods:
```java
@Configuration
public class MyConsumerConfiguration {
  @Bean
  public Consumer<String> myConsumer() {
    return log::info;
  }
}
```

But the following valid configuration was not detected:
```java
@Component
public class MyConsumer implements Consumer<String> {
  @Override
  public void accept(String payload) {
    log.info(payload);
  }
}
```

This PR adds support for auto-detections of Component class in cloud stream plugin. These now lead to the creation of channels and operations automatically.

Additionally, to support this feature `ChannelBindingProcessor` now accepts `AnnotatedElement` instead of `Method`. Bindings could now potentially be used on classes as well, but I did not change the only existing implementation (google pubub) for now.

