### PR TITLE
feat(core): remove studio work-around for yaml

### DIFF
--- a/springwolf-core/build.gradle
+++ b/springwolf-core/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 
     implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonVersion}"
 
     implementation "org.slf4j:slf4j-api:${slf4jApiVersion}"
 

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/components/examples/walkers/yaml/DefaultExampleYamlValueSerializer.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/components/examples/walkers/yaml/DefaultExampleYamlValueSerializer.java
@@ -4,24 +4,11 @@ package io.github.springwolf.core.asyncapi.components.examples.walkers.yaml;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import io.github.springwolf.core.configuration.properties.SpringwolfConfigProperties;
 import io.swagger.v3.core.util.Yaml;
 
 public class DefaultExampleYamlValueSerializer implements ExampleYamlValueSerializer {
 
-    private final ObjectMapper yamlMapper;
-
-    public DefaultExampleYamlValueSerializer(SpringwolfConfigProperties springwolfConfigProperties) {
-        this.yamlMapper = Yaml.mapper();
-
-        if (springwolfConfigProperties.isStudioCompatibility()) {
-            // AsyncApi Studio has problems with missing quotes on dates, so we add quotes on every example
-            // see https://github.com/springwolf/springwolf-core/issues/820
-            ((YAMLFactory) yamlMapper.getFactory()).disable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
-        }
-    }
+    private final ObjectMapper yamlMapper = Yaml.mapper();
 
     @Override
     public String writeDocumentAsYamlString(JsonNode node) throws JsonProcessingException {

--- a/springwolf-core/src/main/java/io/github/springwolf/core/configuration/SpringwolfAutoConfiguration.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/configuration/SpringwolfAutoConfiguration.java
@@ -162,9 +162,8 @@ public class SpringwolfAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public ExampleYamlValueSerializer defaultExampleYamlValueSerializer(
-            SpringwolfConfigProperties springwolfConfigProperties) {
-        return new DefaultExampleYamlValueSerializer(springwolfConfigProperties);
+    public ExampleYamlValueSerializer defaultExampleYamlValueSerializer() {
+        return new DefaultExampleYamlValueSerializer();
     }
 
     @Bean

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/components/DefaultYamlComponentsServiceIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/components/DefaultYamlComponentsServiceIntegrationTest.java
@@ -50,9 +50,7 @@ class DefaultYamlComponentsServiceIntegrationTest {
 
     private final SpringwolfConfigProperties springwolfConfigProperties = new SpringwolfConfigProperties();
     private final ExampleYamlValueGenerator exampleYamlValueGenerator = new ExampleYamlValueGenerator(
-            new ExampleJsonValueGenerator(),
-            new DefaultExampleYamlValueSerializer(springwolfConfigProperties),
-            springwolfConfigProperties);
+            new ExampleJsonValueGenerator(), new DefaultExampleYamlValueSerializer(), springwolfConfigProperties);
 
     private final SwaggerSchemaService schemaService = new SwaggerSchemaService(
             List.of(),

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/components/examples/walkers/DefaultSchemaWalkerYamlIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/components/examples/walkers/DefaultSchemaWalkerYamlIntegrationTest.java
@@ -35,9 +35,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
 
     private final SpringwolfConfigProperties springwolfConfigProperties = new SpringwolfConfigProperties();
     private final ExampleYamlValueGenerator exampleYamlValueGenerator = new ExampleYamlValueGenerator(
-            new ExampleJsonValueGenerator(),
-            new DefaultExampleYamlValueSerializer(springwolfConfigProperties),
-            springwolfConfigProperties);
+            new ExampleJsonValueGenerator(), new DefaultExampleYamlValueSerializer(), springwolfConfigProperties);
     private final DefaultSchemaWalker<JsonNode, String> jsonSchemaWalker =
             new DefaultSchemaWalker<>(exampleYamlValueGenerator);
 
@@ -73,7 +71,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             String actualString = jsonSchemaWalker.fromSchema(schema, emptyMap());
 
             assertThat(actualString).isEqualTo("""
-                    "string"
+                    string
                     """);
         }
 
@@ -242,7 +240,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             String actualString = jsonSchemaWalker.fromSchema(schema, emptyMap());
 
             assertThat(actualString).isEqualTo("""
-                    "string"
+                    string
                     """);
         }
 
@@ -255,7 +253,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             String actualString = jsonSchemaWalker.fromSchema(schema, emptyMap());
 
             assertThat(actualString).isEqualTo("""
-                    "custom-example-value"
+                    custom-example-value
                     """);
         }
 
