### PR TITLE
Enable automatic nexus publishing

### DIFF
--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -31,7 +31,7 @@ jobs:
           ORG_GRADLE_PROJECT_DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Publish maven artifacts
-        run: ./gradlew publish
+        run: ./gradlew publish closeAndReleaseStagingRepositories
         env:
           ORG_GRADLE_PROJECT_SIGNINGKEY: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGKEY}}
           ORG_GRADLE_PROJECT_SIGNINGPASSWORD: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD}}

--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -35,7 +35,6 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_SIGNINGKEY: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGKEY}}
           ORG_GRADLE_PROJECT_SIGNINGPASSWORD: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD}}
-          ORG_GRADLE_PROJECT_MAVEN_URL: https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/
           ORG_GRADLE_PROJECT_MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           ORG_GRADLE_PROJECT_MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
 

--- a/.github/workflows/springwolf-addons.yml
+++ b/.github/workflows/springwolf-addons.yml
@@ -51,6 +51,5 @@ jobs:
           ORG_GRADLE_PROJECT_SIGNINGKEY: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGKEY}}
           ORG_GRADLE_PROJECT_SIGNINGPASSWORD: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD}}
 
-          ORG_GRADLE_PROJECT_MAVEN_URL: https://s01.oss.sonatype.org/content/repositories/snapshots/
           ORG_GRADLE_PROJECT_MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           ORG_GRADLE_PROJECT_MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/springwolf-asyncapi.yml
+++ b/.github/workflows/springwolf-asyncapi.yml
@@ -40,6 +40,5 @@ jobs:
           ORG_GRADLE_PROJECT_SIGNINGKEY: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGKEY}}
           ORG_GRADLE_PROJECT_SIGNINGPASSWORD: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD}}
 
-          ORG_GRADLE_PROJECT_MAVEN_URL: https://s01.oss.sonatype.org/content/repositories/snapshots/
           ORG_GRADLE_PROJECT_MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           ORG_GRADLE_PROJECT_MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/springwolf-bindings.yml
+++ b/.github/workflows/springwolf-bindings.yml
@@ -51,6 +51,5 @@ jobs:
           ORG_GRADLE_PROJECT_SIGNINGKEY: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGKEY}}
           ORG_GRADLE_PROJECT_SIGNINGPASSWORD: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD}}
 
-          ORG_GRADLE_PROJECT_MAVEN_URL: https://s01.oss.sonatype.org/content/repositories/snapshots/
           ORG_GRADLE_PROJECT_MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           ORG_GRADLE_PROJECT_MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/springwolf-core.yml
+++ b/.github/workflows/springwolf-core.yml
@@ -40,6 +40,5 @@ jobs:
           ORG_GRADLE_PROJECT_SIGNINGKEY: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGKEY}}
           ORG_GRADLE_PROJECT_SIGNINGPASSWORD: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD}}
 
-          ORG_GRADLE_PROJECT_MAVEN_URL: https://s01.oss.sonatype.org/content/repositories/snapshots/
           ORG_GRADLE_PROJECT_MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           ORG_GRADLE_PROJECT_MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/springwolf-plugins.yml
+++ b/.github/workflows/springwolf-plugins.yml
@@ -70,6 +70,5 @@ jobs:
           ORG_GRADLE_PROJECT_SIGNINGKEY: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGKEY}}
           ORG_GRADLE_PROJECT_SIGNINGPASSWORD: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD}}
 
-          ORG_GRADLE_PROJECT_MAVEN_URL: https://s01.oss.sonatype.org/content/repositories/snapshots/
           ORG_GRADLE_PROJECT_MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           ORG_GRADLE_PROJECT_MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/springwolf-ui.yml
+++ b/.github/workflows/springwolf-ui.yml
@@ -46,7 +46,6 @@ jobs:
           ORG_GRADLE_PROJECT_SIGNINGKEY: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGKEY}}
           ORG_GRADLE_PROJECT_SIGNINGPASSWORD: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD}}
 
-          ORG_GRADLE_PROJECT_MAVEN_URL: https://s01.oss.sonatype.org/content/repositories/snapshots/
           ORG_GRADLE_PROJECT_MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           ORG_GRADLE_PROJECT_MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,9 +13,5 @@ The following list describe the steps necessary to release a new version.
 3. Update `all-contributors` in [README.md](README.md)
 4. Remove the `-SNAPHSOT` postfix in `.env`, create a new branch `release/0.X.X` (version number), commit & push
 5. Run GitHub `Publish releases` pipeline from the newly created release branch
