### PR TITLE
chore(bindings)!: remove type field from protocol specific binding annotations

### DIFF
--- a/springwolf-bindings/springwolf-googlepubsub-binding/src/main/java/io/github/springwolf/bindings/googlepubsub/annotations/GooglePubSubAsyncChannelBinding.java
+++ b/springwolf-bindings/springwolf-googlepubsub-binding/src/main/java/io/github/springwolf/bindings/googlepubsub/annotations/GooglePubSubAsyncChannelBinding.java
@@ -16,7 +16,6 @@ import java.lang.annotation.Target;
 @Target(value = {ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Inherited
 public @interface GooglePubSubAsyncChannelBinding {
-    String type() default "googlepubsub";
 
     String messageRetentionDuration() default "";
 

--- a/springwolf-bindings/springwolf-googlepubsub-binding/src/main/java/io/github/springwolf/bindings/googlepubsub/annotations/GooglePubSubAsyncMessageBinding.java
+++ b/springwolf-bindings/springwolf-googlepubsub-binding/src/main/java/io/github/springwolf/bindings/googlepubsub/annotations/GooglePubSubAsyncMessageBinding.java
@@ -16,7 +16,6 @@ import java.lang.annotation.Target;
 @Target(value = {ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Inherited
 public @interface GooglePubSubAsyncMessageBinding {
-    String type() default "googlepubsub";
 
     String orderingKey() default "";
 

--- a/springwolf-bindings/springwolf-googlepubsub-binding/src/main/java/io/github/springwolf/bindings/googlepubsub/scanners/channels/GooglePubSubChannelBindingProcessor.java
+++ b/springwolf-bindings/springwolf-googlepubsub-binding/src/main/java/io/github/springwolf/bindings/googlepubsub/scanners/channels/GooglePubSubChannelBindingProcessor.java
@@ -70,6 +70,6 @@ public class GooglePubSubChannelBindingProcessor implements ChannelBindingProces
             bindingBuilder.bindingVersion(bindingAnnotation.bindingVersion());
         }
 
-        return new ProcessedChannelBinding(bindingAnnotation.type(), bindingBuilder.build());
+        return new ProcessedChannelBinding("googlepubsub", bindingBuilder.build());
     }
 }

--- a/springwolf-bindings/springwolf-googlepubsub-binding/src/main/java/io/github/springwolf/bindings/googlepubsub/scanners/messages/GooglePubSubMessageBindingProcessor.java
+++ b/springwolf-bindings/springwolf-googlepubsub-binding/src/main/java/io/github/springwolf/bindings/googlepubsub/scanners/messages/GooglePubSubMessageBindingProcessor.java
@@ -44,6 +44,6 @@ public class GooglePubSubMessageBindingProcessor implements MessageBindingProces
         if (StringUtils.isNotBlank(bindingAnnotation.bindingVersion())) {
             bindingBuilder.bindingVersion(bindingAnnotation.bindingVersion());
         }
-        return new ProcessedMessageBinding(bindingAnnotation.type(), bindingBuilder.build());
+        return new ProcessedMessageBinding("googlepubsub", bindingBuilder.build());
     }
 }

--- a/springwolf-bindings/springwolf-sns-binding/src/main/java/io/github/springwolf/bindings/sns/annotations/SnsAsyncOperationBinding.java
+++ b/springwolf-bindings/springwolf-sns-binding/src/main/java/io/github/springwolf/bindings/sns/annotations/SnsAsyncOperationBinding.java
@@ -21,8 +21,6 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface SnsAsyncOperationBinding {
 
-    String type() default "sns";
-
     String protocol();
 
     SnsAsyncOperationBindingIdentifier endpoint();

--- a/springwolf-bindings/springwolf-sns-binding/src/main/java/io/github/springwolf/bindings/sns/scanners/messages/SnsMessageBindingProcessor.java
+++ b/springwolf-bindings/springwolf-sns-binding/src/main/java/io/github/springwolf/bindings/sns/scanners/messages/SnsMessageBindingProcessor.java
@@ -30,6 +30,6 @@ public class SnsMessageBindingProcessor implements MessageBindingProcessor, Embe
     }
 
     private ProcessedMessageBinding mapToMessageBinding(SnsAsyncOperationBinding bindingAnnotation) {
-        return new ProcessedMessageBinding(bindingAnnotation.type(), new SNSMessageBinding());
+        return new ProcessedMessageBinding("sns", new SNSMessageBinding());
     }
 }