@@ -268,7 +266,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             String actualString = jsonSchemaWalker.fromSchema(schema, emptyMap());
 
             assertThat(actualString).isEqualTo("""
-                    "custom-example-value"
+                    custom-example-value
                     """);
         }
 
@@ -282,7 +280,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             String actualString = jsonSchemaWalker.fromSchema(schema, emptyMap());
 
             assertThat(actualString).isEqualTo("""
-                    "EnumItem1"
+                    EnumItem1
                     """);
         }
 
@@ -295,7 +293,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             String actualString = jsonSchemaWalker.fromSchema(schema, emptyMap());
 
             assertThat(actualString).isEqualTo("""
-                    "YmFzZTY0LWV4YW1wbGU="
+                    YmFzZTY0LWV4YW1wbGU=
                     """);
         }
 
@@ -321,7 +319,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             String actualString = jsonSchemaWalker.fromSchema(schema, emptyMap());
 
             assertThat(actualString).isEqualTo("""
-                    "2015-07-20"
+                    2015-07-20
                     """);
         }
 
@@ -334,7 +332,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
 
             assertThat(actualString)
                     .isEqualTo("""
-                    "2015-07-20T15:49:04-07:00"
+                    2015-07-20T15:49:04-07:00
                     """);
         }
 
@@ -346,7 +344,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             String actualString = jsonSchemaWalker.fromSchema(schema, emptyMap());
 
             assertThat(actualString).isEqualTo("""
-                    "example@example.com"
+                    example@example.com
                     """);
         }
 
@@ -358,7 +356,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             String actualString = jsonSchemaWalker.fromSchema(schema, emptyMap());
 
             assertThat(actualString).isEqualTo("""
-                    "string-password"
+                    string-password
                     """);
         }
 
@@ -371,7 +369,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
 
             assertThat(actualString)
                     .isEqualTo("""
-                    "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+                    3fa85f64-5717-4562-b3fc-2c963f66afa6
                     """);
         }
 
@@ -417,7 +415,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             String actualString = jsonSchemaWalker.fromSchema(schema, emptyMap());
 
             assertThat(actualString).isEqualTo("""
-                    - "string"
+                    - string
                     """);
         }
     }
@@ -440,7 +438,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
                     .isEqualTo(
                             """
                     - b: true
-                      s: "string"
+                      s: string
                     """);
         }
 
@@ -456,7 +454,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             assertThat(actualString)
                     .isEqualTo("""
                     b: true
-                    s: "string"
+                    s: string
                     """);
         }
 
@@ -480,8 +478,8 @@ class DefaultSchemaWalkerYamlIntegrationTest {
                             """
                     f:
                       b: true
-                      s: "string"
-                    s: "string"
+                      s: string
+                    s: string
                     """);
         }
 
@@ -497,7 +495,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             String actualString = jsonSchemaWalker.fromSchema(compositeSchema, Map.of("Nested", propertySchema));
 
             assertThat(actualString).isEqualTo("""
-                    anyOfField: "string"
+                    anyOfField: string
                     """);
         }
 
@@ -513,7 +511,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             String actualString = jsonSchemaWalker.fromSchema(compositeSchema, Map.of("Nested", propertySchema));
 
             assertThat(actualString).isEqualTo("""
-                    oneOfField: "string"
+                    oneOfField: string
                     """);
         }
 
@@ -538,7 +536,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
                     .isEqualTo(
                             """
                     allOfField:
-                      field1: "string"
+                      field1: string
                       field2: 1.1
                     """);
         }
@@ -553,7 +551,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
 
             String actualString = jsonSchemaWalker.fromSchema(mapSchema, Map.of());
 
-            assertThat(actualString).isEqualTo("key: \"string\"\n");
+            assertThat(actualString).isEqualTo("key: string\n");
         }
 
         @Test
@@ -572,7 +570,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
 
             String actualString = jsonSchemaWalker.fromSchema(mapSchema, Map.of());
 
