### PR TITLE
(fix) Fixed a bug loading the Kotlinx Module without `use-fqn` variable

### DIFF
--- a/springwolf-add-ons/springwolf-kotlinx-serialization-model-converter/build.gradle
+++ b/springwolf-add-ons/springwolf-kotlinx-serialization-model-converter/build.gradle
@@ -17,8 +17,11 @@ plugins {
 }
 
 dependencies {
+    api project(":springwolf-core")
+
     implementation "org.springframework:spring-context"
     implementation "org.springframework:spring-beans"
+    implementation "org.springframework.boot:spring-boot-autoconfigure"
 
     implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerVersion}"
     implementation "io.swagger.core.v3:swagger-models-jakarta:${swaggerVersion}"

--- a/springwolf-add-ons/springwolf-kotlinx-serialization-model-converter/build.gradle
+++ b/springwolf-add-ons/springwolf-kotlinx-serialization-model-converter/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     api project(":springwolf-core")
 
     implementation "org.springframework:spring-context"
-    implementation "org.springframework:spring-beans"
     implementation "org.springframework.boot:spring-boot-autoconfigure"
 
     implementation "io.swagger.core.v3:swagger-core-jakarta:${swaggerVersion}"

--- a/springwolf-add-ons/springwolf-kotlinx-serialization-model-converter/src/main/java/io/github/springwolf/addons/kotlinx_serialization_model_converter/configuration/KotlinxSerializationModelConverterAutoConfiguration.java
+++ b/springwolf-add-ons/springwolf-kotlinx-serialization-model-converter/src/main/java/io/github/springwolf/addons/kotlinx_serialization_model_converter/configuration/KotlinxSerializationModelConverterAutoConfiguration.java
@@ -3,12 +3,10 @@ package io.github.springwolf.addons.kotlinx_serialization_model_converter.config
 
 import io.github.springwolf.addons.kotlinx_serialization_model_converter.converter.KotlinxSerializationModelConverter;
 import io.github.springwolf.core.configuration.properties.SpringwolfConfigConstants;
-import org.springframework.beans.factory.annotation.Value;
+import io.github.springwolf.core.configuration.properties.SpringwolfConfigProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import static io.github.springwolf.core.configuration.properties.SpringwolfConfigConstants.SPRINGWOLF_USE_FQN;
 
 /**
  * Spring AutoConfiguration adding an {@link KotlinxSerializationModelConverter} Bean to the spring context.
@@ -18,8 +16,7 @@ import static io.github.springwolf.core.configuration.properties.SpringwolfConfi
 public class KotlinxSerializationModelConverterAutoConfiguration {
 
     @Bean
-    public KotlinxSerializationModelConverter kotlinxSerializationTypeConverter(
-            @Value("${" + SPRINGWOLF_USE_FQN + ":true}") boolean useFqn) {
-        return new KotlinxSerializationModelConverter(useFqn);
+    public KotlinxSerializationModelConverter kotlinxSerializationTypeConverter(SpringwolfConfigProperties properties) {
+        return new KotlinxSerializationModelConverter(properties.isUseFqn());
     }
 }

--- a/springwolf-add-ons/springwolf-kotlinx-serialization-model-converter/src/main/java/io/github/springwolf/addons/kotlinx_serialization_model_converter/configuration/KotlinxSerializationModelConverterAutoConfiguration.java
+++ b/springwolf-add-ons/springwolf-kotlinx-serialization-model-converter/src/main/java/io/github/springwolf/addons/kotlinx_serialization_model_converter/configuration/KotlinxSerializationModelConverterAutoConfiguration.java
@@ -2,19 +2,24 @@
 package io.github.springwolf.addons.kotlinx_serialization_model_converter.configuration;
 
 import io.github.springwolf.addons.kotlinx_serialization_model_converter.converter.KotlinxSerializationModelConverter;
+import io.github.springwolf.core.configuration.properties.SpringwolfConfigConstants;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import static io.github.springwolf.core.configuration.properties.SpringwolfConfigConstants.SPRINGWOLF_USE_FQN;
 
 /**
  * Spring AutoConfiguration adding an {@link KotlinxSerializationModelConverter} Bean to the spring context.
  */
 @Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(name = SpringwolfConfigConstants.SPRINGWOLF_ENABLED, havingValue = "true", matchIfMissing = true)
 public class KotlinxSerializationModelConverterAutoConfiguration {
 
     @Bean
     public KotlinxSerializationModelConverter kotlinxSerializationTypeConverter(
-            @Value("${springwolf.use-fqn}") boolean useFqn) {
+            @Value("${" + SPRINGWOLF_USE_FQN + ":true}") boolean useFqn) {
         return new KotlinxSerializationModelConverter(useFqn);
     }
 }

--- a/springwolf-core/src/main/java/io/github/springwolf/core/configuration/properties/SpringwolfConfigConstants.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/configuration/properties/SpringwolfConfigConstants.java
@@ -10,6 +10,8 @@ public class SpringwolfConfigConstants {
 
     public static final String SPRINGWOLF_ENABLED = SPRINGWOLF_CONFIG_PREFIX + ENABLED;
 
+    public static final String SPRINGWOLF_USE_FQN = SPRINGWOLF_CONFIG_PREFIX + ".use-fqn";
+
     public static final String ENDPOINT_ACTUATOR = ".endpoint.actuator";
 
     public static final String SPRINGWOLF_ENDPOINT_ACTUATOR_ENABLED =


### PR DESCRIPTION
When the Kotlinx Serialization Module was available in an environment without the `springwolf.use-fqn` the code was failing, since it was trying to inject the variable.

The code is now loading the converter **only** if `springwolf.enabled` is `true` (default value). The `springwolf.use-fqn` is also defaulting to `true`.

This solution fixes the identified issue.