--- a/springwolf-bindings/springwolf-sns-binding/src/main/java/io/github/springwolf/bindings/sns/scanners/operations/SnsOperationBindingProcessor.java
+++ b/springwolf-bindings/springwolf-sns-binding/src/main/java/io/github/springwolf/bindings/sns/scanners/operations/SnsOperationBindingProcessor.java
@@ -25,7 +25,7 @@ public class SnsOperationBindingProcessor extends AbstractOperationBindingProces
                 .build();
         var snsOperationBinding =
                 SNSOperationBinding.builder().consumers(List.of(consumer)).build();
-        return new ProcessedOperationBinding(bindingAnnotation.type(), snsOperationBinding);
+        return new ProcessedOperationBinding("sns", snsOperationBinding);
     }
 
     private SNSOperationBindingConsumer.Protocol readProtocol(String protocol) {

--- a/springwolf-bindings/springwolf-sqs-binding/src/main/java/io/github/springwolf/bindings/sqs/annotations/SqsAsyncOperationBinding.java
+++ b/springwolf-bindings/springwolf-sqs-binding/src/main/java/io/github/springwolf/bindings/sqs/annotations/SqsAsyncOperationBinding.java
@@ -21,7 +21,5 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface SqsAsyncOperationBinding {
 
-    String type() default "sqs";
-
     SqsAsyncQueueBinding[] queues() default {};
 }

--- a/springwolf-bindings/springwolf-sqs-binding/src/main/java/io/github/springwolf/bindings/sqs/scanners/messages/SqsMessageBindingProcessor.java
+++ b/springwolf-bindings/springwolf-sqs-binding/src/main/java/io/github/springwolf/bindings/sqs/scanners/messages/SqsMessageBindingProcessor.java
@@ -32,6 +32,6 @@ public class SqsMessageBindingProcessor implements MessageBindingProcessor, Embe
     private ProcessedMessageBinding mapToMessageBinding(SqsAsyncOperationBinding bindingAnnotation) {
         SQSMessageBinding sqsMessageBinding = new SQSMessageBinding();
 
-        return new ProcessedMessageBinding(bindingAnnotation.type(), sqsMessageBinding);
+        return new ProcessedMessageBinding("sqs", sqsMessageBinding);
     }
 }

--- a/springwolf-bindings/springwolf-sqs-binding/src/main/java/io/github/springwolf/bindings/sqs/scanners/operations/SqsOperationBindingProcessor.java
+++ b/springwolf-bindings/springwolf-sqs-binding/src/main/java/io/github/springwolf/bindings/sqs/scanners/operations/SqsOperationBindingProcessor.java
@@ -23,6 +23,6 @@ public class SqsOperationBindingProcessor extends AbstractOperationBindingProces
                     .build());
         }
         var operationBinding = SQSOperationBinding.builder().queues(queues).build();
-        return new ProcessedOperationBinding(bindingAnnotation.type(), operationBinding);
+        return new ProcessedOperationBinding("sqs", operationBinding);
     }
 }

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/annotations/AmqpAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/annotations/AmqpAsyncOperationBinding.java
@@ -21,8 +21,6 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface AmqpAsyncOperationBinding {
 
-    String type() default "amqp";
-
     int expiration() default 0;
 
     String[] cc() default {};

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/messages/AmqpMessageBindingProcessor.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/messages/AmqpMessageBindingProcessor.java
@@ -32,6 +32,6 @@ public class AmqpMessageBindingProcessor implements MessageBindingProcessor, Emb
     private ProcessedMessageBinding mapToMessageBinding(AmqpAsyncOperationBinding bindingAnnotation) {
         AMQPMessageBinding amqpMessageBinding = AMQPMessageBinding.builder().build();
 
-        return new ProcessedMessageBinding(bindingAnnotation.type(), amqpMessageBinding);
+        return new ProcessedMessageBinding("amqp", amqpMessageBinding);
     }
 }

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/operations/AmqpOperationBindingProcessor.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/operations/AmqpOperationBindingProcessor.java
@@ -23,6 +23,6 @@ public class AmqpOperationBindingProcessor extends AbstractOperationBindingProce
                 .ack(bindingAnnotation.ack())
                 .build();
 
