### PR TITLE
chore: comment on issues w.r.t staged_for_release, waiting_for_feedback label

### DIFF
--- a/.github/workflows/gh-issue-comment.yml
+++ b/.github/workflows/gh-issue-comment.yml
@@ -1,0 +1,21 @@
+name: Update issue comment
+
+on:
+  issue_comment:
+
+jobs:
+  when_user_comments_remove_label_waiting_for_feedback:
+    runs-on: ubuntu-latest
+    if: >-
+      !github.event.issue.pull_request &&
+      github.event.action == 'created' &&
+      github.event.pull_request.author_association != 'CONTRIBUTOR' &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      contains(github.event.issue.labels.*.name, 'waiting for feedback')
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_ISSUE_NUMBER: ${{ github.event.issue.number }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Remove label "waiting for feedback"
+        run: gh issue edit ${{ env.GH_ISSUE_NUMBER }} --remove-label "waiting for feedback"

--- a/.github/workflows/gh-issues.yml
+++ b/.github/workflows/gh-issues.yml
@@ -1,0 +1,45 @@
+name: Update issue
+
+on:
+  issues:
+
+jobs:
+  comment_when_issue_labeled_staged_for_release:
+    runs-on: ubuntu-latest
+    if: >-
+      !github.event.issue.pull_request &&
+      github.event.action == 'labeled' && 
+      github.event.label.name == 'staged for release'
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_ISSUE_NUMBER: ${{ github.event.issue.number }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Comment on issue
+        run: |
+          cat << EOF | gh issue comment ${{ env.GH_ISSUE_NUMBER }} -F -
+          The change is staged for release and will be part of the next release.
+
+          If you want to try and verify it in your application today,
+          use the latest 1.X.0-SNAPSHOT build as described in our [README.md > Testing SNAPSHOT version](https://github.com/springwolf/springwolf-core)
+
+          Thank you for the report/contribution!
+          EOF
+  comment_when_staged_for_release_issue_is_closed:
+    runs-on: ubuntu-latest
+    if: >-
+      !github.event.issue.pull_request &&
+      github.event.action == 'closed' && 
+      contains(github.event.issue.labels.*.name, 'staged for release')
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_ISSUE_NUMBER: ${{ github.event.issue.number }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Comment on issue
+        run: |
+          cat << EOF | gh issue comment ${{ env.GH_ISSUE_NUMBER }} -F -
+          The change is available in the latest release. 🎉
+
+          Thank you for the report/contribution and making Springwolf better!
+          EOF


### PR DESCRIPTION
Feel free to suggested better messages. The intention is to keep the user in the loop regarding the current status of the issue.

Current practice:
An issue is kept open until the release is available. To indicate that an issue has been addressed/solved, we continue to add the `staged for release` label manually.

(Similarly, the `waiting for feedback` label is automatically removed when a user ( = non Springwolf member) comments)

Tested in https://github.com/timonback/springwolf-core/issues/124