### PR TITLE
feat(ui): handle allOf schemas

### DIFF
--- a/springwolf-ui/src/app/service/asyncapi/models/schema.model.ts
+++ b/springwolf-ui/src/app/service/asyncapi/models/schema.model.ts
@@ -1,13 +1,20 @@
 /* SPDX-License-Identifier: Apache-2.0 */
+export type ServerAsyncApiSchemaOrRef = ServerAsyncApiSchema | { $ref: string };
+
 export interface ServerAsyncApiSchema {
   description?: string;
   type: string;
   format?: string;
   enum?: string[];
+
   properties?: {
-    [key: string]: ServerAsyncApiSchema | { $ref: string };
+    [key: string]: ServerAsyncApiSchemaOrRef;
   };
-  items?: ServerAsyncApiSchema | { $ref: string };
+  allOf?: ServerAsyncApiSchemaOrRef[];
+  anyOf?: ServerAsyncApiSchemaOrRef[];
+  oneOf?: ServerAsyncApiSchemaOrRef[];
+
+  items?: ServerAsyncApiSchemaOrRef;
   examples?: any[];
 
   required?: string[];


### PR DESCRIPTION
Visualizes the any,all,oneOf schema in the ui.
This is a very basic implementation, which simply extracts the schema.
Better implementations may show the actual any,all,oneOf schema relationships

CC: @aerfus 

Relates to GH-730