### PR TITLE
feat(core): show publish button in ui only when publishing is enabled

### DIFF
--- a/springwolf-core/src/main/java/io/github/springwolf/core/controller/PublishingBaseController.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/controller/PublishingBaseController.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,6 +25,14 @@ public abstract class PublishingBaseController implements InitializingBean {
     protected abstract boolean isEnabled();
 
     protected abstract void publishMessage(String topic, MessageDto message, Object payload);
+
+    @GetMapping("/publish")
+    public ResponseEntity<String> canPublish() {
+        if (!isEnabled()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok().build();
+    }
 
     @PostMapping("/publish")
     public ResponseEntity<String> publish(@RequestParam String topic, @RequestBody MessageDto message) {

--- a/springwolf-plugins/springwolf-jms-plugin/src/test/java/io/github/springwolf/plugins/jms/controller/SpringwolfJmsControllerIntegrationTest.java
+++ b/springwolf-plugins/springwolf-jms-plugin/src/test/java/io/github/springwolf/plugins/jms/controller/SpringwolfJmsControllerIntegrationTest.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -40,6 +41,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -93,6 +95,23 @@ class SpringwolfJmsControllerIntegrationTest {
                 .title(PayloadDto.class.getName())
                 .properties(new HashMap<>())
                 .build());
+    }
+
+    @Nested
+    class CanPublish {
+        @Test
+        void testControllerShouldReturnOkWhenPublishingIsEnabled() throws Exception {
+            mvc.perform(get("/springwolf/jms/publish").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().is2xxSuccessful());
+        }
+
+        @Test
+        void testControllerShouldReturnNotFoundWhenPublishingIsDisabled() throws Exception {
+            when(springwolfJmsProducer.isEnabled()).thenReturn(false);
+
+            mvc.perform(get("/springwolf/jms/publish").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().is4xxClientError());
+        }
     }
 
     @Test

--- a/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/springwolf/plugins/kafka/controller/SpringwolfKafkaControllerIntegrationTest.java
+++ b/springwolf-plugins/springwolf-kafka-plugin/src/test/java/io/github/springwolf/plugins/kafka/controller/SpringwolfKafkaControllerIntegrationTest.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -40,6 +41,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -93,6 +95,23 @@ class SpringwolfKafkaControllerIntegrationTest {
                 .title(PayloadDto.class.getName())
                 .properties(new HashMap<>())
                 .build());
+    }
+
+    @Nested
+    class CanPublish {
+        @Test
+        void testControllerShouldReturnOkWhenPublishingIsEnabled() throws Exception {
+            mvc.perform(get("/springwolf/kafka/publish").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().is2xxSuccessful());
+        }
+
+        @Test
+        void testControllerShouldReturnNotFoundWhenPublishingIsDisabled() throws Exception {
+            when(springwolfKafkaProducer.isEnabled()).thenReturn(false);
+
+            mvc.perform(get("/springwolf/kafka/publish").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().is4xxClientError());
+        }
     }
 
     @Test

--- a/springwolf-ui/src/app/components/channels/channel-main/channel-main.component.html
+++ b/springwolf-ui/src/app/components/channels/channel-main/channel-main.component.html
@@ -59,6 +59,7 @@
           <button
             mat-raised-button
             color="primary"
+            [disabled]="!canPublish"
             (click)="
               publish(
                 messageTextArea.value,

--- a/springwolf-ui/src/app/components/channels/channel-main/channel-main.component.ts
+++ b/springwolf-ui/src/app/components/channels/channel-main/channel-main.component.ts
@@ -32,7 +32,6 @@ export class ChannelMainComponent implements OnInit {
   messageBindingExample?: Example;
   messageBindingExampleTextAreaLineCount: number = 1;
   canPublish: boolean = false;
-  canPublishSubscription?: Subscription;
 
   constructor(
     private asyncApiService: AsyncApiService,
@@ -61,10 +60,7 @@ export class ChannelMainComponent implements OnInit {
       this.messageBindingExampleTextAreaLineCount =
         this.messageBindingExample?.lineCount || 1;
 
-      if (this.canPublishSubscription !== undefined) {
-        this.canPublishSubscription.unsubscribe();
-      }
-      this.canPublishSubscription = this.publisherService
+      this.publisherService
         .canPublish(this.operation.protocol)
         .subscribe((response) => {
           this.canPublish = response;

--- a/springwolf-ui/src/app/components/channels/channel-main/channel-main.component.ts
+++ b/springwolf-ui/src/app/components/channels/channel-main/channel-main.component.ts
@@ -9,6 +9,7 @@ import { Schema } from "../../../models/schema.model";
 import { AsyncApiService } from "../../../service/asyncapi/asyncapi.service";
 import { PublisherService } from "../../../service/publisher.service";
 import { wrapException } from "../../../util/error-boundary";
+import { Subscription } from "rxjs";
 
 @Component({
   selector: "app-channel-main",
@@ -30,6 +31,8 @@ export class ChannelMainComponent implements OnInit {
   headersTextAreaLineCount: number = 1;
   messageBindingExample?: Example;
   messageBindingExampleTextAreaLineCount: number = 1;
+  canPublish: boolean = false;
+  canPublishSubscription?: Subscription;
 
   constructor(
     private asyncApiService: AsyncApiService,
@@ -57,6 +60,15 @@ export class ChannelMainComponent implements OnInit {
       this.headersTextAreaLineCount = this.headersExample?.lineCount || 1;
       this.messageBindingExampleTextAreaLineCount =
         this.messageBindingExample?.lineCount || 1;
+
+      if (this.canPublishSubscription !== undefined) {
+        this.canPublishSubscription.unsubscribe();
+      }
+      this.canPublishSubscription = this.publisherService
+        .canPublish(this.operation.protocol)
+        .subscribe((response) => {
+          this.canPublish = response;
+        });
     });
   }
 

--- a/springwolf-ui/src/app/service/mock/mock-server.ts
+++ b/springwolf-ui/src/app/service/mock/mock-server.ts
@@ -12,14 +12,18 @@ export class MockServer implements InMemoryDbService {
   }
 
   get(reqInfo: RequestInfo) {
-    console.log("Returning mock data");
     if (reqInfo.req.url.endsWith("/docs")) {
+      console.log("Returning mock data");
       const body = this.selectMockData();
       return reqInfo.utils.createResponse$(() => {
         return {
           status: STATUS.OK,
           body: body,
         };
+      });
+    } else if (reqInfo.req.url.endsWith("/publish")) {
+      return reqInfo.utils.createResponse$(() => {
+        return { status: STATUS.OK, body: {} };
       });
     }
 

--- a/springwolf-ui/src/app/service/publisher.service.ts
+++ b/springwolf-ui/src/app/service/publisher.service.ts
@@ -1,12 +1,28 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 import { Injectable } from "@angular/core";
 import { HttpClient, HttpParams } from "@angular/common/http";
-import { Observable } from "rxjs";
+import { Observable, map, share } from "rxjs";
 import { EndpointService } from "./endpoint.service";
 
 @Injectable()
 export class PublisherService {
   constructor(private http: HttpClient) {}
+  publishable: { [key: string]: Observable<boolean> } = {};
+
+  canPublish(protocol: string): Observable<boolean> {
+    if (this.publishable[protocol] === undefined) {
+      this.publishable[protocol] = this.http
+        .get<undefined>(EndpointService.getPublishEndpoint(protocol), {
+          observe: "response",
+        })
+        .pipe(
+          map((response: any) => response.status === 200),
+          share()
+        );
+    }
+
+    return this.publishable[protocol];
+  }
 
   publish(
     protocol: string,


### PR DESCRIPTION
This uses a trivial approach of adding a GET endpoint per protocol (no single combined one) to indicate to the ui, whether publishing is enabled.

Relates to https://github.com/springwolf/springwolf-core/issues/609