### PR TITLE
fix(core): Fix startup when Spring WebMVC is not used

### DIFF
--- a/springwolf-core/src/main/java/io/github/springwolf/core/configuration/SpringwolfUiResourceConfiguration.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/configuration/SpringwolfUiResourceConfiguration.java
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.springwolf.core.configuration;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @ConditionalOnClass(WebMvcConfigurer.class)
+@ConditionalOnBean({WebMvcProperties.class, WebProperties.class})
 @Import(SpringwolfUiResourceConfigurer.class)
 public class SpringwolfUiResourceConfiguration {}


### PR DESCRIPTION
Only use SpringwolfUiResourceConfiguration if the required beans are present in the spring context (WebMvcProperties, WebProperties)

Fixes https://github.com/springwolf/springwolf-core/issues/866