-        return new ProcessedOperationBinding(bindingAnnotation.type(), amqpOperationBinding);
+        return new ProcessedOperationBinding("amqp", amqpOperationBinding);
     }
 }

--- a/springwolf-plugins/springwolf-jms-plugin/src/main/java/io/github/springwolf/plugins/jms/asyncapi/annotations/JmsAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-jms-plugin/src/main/java/io/github/springwolf/plugins/jms/asyncapi/annotations/JmsAsyncOperationBinding.java
@@ -17,7 +17,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @AsyncOperationBinding
-public @interface JmsAsyncOperationBinding {
-
-    String type() default "jms";
-}
+public @interface JmsAsyncOperationBinding {}

--- a/springwolf-plugins/springwolf-jms-plugin/src/main/java/io/github/springwolf/plugins/jms/asyncapi/scanners/bindings/messages/JmsMessageBindingProcessor.java
+++ b/springwolf-plugins/springwolf-jms-plugin/src/main/java/io/github/springwolf/plugins/jms/asyncapi/scanners/bindings/messages/JmsMessageBindingProcessor.java
@@ -32,6 +32,6 @@ public class JmsMessageBindingProcessor implements MessageBindingProcessor, Embe
     private ProcessedMessageBinding mapToMessageBinding(JmsAsyncOperationBinding bindingAnnotation) {
         JMSMessageBinding jmsMessageBinding = new JMSMessageBinding();
 
-        return new ProcessedMessageBinding(bindingAnnotation.type(), jmsMessageBinding);
+        return new ProcessedMessageBinding("jms", jmsMessageBinding);
     }
 }

--- a/springwolf-plugins/springwolf-jms-plugin/src/main/java/io/github/springwolf/plugins/jms/asyncapi/scanners/bindings/operations/JmsOperationBindingProcessor.java
+++ b/springwolf-plugins/springwolf-jms-plugin/src/main/java/io/github/springwolf/plugins/jms/asyncapi/scanners/bindings/operations/JmsOperationBindingProcessor.java
@@ -10,6 +10,6 @@ public class JmsOperationBindingProcessor extends AbstractOperationBindingProces
 
     @Override
     protected ProcessedOperationBinding mapToOperationBinding(JmsAsyncOperationBinding bindingAnnotation) {
-        return new ProcessedOperationBinding(bindingAnnotation.type(), new JMSOperationBinding());
+        return new ProcessedOperationBinding("jms", new JMSOperationBinding());
     }
 }

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/springwolf/plugins/kafka/asyncapi/annotations/KafkaAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/springwolf/plugins/kafka/asyncapi/annotations/KafkaAsyncOperationBinding.java
@@ -21,8 +21,6 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface KafkaAsyncOperationBinding {
 
-    String type() default "kafka";
-
     String groupId() default "";
 
     String clientId() default "";

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/springwolf/plugins/kafka/asyncapi/scanners/bindings/messages/KafkaMessageBindingProcessor.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/springwolf/plugins/kafka/asyncapi/scanners/bindings/messages/KafkaMessageBindingProcessor.java
@@ -45,7 +45,7 @@ public class KafkaMessageBindingProcessor implements MessageBindingProcessor, Em
             kafkaMessageBindingBuilder.bindingVersion(bindingVersion);
         }
 
-        return new ProcessedMessageBinding(bindingAnnotation.type(), kafkaMessageBindingBuilder.build());
+        return new ProcessedMessageBinding("kafka", kafkaMessageBindingBuilder.build());
     }
 
     private String resolveOrNull(String stringValue) {

--- a/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/springwolf/plugins/kafka/asyncapi/scanners/bindings/operations/KafkaOperationBindingProcessor.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/main/java/io/github/springwolf/plugins/kafka/asyncapi/scanners/bindings/operations/KafkaOperationBindingProcessor.java
@@ -25,6 +25,6 @@ public class KafkaOperationBindingProcessor extends AbstractOperationBindingProc
             kafkaOperationBindingBuilder.bindingVersion(bindingVersion);
         }
 