-   1. The stage artifacts can be viewed in https://s01.oss.sonatype.org/#view-repositories
-   2. To view them, select `Nexus Managed Repositories` in the drop-down and search for springwolf in the searchbox 
-6. Release version in nexus
-   1. Artifacts are visible in the public maven repository: https://repo1.maven.org/maven2/io/github/springwolf/
-7. Update version number on website
-8. Update the version number in `.env` for next snapshot on branch `master`, commit & push
+6. Update version number on website
+7. Update the version number in `.env` for next snapshot on branch `master`, commit & push

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
 }
 
 plugins {
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
     id 'ca.cutterslade.analyze' version '1.9.1'
     id 'io.spring.dependency-management' version '1.1.4' apply false
     id 'org.springframework.boot' version '3.2.5' apply false
@@ -212,16 +213,6 @@ allprojects {
                 }
             }
         }
-
-        repositories {
-            maven {
-                url = project.findProperty('MAVEN_URL')
-                credentials {
-                    username = project.findProperty('MAVEN_USERNAME') ?: ''
-                    password = project.findProperty('MAVEN_PASSWORD') ?: ''
-                }
-            }
-        }
     }
 
     signing {
@@ -242,6 +233,17 @@ allprojects {
                         .file('springwolf-examples/' + it + '-example/src/test/resources/asyncapi.actual.json')
                         .renameTo('springwolf-examples/' + it + '-example/src/test/resources/asyncapi.json')
             }
+        }
+    }
+}
+
+nexusPublishing {
+    repositories {
+        MavenRepository {
+            nexusUrl = uri('https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/')
+            snapshotRepositoryUrl = uri('https://s01.oss.sonatype.org/content/repositories/snapshots/')
+            username = project.findProperty('MAVEN_USERNAME') ?: ''
+            password = project.findProperty('MAVEN_PASSWORD') ?: ''
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,6 @@ allprojects {
             exceptionFormat = 'full'
         }
     }
-
     tasks.register('unitTest', Test) {
         enabled = !it.project.name.contains("-example") // Examples do not contain unit tests and would fail otherwise
         dependsOn spotlessApply // Automatically fix code formatting if possible
@@ -111,8 +110,6 @@ allprojects {
             exceptionFormat = 'full'
         }
     }
-
-
     tasks.register('integrationTest', Test) {
         dependsOn spotlessApply // Automatically fix code formatting if possible
 
@@ -128,6 +125,19 @@ allprojects {
 
             events "skipped", "failed"
             exceptionFormat = 'full'
+        }
+    }
+
+    tasks.register('updateAsyncApiJson') {
+        group 'verification'
+        description 'Update the AsyncAPI JSON files in the examples to match the current state of the plugin'
+
+        doLast { // ensure that the code is not executed as part of a gradle refresh
+            plugins.forEach {
+                project
+                        .file('springwolf-examples/' + it + '-example/src/test/resources/asyncapi.actual.json')
+                        .renameTo('springwolf-examples/' + it + '-example/src/test/resources/asyncapi.json')
+            }
         }
     }
 
@@ -221,19 +231,6 @@ allprojects {
         def signingPassword = project.findProperty("SIGNINGPASSWORD")
         useInMemoryPgpKeys(signingKey, signingPassword)
         sign publishing.publications.mavenJava
-    }
-
-    tasks.register('updateAsyncApiJson') {
-        group 'verification'
-        description 'Update the AsyncAPI JSON files in the examples to match the current state of the plugin'
-
-        doLast { // ensure that the code is not executed as part of a gradle refresh
-            plugins.forEach {
-                project
-                        .file('springwolf-examples/' + it + '-example/src/test/resources/asyncapi.actual.json')
-                        .renameTo('springwolf-examples/' + it + '-example/src/test/resources/asyncapi.json')
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Uses: https://github.com/gradle-nexus/publish-plugin

Based on the documentation, the existing secrets can be used.

Also, we use the gradle version field to indiciate whether it is a release or SNAPSHOT version.
The plugin uses this to decide which repo url to use