### PR TITLE
test: improve testcontainer test stability

### DIFF
--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/springwolf/examples/amqp/ApiSystemTest.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/springwolf/examples/amqp/ApiSystemTest.java
@@ -47,6 +47,7 @@ public class ApiSystemTest {
 
     @Container
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+            .withCopyFilesInContainer(".env") // do not copy all files in the directory
             .withExposedService(APP_NAME, APP_PORT)
             .waitingFor(APP_NAME, Wait.forLogMessage(".*AsyncAPI document was built.*", 1))
             .withEnv(ENV)

--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/springwolf/examples/amqp/ProducerSystemTest.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/springwolf/examples/amqp/ProducerSystemTest.java
@@ -57,6 +57,7 @@ public class ProducerSystemTest {
 
     @Container
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+            .withCopyFilesInContainer(".env") // do not copy all files in the directory
             .withServices(AMQP_NAME)
             .waitingFor(AMQP_NAME, Wait.forLogMessage(".*Server startup complete.*", 1))
             .withLogConsumer(AMQP_NAME, l -> log.debug("amqp: {}", l.getUtf8StringWithoutLineEnding()));

--- a/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/springwolf/examples/cloudstream/ApiSystemTest.java
+++ b/springwolf-examples/springwolf-cloud-stream-example/src/test/java/io/github/springwolf/examples/cloudstream/ApiSystemTest.java
@@ -47,6 +47,7 @@ public class ApiSystemTest {
 
     @Container
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+            .withCopyFilesInContainer(".env") // do not copy all files in the directory
             .withExposedService(APP_NAME, APP_PORT)
             .waitingFor(APP_NAME, Wait.forLogMessage(".*AsyncAPI document was built.*", 1))
             .withEnv(ENV)

--- a/springwolf-examples/springwolf-jms-example/src/test/java/io/github/springwolf/examples/jms/ApiSystemTest.java
+++ b/springwolf-examples/springwolf-jms-example/src/test/java/io/github/springwolf/examples/jms/ApiSystemTest.java
@@ -47,6 +47,7 @@ public class ApiSystemTest {
 
     @Container
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+            .withCopyFilesInContainer(".env") // do not copy all files in the directory
             .withExposedService(APP_NAME, APP_PORT)
             .waitingFor(APP_NAME, Wait.forLogMessage(".*AsyncAPI document was built.*", 1))
             .withEnv(ENV)

--- a/springwolf-examples/springwolf-jms-example/src/test/java/io/github/springwolf/examples/jms/ProducerSystemTest.java
+++ b/springwolf-examples/springwolf-jms-example/src/test/java/io/github/springwolf/examples/jms/ProducerSystemTest.java
@@ -48,6 +48,7 @@ public class ProducerSystemTest {
 
     @Container
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+            .withCopyFilesInContainer(".env") // do not copy all files in the directory
             .withServices(APP_JMS)
             .withLogConsumer(APP_JMS, l -> log.debug("jms: {}", l.getUtf8StringWithoutLineEnding()))
             .waitingFor(APP_JMS, Wait.forLogMessage(".*Artemis Console available.*", 1));

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/springwolf/examples/kafka/ApiSystemTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/springwolf/examples/kafka/ApiSystemTest.java
@@ -47,6 +47,7 @@ public class ApiSystemTest {
 
     @Container
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+            .withCopyFilesInContainer(".env") // do not copy all files in the directory
             .withExposedService(APP_NAME, APP_PORT)
             .waitingFor(APP_NAME, Wait.forLogMessage(".*AsyncAPI document was built.*", 1))
             .withEnv(ENV)

--- a/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/springwolf/examples/kafka/ProducerSystemTest.java
+++ b/springwolf-examples/springwolf-kafka-example/src/test/java/io/github/springwolf/examples/kafka/ProducerSystemTest.java
@@ -73,6 +73,7 @@ public class ProducerSystemTest {
 
     @Container
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+            .withCopyFilesInContainer(".env") // do not copy all files in the directory
             .withServices(KAFKA_NAME, USE_SCHEMA_REGISTRY ? "kafka-schema-registry" : "")
             .withLogConsumer(KAFKA_NAME, l -> log.debug("kafka: {}", l.getUtf8StringWithoutLineEnding()));
 

--- a/springwolf-examples/springwolf-sns-example/src/test/java/io/github/springwolf/examples/sns/ApiSystemTest.java
+++ b/springwolf-examples/springwolf-sns-example/src/test/java/io/github/springwolf/examples/sns/ApiSystemTest.java
@@ -47,6 +47,7 @@ public class ApiSystemTest {
 
     @Container
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+            .withCopyFilesInContainer(".env") // do not copy all files in the directory
             .withExposedService(APP_NAME, APP_PORT)
             .waitingFor(APP_NAME, Wait.forLogMessage(".*AsyncAPI document was built.*", 1))
             .withEnv(ENV)

--- a/springwolf-examples/springwolf-sqs-example/src/test/java/io/github/springwolf/examples/sqs/ApiSystemTest.java
+++ b/springwolf-examples/springwolf-sqs-example/src/test/java/io/github/springwolf/examples/sqs/ApiSystemTest.java
@@ -47,6 +47,7 @@ public class ApiSystemTest {
 
     @Container
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+            .withCopyFilesInContainer(".env") // do not copy all files in the directory
             .withExposedService(APP_NAME, APP_PORT)
             .waitingFor(APP_NAME, Wait.forLogMessage(".*AsyncAPI document was built.*", 1))
             .withEnv(ENV)

--- a/springwolf-examples/springwolf-sqs-example/src/test/java/io/github/springwolf/examples/sqs/ProducerSystemTest.java
+++ b/springwolf-examples/springwolf-sqs-example/src/test/java/io/github/springwolf/examples/sqs/ProducerSystemTest.java
@@ -61,6 +61,7 @@ public class ProducerSystemTest {
 
     @Container
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+            .withCopyFilesInContainer(".env") // do not copy all files in the directory
             .withEnv(ENV)
             .withServices(LOCALSTACK_NAME)
             .withLogConsumer(LOCALSTACK_NAME, l -> log.debug("localstack: {}", l.getUtf8StringWithoutLineEnding()))

--- a/springwolf-examples/springwolf-stomp-example/src/test/java/io/github/springwolf/examples/stomp/ApiSystemTest.java
+++ b/springwolf-examples/springwolf-stomp-example/src/test/java/io/github/springwolf/examples/stomp/ApiSystemTest.java
@@ -45,6 +45,7 @@ public class ApiSystemTest {
 
     @Container
     public static DockerComposeContainer<?> environment = new DockerComposeContainer<>(new File("docker-compose.yml"))
+            .withCopyFilesInContainer(".env") // do not copy all files in the directory
             .withExposedService(APP_NAME, APP_PORT)
             .waitingFor(APP_NAME, Wait.forLogMessage(".*AsyncAPI document was built.*", 1))
             .withEnv(ENV)


### PR DESCRIPTION
By default, a DockerComposeContainer copies the full gradle project directory into container. When running tests, the `build/test-results/test/binary/output.bin` file is written, which can get large. This file is not required for the tests and the test container default is overwritten to a single file (i.e. `.env`)

Original error messages:
org.testcontainers.containers.ContainerLaunchException: Container startup failed for image docker/compose com.github.dockerjava.api.exception.InternalServerErrorException: Status 500: {"message":"unexpected EOF"} java.io.IOException: Request to write '8192' bytes exceeds size in header of '2064381' bytes for entry