-        return new ProcessedOperationBinding(bindingAnnotation.type(), kafkaOperationBindingBuilder.build());
+        return new ProcessedOperationBinding("kafka", kafkaOperationBindingBuilder.build());
     }
 }

--- a/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/springwolf/plugins/sns/annotations/SnsAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/springwolf/plugins/sns/annotations/SnsAsyncOperationBinding.java
@@ -21,8 +21,6 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface SnsAsyncOperationBinding {
 
-    String type() default "sns";
-
     String protocol();
 
     SnsAsyncOperationBindingIdentifier endpoint();

--- a/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/springwolf/plugins/sns/asyncapi/scanners/bindings/messages/SnsMessageBindingProcessor.java
+++ b/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/springwolf/plugins/sns/asyncapi/scanners/bindings/messages/SnsMessageBindingProcessor.java
@@ -30,6 +30,6 @@ public class SnsMessageBindingProcessor implements MessageBindingProcessor, Embe
     }
 
     private ProcessedMessageBinding mapToMessageBinding(SnsAsyncOperationBinding bindingAnnotation) {
-        return new ProcessedMessageBinding(bindingAnnotation.type(), new SNSMessageBinding());
+        return new ProcessedMessageBinding("sns", new SNSMessageBinding());
     }
 }

--- a/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/springwolf/plugins/sns/asyncapi/scanners/bindings/operations/SnsOperationBindingProcessor.java
+++ b/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/springwolf/plugins/sns/asyncapi/scanners/bindings/operations/SnsOperationBindingProcessor.java
@@ -25,7 +25,7 @@ public class SnsOperationBindingProcessor extends AbstractOperationBindingProces
                 .build();
         var snsOperationBinding =
                 SNSOperationBinding.builder().consumers(List.of(consumer)).build();
-        return new ProcessedOperationBinding(bindingAnnotation.type(), snsOperationBinding);
+        return new ProcessedOperationBinding("sns", snsOperationBinding);
     }
 
     private SNSOperationBindingConsumer.Protocol readProtocol(String protocol) {

--- a/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/springwolf/plugins/sqs/annotations/SqsAsyncOperationBinding.java
+++ b/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/springwolf/plugins/sqs/annotations/SqsAsyncOperationBinding.java
@@ -21,7 +21,5 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface SqsAsyncOperationBinding {
 
-    String type() default "sqs";
-
     SqsAsyncQueueBinding[] queues() default {};
 }

--- a/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/springwolf/plugins/sqs/asyncapi/scanners/bindings/messages/SqsMessageBindingProcessor.java
+++ b/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/springwolf/plugins/sqs/asyncapi/scanners/bindings/messages/SqsMessageBindingProcessor.java
@@ -32,6 +32,6 @@ public class SqsMessageBindingProcessor implements MessageBindingProcessor, Embe
     private ProcessedMessageBinding mapToMessageBinding(SqsAsyncOperationBinding bindingAnnotation) {
         SQSMessageBinding sqsMessageBinding = new SQSMessageBinding();
 
-        return new ProcessedMessageBinding(bindingAnnotation.type(), sqsMessageBinding);
+        return new ProcessedMessageBinding("sqs", sqsMessageBinding);
     }
 }

--- a/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/springwolf/plugins/sqs/asyncapi/scanners/bindings/operations/SqsOperationBindingProcessor.java
+++ b/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/springwolf/plugins/sqs/asyncapi/scanners/bindings/operations/SqsOperationBindingProcessor.java
@@ -23,6 +23,6 @@ public class SqsOperationBindingProcessor extends AbstractOperationBindingProces
                     .build());
         }
         var operationBinding = SQSOperationBinding.builder().queues(queues).build();
-        return new ProcessedOperationBinding(bindingAnnotation.type(), operationBinding);
+        return new ProcessedOperationBinding("sqs", operationBinding);
     }
 }


### PR DESCRIPTION

the field is fixed by the spec and should not be modified by the user