-            assertThat(actualString).isEqualTo("key:\n- field1: \"string\"\n");
+            assertThat(actualString).isEqualTo("key:\n- field1: string\n");
         }
 
         @Test
@@ -586,7 +584,7 @@ class DefaultSchemaWalkerYamlIntegrationTest {
             assertThat(actualString)
                     .isEqualTo(
                             """
-                            "Text with special character /\\\\\\\\'\\\\b\\\\f\\\\t\\\\r\\\\n."
+                            Text with special character /\\\\'\\b\\f\\t\\r\\n.
                             """);
         }
 

--- a/springwolf-core/src/test/resources/schemas/yaml/annotation-definitions-yaml.json
+++ b/springwolf-core/src/test/resources/schemas/yaml/annotation-definitions-yaml.json
@@ -1,7 +1,7 @@
 {
   "io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$SchemaWithOneOf$AllOf" : {
     "type" : "string",
-    "examples" : [ "firstOne: \"string\"\nfirstTwo: 0\nsecondOne: \"string\"\nsecondTwo: true\n" ],
+    "examples" : [ "firstOne: string\nfirstTwo: 0\nsecondOne: string\nsecondTwo: true\n" ],
     "allOf" : [ {
       "$ref" : "#/components/schemas/io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$SchemaWithOneOf$ImplementationOne"
     }, {
@@ -10,7 +10,7 @@
   },
   "io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$SchemaWithOneOf$AnyOf" : {
     "type" : "string",
-    "examples" : [ "firstOne: \"string\"\nsecondOne: \"string\"\n" ],
+    "examples" : [ "firstOne: string\nsecondOne: string\n" ],
     "anyOf" : [ {
       "$ref" : "#/components/schemas/io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$SchemaWithOneOf$ImplementationOne"
     }, {
@@ -27,7 +27,7 @@
         "type" : "string"
       }
     },
-    "examples" : [ "firstOne: \"string\"\nsecondOne: \"string\"\n" ]
+    "examples" : [ "firstOne: string\nsecondOne: string\n" ]
   },
   "io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$SchemaWithOneOf$ImplementationTwo" : {
     "type" : "string",
@@ -44,7 +44,7 @@
   },
   "io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$SchemaWithOneOf$OneOf" : {
     "type" : "string",
-    "examples" : [ "\"firstOne: \\\"string\\\"\\nsecondOne: \\\"string\\\"\\n\"\n" ],
+    "examples" : [ "|\n  firstOne: string\n  secondOne: string\n" ],
     "oneOf" : [ {
       "$ref" : "#/components/schemas/io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$SchemaWithOneOf$ImplementationOne"
     }, {
@@ -67,6 +67,6 @@
         "$ref" : "#/components/schemas/io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$SchemaWithOneOf$OneOf"
       }
     },
-    "examples" : [ "allOf: \"firstOne: \\\"string\\\"\\nfirstTwo: 0\\nsecondOne: \\\"string\\\"\\nsecondTwo: true\\n\"\nanyOf: \"firstOne: \\\"string\\\"\\nsecondOne: \\\"string\\\"\\n\"\nfield: \"string\"\noneOf: \"\\\"firstOne: \\\\\\\"string\\\\\\\"\\\\nsecondOne: \\\\\\\"string\\\\\\\"\\\\n\\\"\\n\"\n" ]
+    "examples" : [ "allOf: |\n  firstOne: string\n  firstTwo: 0\n  secondOne: string\n  secondTwo: true\nanyOf: |\n  firstOne: string\n  secondOne: string\nfield: string\noneOf: |\n  |\n    firstOne: string\n    secondOne: string\n" ]
   }
 }

--- a/springwolf-core/src/test/resources/schemas/yaml/array-definitions-yaml.json
+++ b/springwolf-core/src/test/resources/schemas/yaml/array-definitions-yaml.json
@@ -9,7 +9,7 @@
         }
       }
     },
-    "examples" : [ "flist:\n- b: true\n  s: \"string\"\n" ]
+    "examples" : [ "flist:\n- b: true\n  s: string\n" ]
   },
   "io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$SimpleFoo" : {
     "type" : "string",
@@ -21,6 +21,6 @@
         "type" : "string"
       }
     },
-    "examples" : [ "b: true\ns: \"string\"\n" ]
+    "examples" : [ "b: true\ns: string\n" ]
   }
 }

