### PR TITLE
(feat) Add support to parse Annotations from super classes

### DIFF
--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/AsyncAnnotationScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/AsyncAnnotationScanner.java
@@ -26,6 +26,7 @@ import io.github.springwolf.core.asyncapi.scanners.common.utils.TextUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.StringValueResolver;
 
@@ -58,7 +59,7 @@ public abstract class AsyncAnnotationScanner<A extends Annotation> implements Em
         Class<A> annotationClass = this.asyncAnnotationProvider.getAnnotation();
         log.debug("Scanning class \"{}\" for @\"{}\" annotated methods", type.getName(), annotationClass.getName());
 
-        return Arrays.stream(type.getDeclaredMethods())
+        return Arrays.stream(ReflectionUtils.getAllDeclaredMethods(type))
                 .filter(method -> !method.isBridge())
                 .filter(method -> AnnotationScannerUtil.findAnnotation(annotationClass, method) != null)
                 .peek(method -> log.debug("Mapping method \"{}\" to channels", method.getName()))


### PR DESCRIPTION
When a class is inheriting annotated methods from a superclass, the code is now properly parsing those methods for annotations.

This development allows to parse annotations from abstract classes or other inheritance classes, where the annotations are defined in a common class.