--- a/springwolf-core/src/test/resources/schemas/yaml/complex-definitions-yaml.json
+++ b/springwolf-core/src/test/resources/schemas/yaml/complex-definitions-yaml.json
@@ -28,7 +28,7 @@
         "type" : "string"
       }
     },
-    "examples" : [ "b: true\nd: 1.1\ndt: \"2015-07-20T15:49:04-07:00\"\nf: 1.1\ni: 0\n\"n\":\n  nba: \"YmFzZTY0LWV4YW1wbGU=\"\n  nc:\n    cyclic: {}\n  nli:\n  - 0\n  nmfm:\n    key:\n      s: \"string\"\n  ns: \"string\"\n  nsm:\n  - s: \"string\"\n  nu: \"3fa85f64-5717-4562-b3fc-2c963f66afa6\"\ns: \"string\"\n" ]
+    "examples" : [ "b: true\nd: 1.1\ndt: 2015-07-20T15:49:04-07:00\nf: 1.1\ni: 0\n\"n\":\n  nba: YmFzZTY0LWV4YW1wbGU=\n  nc:\n    cyclic: {}\n  nli:\n  - 0\n  nmfm:\n    key:\n      s: string\n  ns: string\n  nsm:\n  - s: string\n  nu: 3fa85f64-5717-4562-b3fc-2c963f66afa6\ns: string\n" ]
   },
   "io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$ComplexFoo$Nested" : {
     "type" : "string",
@@ -68,7 +68,7 @@
         "format" : "uuid"
       }
     },
-    "examples" : [ "nba: \"YmFzZTY0LWV4YW1wbGU=\"\nnc:\n  cyclic: {}\nnli:\n- 0\nnmfm:\n  key:\n    s: \"string\"\nns: \"string\"\nnsm:\n- s: \"string\"\nnu: \"3fa85f64-5717-4562-b3fc-2c963f66afa6\"\n" ]
+    "examples" : [ "nba: YmFzZTY0LWV4YW1wbGU=\nnc:\n  cyclic: {}\nnli:\n- 0\nnmfm:\n  key:\n    s: string\nns: string\nnsm:\n- s: string\nnu: 3fa85f64-5717-4562-b3fc-2c963f66afa6\n" ]
   },
   "io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$ComplexFoo$Nested$Cyclic" : {
     "type" : "string",
@@ -86,6 +86,6 @@
         "type" : "string"
       }
     },
-    "examples" : [ "s: \"string\"\n" ]
+    "examples" : [ "s: string\n" ]
   }
 }

--- a/springwolf-core/src/test/resources/schemas/yaml/definitions-yaml.json
+++ b/springwolf-core/src/test/resources/schemas/yaml/definitions-yaml.json
@@ -9,7 +9,7 @@
         "type" : "string"
       }
     },
-    "examples" : [ "f:\n  b: true\n  s: \"string\"\ns: \"string\"\n" ]
+    "examples" : [ "f:\n  b: true\n  s: string\ns: string\n" ]
   },
   "io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$FooWithEnum" : {
     "type" : "string",
@@ -22,7 +22,7 @@
         "type" : "string"
       }
     },
-    "examples" : [ "b: \"BAR1\"\ns: \"string\"\n" ]
+    "examples" : [ "b: BAR1\ns: string\n" ]
   },
   "io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$SimpleFoo" : {
     "type" : "string",
@@ -34,6 +34,6 @@
         "type" : "string"
       }
     },
-    "examples" : [ "b: true\ns: \"string\"\n" ]
+    "examples" : [ "b: true\ns: string\n" ]
   }
 }

--- a/springwolf-core/src/test/resources/schemas/yaml/documented-definitions-yaml.json
+++ b/springwolf-core/src/test/resources/schemas/yaml/documented-definitions-yaml.json
@@ -53,7 +53,7 @@
       }
     },
     "description" : "foo model",
-    "examples" : [ "bi: 0\ndt: \"2000-01-01T02:00:00+02:00\"\nf:\n  b: true\n  s: \"string\"\nld: \"2024-04-24\"\nls_plain:\n- \"string\"\nmss:\n  key1: \"value1\"\nmss_plain:\n  key: \"string\"\ns: \"s value\"\n" ],
+    "examples" : [ "bi: 0\ndt: 2000-01-01T02:00:00+02:00\nf:\n  b: true\n  s: string\nld: 2024-04-24\nls_plain:\n- string\nmss:\n  key1: value1\nmss_plain:\n  key: string\ns: s value\n" ],
     "required" : [ "dt", "f", "s" ]
   },
   "io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$SimpleFoo" : {
@@ -66,6 +66,6 @@
         "type" : "string"
       }
     },
-    "examples" : [ "b: true\ns: \"string\"\n" ]
+    "examples" : [ "b: true\ns: string\n" ]
   }
 }

--- a/springwolf-core/src/test/resources/schemas/yaml/generics-wrapper-definitions-yaml.json
+++ b/springwolf-core/src/test/resources/schemas/yaml/generics-wrapper-definitions-yaml.json
@@ -6,6 +6,6 @@
         "type" : "boolean"
       }
     },
-    "examples" : [ "- \"string\"\n" ]
+    "examples" : [ "- string\n" ]
   }
 }

--- a/springwolf-core/src/test/resources/schemas/yaml/json-type-definitions-yaml.json
+++ b/springwolf-core/src/test/resources/schemas/yaml/json-type-definitions-yaml.json
@@ -2,7 +2,7 @@
   "io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$JsonTypeTest$JsonTypeInfoExampleOne" : {
     "type" : "string",
     "description" : "Json Type Info Example One model",
-    "examples" : [ "foo: \"fooValue\"\ntype: \"string\"\n" ],
+    "examples" : [ "foo: fooValue\ntype: string\n" ],
     "allOf" : [ {
       "$ref" : "#/components/schemas/io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$JsonTypeTest$JsonTypeInfoInterface"
     }, {
@@ -19,7 +19,7 @@
   "io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$JsonTypeTest$JsonTypeInfoExampleTwo" : {
     "type" : "string",
     "description" : "Json Type Info Example Two model",
-    "examples" : [ "boo: \"booValue\"\ntype: \"string\"\n" ],
+    "examples" : [ "boo: booValue\ntype: string\n" ],
     "allOf" : [ {
       "$ref" : "#/components/schemas/io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$JsonTypeTest$JsonTypeInfoInterface"
     }, {
@@ -41,7 +41,7 @@
         "type" : "string"
       }
     },
-    "examples" : [ "\"foo: \\\"fooValue\\\"\\ntype: \\\"string\\\"\\n\"\n" ],
+    "examples" : [ "|\n  foo: fooValue\n  type: string\n" ],
     "required" : [ "type" ],
     "oneOf" : [ {
       "$ref" : "#/components/schemas/io.github.springwolf.core.asyncapi.components.DefaultYamlComponentsServiceIntegrationTest$JsonTypeTest$JsonTypeInfoExampleOne"
@@ -57,6 +57,6 @@
       }
     },
     "description" : "Json Type Info Payload Dto model",
-    "examples" : [ "jsonTypeInfoInterface: \"\\\"foo: \\\\\\\"fooValue\\\\\\\"\\\\ntype: \\\\\\\"string\\\\\\\"\\\\n\\\"\\n\"\n" ]
+    "examples" : [ "jsonTypeInfoInterface: |\n  |\n    foo: fooValue\n    type: string\n" ]
   }
 }

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.json
@@ -1206,7 +1206,7 @@
           }
         },
         "examples": [
-          "someEnum: \"FOO1\"\nsomeLong: 0\nsomeString: \"string\"\n"
+          "someEnum: FOO1\nsomeLong: 0\nsomeString: string\n"
         ],
         "x-json-schema": {
           "$schema": "https://json-schema.org/draft-04/schema#",

--- a/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.yaml
+++ b/springwolf-examples/springwolf-kafka-example/src/test/resources/asyncapi.yaml
@@ -879,9 +879,9 @@ components:
           type: string
       examples:
         - |
-          someEnum: "FOO1"
+          someEnum: FOO1
           someLong: 0
-          someString: "string"
+          someString: string
       x-json-schema:
         $schema: https://json-schema.org/draft-04/schema#
         properties:


### PR DESCRIPTION
Since js `@asyncapi/parser@3.2.1`, the workaround for async api studio for date strings to need quotes is no longer needed