### PR TITLE
feat(amqp): differentiate between exchange and queue

### DIFF
--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/bindings/BindingFactory.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/bindings/BindingFactory.java
@@ -4,11 +4,16 @@ package io.github.springwolf.core.asyncapi.scanners.bindings;
 import io.github.springwolf.asyncapi.v3.bindings.ChannelBinding;
 import io.github.springwolf.asyncapi.v3.bindings.MessageBinding;
 import io.github.springwolf.asyncapi.v3.bindings.OperationBinding;
+import io.github.springwolf.asyncapi.v3.model.ReferenceUtil;
 import io.github.springwolf.asyncapi.v3.model.schema.SchemaObject;
 
 import java.util.Map;
 
 public interface BindingFactory<T> {
+    default String getChannelId(T annotation) {
+        return ReferenceUtil.toValidId(getChannelName(annotation));
+    }
+
     String getChannelName(T annotation);
 
     Map<String, ChannelBinding> buildChannelBinding(T annotation);

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/MessageHelper.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/MessageHelper.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.springwolf.core.asyncapi.scanners.common;
 
-import io.github.springwolf.asyncapi.v3.model.ReferenceUtil;
 import io.github.springwolf.asyncapi.v3.model.channel.message.MessageObject;
 import io.github.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import lombok.extern.slf4j.Slf4j;
@@ -28,14 +27,13 @@ public class MessageHelper {
         return toMessageReferences(messages, aggregator);
     }
 
-    public static Map<String, MessageReference> toOperationsMessagesMap(
-            String channelName, Set<MessageObject> messages) {
-        if (channelName == null || channelName.isBlank()) {
-            throw new IllegalArgumentException("channelName must not be empty");
+    public static Map<String, MessageReference> toOperationsMessagesMap(String channelId, Set<MessageObject> messages) {
+        if (channelId == null || channelId.isBlank()) {
+            throw new IllegalArgumentException("channelId must not be empty");
         }
 
-        Function<MessageObject, MessageReference> aggregator = (message) ->
-                MessageReference.toChannelMessage(ReferenceUtil.toValidId(channelName), message.getMessageId());
+        Function<MessageObject, MessageReference> aggregator =
+                (message) -> MessageReference.toChannelMessage(channelId, message.getMessageId());
         return toMessageReferences(messages, aggregator);
     }
 

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/message/SpringAnnotationMessagesService.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/message/SpringAnnotationMessagesService.java
@@ -49,8 +49,8 @@ public class SpringAnnotationMessagesService<ClassAnnotation extends Annotation>
                 .collect(toSet());
 
         if (messageType == MessageType.OPERATION) {
-            String channelName = bindingFactory.getChannelName(classAnnotation);
-            return toOperationsMessagesMap(channelName, messages);
+            String channelId = bindingFactory.getChannelName(classAnnotation);
+            return toOperationsMessagesMap(channelId, messages);
         }
         return toMessagesMap(messages);
     }

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/operation/SpringAnnotationOperationService.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/common/operation/SpringAnnotationOperationService.java
@@ -2,7 +2,6 @@
 package io.github.springwolf.core.asyncapi.scanners.common.operation;
 
 import io.github.springwolf.asyncapi.v3.bindings.OperationBinding;
-import io.github.springwolf.asyncapi.v3.model.ReferenceUtil;
 import io.github.springwolf.asyncapi.v3.model.channel.ChannelReference;
 import io.github.springwolf.asyncapi.v3.model.channel.message.MessageObject;
 import io.github.springwolf.asyncapi.v3.model.channel.message.MessageReference;
@@ -30,7 +29,7 @@ public class SpringAnnotationOperationService<MethodAnnotation extends Annotatio
         MessageObject message = springAnnotationMessageService.buildMessage(annotation, payloadType, headerSchema);
         Map<String, OperationBinding> operationBinding = bindingFactory.buildOperationBinding(annotation);
         Map<String, OperationBinding> opBinding = operationBinding != null ? new HashMap<>(operationBinding) : null;
-        String channelId = ReferenceUtil.toValidId(bindingFactory.getChannelName(annotation));
+        String channelId = bindingFactory.getChannelId(annotation);
 
         return Operation.builder()
                 .action(OperationAction.RECEIVE)

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationClassLevelOperationsScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationClassLevelOperationsScanner.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.springwolf.core.asyncapi.scanners.operations.annotations;
 
-import io.github.springwolf.asyncapi.v3.model.ReferenceUtil;
 import io.github.springwolf.asyncapi.v3.model.operation.Operation;
 import io.github.springwolf.asyncapi.v3.model.operation.OperationAction;
 import io.github.springwolf.core.asyncapi.scanners.bindings.BindingFactory;
@@ -44,8 +43,7 @@ public class SpringAnnotationClassLevelOperationsScanner<
             Class<?> component, Set<MethodAndAnnotation<MethodAnnotation>> annotatedMethods) {
         ClassAnnotation classAnnotation = AnnotationUtil.findFirstAnnotationOrThrow(classAnnotationClass, component);
 
-        String channelName = bindingFactory.getChannelName(classAnnotation);
-        String channelId = ReferenceUtil.toValidId(channelName);
+        String channelId = bindingFactory.getChannelId(classAnnotation);
         String operationId =
                 StringUtils.joinWith("_", channelId, OperationAction.RECEIVE.type, component.getSimpleName());
 

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationMethodLevelOperationsScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationMethodLevelOperationsScanner.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.springwolf.core.asyncapi.scanners.operations.annotations;
 
-import io.github.springwolf.asyncapi.v3.model.ReferenceUtil;
 import io.github.springwolf.asyncapi.v3.model.operation.Operation;
 import io.github.springwolf.asyncapi.v3.model.operation.OperationAction;
 import io.github.springwolf.asyncapi.v3.model.schema.SchemaObject;
@@ -44,8 +43,7 @@ public class SpringAnnotationMethodLevelOperationsScanner<MethodAnnotation exten
     private Map.Entry<String, Operation> mapMethodToOperation(MethodAndAnnotation<MethodAnnotation> method) {
         MethodAnnotation annotation = AnnotationUtil.findFirstAnnotationOrThrow(methodAnnotationClass, method.method());
 
-        String channelName = bindingFactory.getChannelName(annotation);
-        String channelId = ReferenceUtil.toValidId(channelName);
+        String channelId = bindingFactory.getChannelId(annotation);
         String operationId = StringUtils.joinWith(
                 "_", channelId, OperationAction.RECEIVE.type, method.method().getName());
 

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/common/operation/SpringAnnotationOperationServiceTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/common/operation/SpringAnnotationOperationServiceTest.java
@@ -40,7 +40,7 @@ class SpringAnnotationOperationServiceTest {
     @BeforeEach
     void setUp() {
         // when
-        when(bindingFactory.getChannelName(any())).thenReturn(CHANNEL_ID);
+        when(bindingFactory.getChannelId(any())).thenReturn(CHANNEL_ID);
         doReturn(defaultOperationBinding).when(bindingFactory).buildOperationBinding(any());
     }
 

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationClassLevelOperationsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationClassLevelOperationsScannerTest.java
@@ -35,14 +35,14 @@ class SpringAnnotationClassLevelOperationsScannerTest {
                     springAnnotationOperationsService,
                     List.of(operationCustomizer));
 
-    private static final String CHANNEL_NAME = "test-channel";
+    private static final String CHANNEL_NAME_ID = "test-channel";
 
     private static final Map<String, MessageBinding> defaultMessageBinding =
             Map.of("protocol", new AMQPMessageBinding());
 
     @BeforeEach
     void setUp() {
-        when(bindingFactory.getChannelName(any())).thenReturn(CHANNEL_NAME);
+        when(bindingFactory.getChannelId(any())).thenReturn(CHANNEL_NAME_ID);
     }
 
     @Test
@@ -56,7 +56,7 @@ class SpringAnnotationClassLevelOperationsScannerTest {
                 scanner.scan(ClassWithTestListenerAnnotation.class).toList();
 
         // then
-        String operationName = CHANNEL_NAME + "_receive_ClassWithTestListenerAnnotation";
+        String operationName = CHANNEL_NAME_ID + "_receive_ClassWithTestListenerAnnotation";
         assertThat(operations).containsExactly(Map.entry(operationName, operation));
     }
 

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationMethodLevelOperationsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationMethodLevelOperationsScannerTest.java
@@ -37,11 +37,11 @@ class SpringAnnotationMethodLevelOperationsScannerTest {
                     springAnnotationOperationService,
                     List.of(operationCustomizer));
 
-    private static final String CHANNEL_NAME = "test-channel";
+    private static final String CHANNEL_ID = "test-channel";
 
     @BeforeEach
     void setUp() {
-        when(bindingFactory.getChannelName(any())).thenReturn(CHANNEL_NAME);
+        when(bindingFactory.getChannelId(any())).thenReturn(CHANNEL_ID);
     }
 
     @Test
@@ -56,7 +56,7 @@ class SpringAnnotationMethodLevelOperationsScannerTest {
                 scanner.scan(ClassWithTestListenerAnnotation.class).toList();
 
         // then
-        String operationName = CHANNEL_NAME + "_receive_methodWithAnnotation";
+        String operationName = CHANNEL_ID + "_receive_methodWithAnnotation";
         assertThat(operations).containsExactly(Map.entry(operationName, operation));
     }
 

--- a/springwolf-examples/e2e/tests/publishing.spec.ts
+++ b/springwolf-examples/e2e/tests/publishing.spec.ts
@@ -72,8 +72,8 @@ function testPublishingEveryChannelItem() {
         messageTitle === "Message" || // Unable to instantiate ExamplePayloadProtobufDto$Message class
         messageTitle === "VehicleBase" || // Unable to publish abstract class for discriminator demo
         messageTitle.startsWith("GenericPayload") || // Unable to publish generic payload (amqp)
-        channelName === "#" || // Publishing through amqp exchange is not supported, see GH-366
-        channelName === "example-topic-routing-key" // Publishing through amqp exchange is not supported, see GH-366
+        channelName === "CRUD-topic-exchange-2" || // Publishing through amqp exchange is not supported, see GH-366
+        channelName === "example-topic-exchange_example-topic-routing-key" // Publishing through amqp exchange is not supported, see GH-366
       ) {
         return; // skip
       }

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/springwolf/examples/amqp/configuration/RabbitConfiguration.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/springwolf/examples/amqp/configuration/RabbitConfiguration.java
@@ -53,7 +53,7 @@ public class RabbitConfiguration {
      */
     @Bean
     public Queue exampleBindingsQueue() {
-        return new Queue(AmqpConstants.QUEUE_EXAMPLE_BINDINGS_QUEUE, false, true, true);
+        return new Queue(AmqpConstants.QUEUE_EXAMPLE_BINDINGS_QUEUE, false, false, true);
     }
 
     /**

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/springwolf/examples/amqp/configuration/RabbitConfiguration.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/springwolf/examples/amqp/configuration/RabbitConfiguration.java
@@ -2,6 +2,7 @@
 package io.github.springwolf.examples.amqp.configuration;
 
 import io.github.springwolf.examples.amqp.AmqpConstants;
+import io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Exchange;
@@ -33,11 +34,6 @@ public class RabbitConfiguration {
     }
 
     @Bean
-    public Queue exampleBindingsQueue() {
-        return new Queue(AmqpConstants.QUEUE_EXAMPLE_BINDINGS_QUEUE, false, false, true);
-    }
-
-    @Bean
     public Queue queueRead() {
         return new Queue(AmqpConstants.QUEUE_READ, false);
     }
@@ -52,6 +48,17 @@ public class RabbitConfiguration {
         return new Queue(AmqpConstants.QUEUE_MULTI_PAYLOAD_QUEUE);
     }
 
+    /**
+     * Defined by @RabbitListener annotation in {@link io.github.springwolf.examples.amqp.consumers.ExampleConsumer#bindingsExample(AnotherPayloadDto)}
+     */
+    @Bean
+    public Queue exampleBindingsQueue() {
+        return new Queue(AmqpConstants.QUEUE_EXAMPLE_BINDINGS_QUEUE, false, true, true);
+    }
+
+    /**
+     * Defined by @RabbitListener annotation in {@link io.github.springwolf.examples.amqp.consumers.ExampleConsumer#bindingsExample(AnotherPayloadDto)}
+     */
     @Bean
     public Binding exampleTopicBinding(Queue exampleBindingsQueue, Exchange exampleTopicExchange) {
         return BindingBuilder.bind(exampleBindingsQueue)

--- a/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/springwolf/examples/amqp/consumers/ExampleConsumer.java
+++ b/springwolf-examples/springwolf-amqp-example/src/main/java/io/github/springwolf/examples/amqp/consumers/ExampleConsumer.java
@@ -55,7 +55,7 @@ public class ExampleConsumer {
                                         autoDelete = "true"),
                         key = AmqpConstants.ROUTING_KEY_EXAMPLE_TOPIC_ROUTING_KEY)
             })
-    public void bindingsExample(AnotherPayloadDto payload) {
+    public void bindingsExample(ExamplePayloadDto payload) {
         log.info(
                 "Received new message in {}" + " through exchange {}" + " using routing key {}: {}",
                 AmqpConstants.QUEUE_EXAMPLE_BINDINGS_QUEUE,
@@ -112,7 +112,7 @@ public class ExampleConsumer {
         log.info(
                 "Received new message {} in {} (GenericPayloadDto<ExamplePayloadDto>): {}",
                 message,
-                AmqpConstants.QUEUE_UPDATE,
+                AmqpConstants.EXCHANGE_CRUD_TOPIC_EXCHANGE_1,
                 payload.toString());
     }
 
@@ -130,7 +130,7 @@ public class ExampleConsumer {
         log.info(
                 "Received new message {} in {} (ExamplePayloadDto): {}",
                 message,
-                AmqpConstants.QUEUE_UPDATE,
+                AmqpConstants.EXCHANGE_CRUD_TOPIC_EXCHANGE_2,
                 payload.toString());
     }
 }

--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/springwolf/examples/amqp/SpringContextIntegrationTest.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/springwolf/examples/amqp/SpringContextIntegrationTest.java
@@ -52,6 +52,7 @@ public class SpringContextIntegrationTest {
                             "example-bindings-queue",
                             "example-queue",
                             "example-topic-exchange",
+                            "example-topic-exchange_example-topic-routing-key",
                             "multi-payload-queue",
                             "queue-create",
                             "queue-delete",

--- a/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/springwolf/examples/amqp/SpringContextIntegrationTest.java
+++ b/springwolf-examples/springwolf-amqp-example/src/test/java/io/github/springwolf/examples/amqp/SpringContextIntegrationTest.java
@@ -46,12 +46,12 @@ public class SpringContextIntegrationTest {
         void testAllChannelsAreFound() {
             assertThat(asyncApiService.getAsyncAPI().getChannels().keySet())
                     .containsExactlyInAnyOrder(
-                            "#",
+                            "CRUD-topic-exchange-1",
+                            "CRUD-topic-exchange-2",
                             "another-queue",
                             "example-bindings-queue",
                             "example-queue",
                             "example-topic-exchange",
-                            "example-topic-routing-key",
                             "multi-payload-queue",
                             "queue-create",
                             "queue-delete",

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -96,7 +96,7 @@
           "queue": {
             "name": "example-bindings-queue",
             "durable": false,
-            "exclusive": true,
+            "exclusive": false,
             "autoDelete": true,
             "vhost": "/"
           },
@@ -130,6 +130,27 @@
       "messages": {
         "io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto": {
           "$ref": "#/components/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
+        }
+      }
+    },
+    "example-topic-exchange_example-topic-routing-key": {
+      "address": "example-topic-exchange_example-topic-routing-key",
+      "messages": {
+        "io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto": {
+          "$ref": "#/components/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
+        }
+      },
+      "bindings": {
+        "amqp": {
+          "is": "routingKey",
+          "exchange": {
+            "name": "example-topic-exchange",
+            "type": "topic",
+            "durable": true,
+            "autoDelete": false,
+            "vhost": "/"
+          },
+          "bindingVersion": "0.3.0"
         }
       }
     },
@@ -552,10 +573,10 @@
         }
       ]
     },
-    "example-topic-exchange_receive_bindingsExample": {
+    "example-topic-exchange_example-topic-routing-key_receive_bindingsExample": {
       "action": "receive",
       "channel": {
-        "$ref": "#/channels/example-topic-exchange"
+        "$ref": "#/channels/example-topic-exchange_example-topic-routing-key"
       },
       "bindings": {
         "amqp": {
@@ -565,7 +586,7 @@
       },
       "messages": [
         {
-          "$ref": "#/channels/example-topic-exchange/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
+          "$ref": "#/channels/example-topic-exchange_example-topic-routing-key/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
         }
       ]
     },

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.json
@@ -25,12 +25,9 @@
     }
   },
   "channels": {
-    "#": {
-      "address": "#",
+    "CRUD-topic-exchange-1": {
+      "address": "CRUD-topic-exchange-1",
       "messages": {
-        "io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto": {
-          "$ref": "#/components/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
-        },
         "io.github.springwolf.examples.amqp.dtos.GenericPayloadDtoIo.github.springwolf.examples.amqp.dtos.ExamplePayloadDto": {
           "$ref": "#/components/messages/io.github.springwolf.examples.amqp.dtos.GenericPayloadDtoIo.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
         }
@@ -40,6 +37,27 @@
           "is": "routingKey",
           "exchange": {
             "name": "CRUD-topic-exchange-1",
+            "type": "topic",
+            "durable": true,
+            "autoDelete": false,
+            "vhost": "/"
+          },
+          "bindingVersion": "0.3.0"
+        }
+      }
+    },
+    "CRUD-topic-exchange-2": {
+      "address": "CRUD-topic-exchange-2",
+      "messages": {
+        "io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto": {
+          "$ref": "#/components/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
+        }
+      },
+      "bindings": {
+        "amqp": {
+          "is": "routingKey",
+          "exchange": {
+            "name": "CRUD-topic-exchange-2",
             "type": "topic",
             "durable": true,
             "autoDelete": false,
@@ -78,7 +96,7 @@
           "queue": {
             "name": "example-bindings-queue",
             "durable": false,
-            "exclusive": false,
+            "exclusive": true,
             "autoDelete": true,
             "vhost": "/"
           },
@@ -112,27 +130,6 @@
       "messages": {
         "io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto": {
           "$ref": "#/components/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
-        }
-      }
-    },
-    "example-topic-routing-key": {
-      "address": "example-topic-routing-key",
-      "messages": {
-        "io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto": {
-          "$ref": "#/components/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
-        }
-      },
-      "bindings": {
-        "amqp": {
-          "is": "routingKey",
-          "exchange": {
-            "name": "example-topic-exchange",
-            "type": "topic",
-            "durable": true,
-            "autoDelete": false,
-            "vhost": "/"
-          },
-          "bindingVersion": "0.3.0"
         }
       }
     },
@@ -487,43 +484,37 @@
     }
   },
   "operations": {
-    "#_receive_bindingsRead": {
+    "CRUD-topic-exchange-1_receive_bindingsUpdate": {
       "action": "receive",
       "channel": {
-        "$ref": "#/channels/#"
+        "$ref": "#/channels/CRUD-topic-exchange-1"
       },
       "bindings": {
         "amqp": {
           "expiration": 0,
-          "cc": [
-            "#"
-          ],
           "bindingVersion": "0.3.0"
         }
       },
       "messages": [
         {
-          "$ref": "#/channels/#/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
+          "$ref": "#/channels/CRUD-topic-exchange-1/messages/io.github.springwolf.examples.amqp.dtos.GenericPayloadDtoIo.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
         }
       ]
     },
-    "#_receive_bindingsUpdate": {
+    "CRUD-topic-exchange-2_receive_bindingsRead": {
       "action": "receive",
       "channel": {
-        "$ref": "#/channels/#"
+        "$ref": "#/channels/CRUD-topic-exchange-2"
       },
       "bindings": {
         "amqp": {
           "expiration": 0,
-          "cc": [
-            "#"
-          ],
           "bindingVersion": "0.3.0"
         }
       },
       "messages": [
         {
-          "$ref": "#/channels/#/messages/io.github.springwolf.examples.amqp.dtos.GenericPayloadDtoIo.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
+          "$ref": "#/channels/CRUD-topic-exchange-2/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
         }
       ]
     },
@@ -535,9 +526,6 @@
       "bindings": {
         "amqp": {
           "expiration": 0,
-          "cc": [
-            "another-queue"
-          ],
           "bindingVersion": "0.3.0"
         }
       },
@@ -555,15 +543,29 @@
       "bindings": {
         "amqp": {
           "expiration": 0,
-          "cc": [
-            "example-queue"
-          ],
           "bindingVersion": "0.3.0"
         }
       },
       "messages": [
         {
           "$ref": "#/channels/example-queue/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
+        }
+      ]
+    },
+    "example-topic-exchange_receive_bindingsExample": {
+      "action": "receive",
+      "channel": {
+        "$ref": "#/channels/example-topic-exchange"
+      },
+      "bindings": {
+        "amqp": {
+          "expiration": 0,
+          "bindingVersion": "0.3.0"
+        }
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/example-topic-exchange/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
         }
       ]
     },
@@ -593,26 +595,6 @@
         }
       ]
     },
-    "example-topic-routing-key_receive_bindingsExample": {
-      "action": "receive",
-      "channel": {
-        "$ref": "#/channels/example-topic-routing-key"
-      },
-      "bindings": {
-        "amqp": {
-          "expiration": 0,
-          "cc": [
-            "example-topic-routing-key"
-          ],
-          "bindingVersion": "0.3.0"
-        }
-      },
-      "messages": [
-        {
-          "$ref": "#/channels/example-topic-routing-key/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
-        }
-      ]
-    },
     "multi-payload-queue_receive_bindingsBeanExample": {
       "action": "receive",
       "channel": {
@@ -621,9 +603,6 @@
       "bindings": {
         "amqp": {
           "expiration": 0,
-          "cc": [
-            "multi-payload-queue"
-          ],
           "bindingVersion": "0.3.0"
         }
       },
@@ -644,9 +623,6 @@
       "bindings": {
         "amqp": {
           "expiration": 0,
-          "cc": [
-            "queue-create"
-          ],
           "bindingVersion": "0.3.0"
         }
       },
@@ -664,9 +640,6 @@
       "bindings": {
         "amqp": {
           "expiration": 0,
-          "cc": [
-            "queue-delete"
-          ],
           "bindingVersion": "0.3.0"
         }
       },

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.yaml
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.yaml
@@ -72,7 +72,7 @@ channels:
         queue:
           name: example-bindings-queue
           durable: false
-          exclusive: true
+          exclusive: false
           autoDelete: true
           vhost: /
         bindingVersion: 0.3.0
@@ -96,6 +96,21 @@ channels:
     messages:
       io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto:
         $ref: "#/components/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
+  example-topic-exchange_example-topic-routing-key:
+    address: example-topic-exchange_example-topic-routing-key
+    messages:
+      io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto:
+        $ref: "#/components/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
+    bindings:
+      amqp:
+        is: routingKey
+        exchange:
+          name: example-topic-exchange
+          type: topic
+          durable: true
+          autoDelete: false
+          vhost: /
+        bindingVersion: 0.3.0
   multi-payload-queue:
     address: multi-payload-queue
     messages:
@@ -377,16 +392,16 @@ operations:
         bindingVersion: 0.3.0
     messages:
       - $ref: "#/channels/example-queue/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
-  example-topic-exchange_receive_bindingsExample:
+  example-topic-exchange_example-topic-routing-key_receive_bindingsExample:
     action: receive
     channel:
-      $ref: "#/channels/example-topic-exchange"
+      $ref: "#/channels/example-topic-exchange_example-topic-routing-key"
     bindings:
       amqp:
         expiration: 0
         bindingVersion: 0.3.0
     messages:
-      - $ref: "#/channels/example-topic-exchange/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
+      - $ref: "#/channels/example-topic-exchange_example-topic-routing-key/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
   example-topic-exchange_send_sendMessage:
     action: send
     channel:

--- a/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.yaml
+++ b/springwolf-examples/springwolf-amqp-example/src/test/resources/asyncapi.yaml
@@ -19,11 +19,9 @@ servers:
     host: amqp:5672
     protocol: amqp
 channels:
-  '#':
-    address: "#"
+  CRUD-topic-exchange-1:
+    address: CRUD-topic-exchange-1
     messages:
-      io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto:
-        $ref: "#/components/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
       io.github.springwolf.examples.amqp.dtos.GenericPayloadDtoIo.github.springwolf.examples.amqp.dtos.ExamplePayloadDto:
         $ref: "#/components/messages/io.github.springwolf.examples.amqp.dtos.GenericPayloadDtoIo.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
     bindings:
@@ -31,6 +29,21 @@ channels:
         is: routingKey
         exchange:
           name: CRUD-topic-exchange-1
+          type: topic
+          durable: true
+          autoDelete: false
+          vhost: /
+        bindingVersion: 0.3.0
+  CRUD-topic-exchange-2:
+    address: CRUD-topic-exchange-2
+    messages:
+      io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto:
+        $ref: "#/components/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
+    bindings:
+      amqp:
+        is: routingKey
+        exchange:
+          name: CRUD-topic-exchange-2
           type: topic
           durable: true
           autoDelete: false
@@ -59,7 +72,7 @@ channels:
         queue:
           name: example-bindings-queue
           durable: false
-          exclusive: false
+          exclusive: true
           autoDelete: true
           vhost: /
         bindingVersion: 0.3.0
@@ -83,21 +96,6 @@ channels:
     messages:
       io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto:
         $ref: "#/components/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
-  example-topic-routing-key:
-    address: example-topic-routing-key
-    messages:
-      io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto:
-        $ref: "#/components/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
-    bindings:
-      amqp:
-        is: routingKey
-        exchange:
-          name: example-topic-exchange
-          type: topic
-          durable: true
-          autoDelete: false
-          vhost: /
-        bindingVersion: 0.3.0
   multi-payload-queue:
     address: multi-payload-queue
     messages:
@@ -339,30 +337,26 @@ components:
         amqp:
           bindingVersion: 0.3.0
 operations:
-  '#_receive_bindingsRead':
+  CRUD-topic-exchange-1_receive_bindingsUpdate:
     action: receive
     channel:
-      $ref: "#/channels/#"
+      $ref: "#/channels/CRUD-topic-exchange-1"
     bindings:
       amqp:
         expiration: 0
-        cc:
-          - "#"
         bindingVersion: 0.3.0
     messages:
-      - $ref: "#/channels/#/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
-  '#_receive_bindingsUpdate':
+      - $ref: "#/channels/CRUD-topic-exchange-1/messages/io.github.springwolf.examples.amqp.dtos.GenericPayloadDtoIo.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
+  CRUD-topic-exchange-2_receive_bindingsRead:
     action: receive
     channel:
-      $ref: "#/channels/#"
+      $ref: "#/channels/CRUD-topic-exchange-2"
     bindings:
       amqp:
         expiration: 0
-        cc:
-          - "#"
         bindingVersion: 0.3.0
     messages:
-      - $ref: "#/channels/#/messages/io.github.springwolf.examples.amqp.dtos.GenericPayloadDtoIo.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
+      - $ref: "#/channels/CRUD-topic-exchange-2/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
   another-queue_receive_receiveAnotherPayload:
     action: receive
     channel:
@@ -370,8 +364,6 @@ operations:
     bindings:
       amqp:
         expiration: 0
-        cc:
-          - another-queue
         bindingVersion: 0.3.0
     messages:
       - $ref: "#/channels/another-queue/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
@@ -382,11 +374,19 @@ operations:
     bindings:
       amqp:
         expiration: 0
-        cc:
-          - example-queue
         bindingVersion: 0.3.0
     messages:
       - $ref: "#/channels/example-queue/messages/io.github.springwolf.examples.amqp.dtos.ExamplePayloadDto"
+  example-topic-exchange_receive_bindingsExample:
+    action: receive
+    channel:
+      $ref: "#/channels/example-topic-exchange"
+    bindings:
+      amqp:
+        expiration: 0
+        bindingVersion: 0.3.0
+    messages:
+      - $ref: "#/channels/example-topic-exchange/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
   example-topic-exchange_send_sendMessage:
     action: send
     channel:
@@ -406,18 +406,6 @@ operations:
         bindingVersion: 0.3.0
     messages:
       - $ref: "#/channels/example-topic-exchange/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
-  example-topic-routing-key_receive_bindingsExample:
-    action: receive
-    channel:
-      $ref: "#/channels/example-topic-routing-key"
-    bindings:
-      amqp:
-        expiration: 0
-        cc:
-          - example-topic-routing-key
-        bindingVersion: 0.3.0
-    messages:
-      - $ref: "#/channels/example-topic-routing-key/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
   multi-payload-queue_receive_bindingsBeanExample:
     action: receive
     channel:
@@ -425,8 +413,6 @@ operations:
     bindings:
       amqp:
         expiration: 0
-        cc:
-          - multi-payload-queue
         bindingVersion: 0.3.0
     messages:
       - $ref: "#/channels/multi-payload-queue/messages/io.github.springwolf.examples.amqp.dtos.AnotherPayloadDto"
@@ -438,8 +424,6 @@ operations:
     bindings:
       amqp:
         expiration: 0
-        cc:
-          - queue-create
         bindingVersion: 0.3.0
     messages:
       - $ref: "#/channels/queue-create/messages/io.github.springwolf.examples.amqp.dtos.GenericPayloadDtoJava.lang.String"
@@ -450,8 +434,6 @@ operations:
     bindings:
       amqp:
         expiration: 0
-        cc:
-          - queue-delete
         bindingVersion: 0.3.0
     messages:
       - $ref: "#/channels/queue-delete/messages/io.github.springwolf.examples.amqp.dtos.GenericPayloadDtoJava.lang.Long"

--- a/springwolf-plugins/springwolf-amqp-plugin/build.gradle
+++ b/springwolf-plugins/springwolf-amqp-plugin/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation("org.junit.jupiter:junit-jupiter-params")
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter'
 }
 

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/AmqpBindingFactory.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/AmqpBindingFactory.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 public class AmqpBindingFactory implements BindingFactory<RabbitListener> {
-    private final RabbitListenerUtil.RabbitListenerUtilContext context;
+    private final RabbitListenerUtilContext context;
     private final StringValueResolver stringValueResolver;
 
     public AmqpBindingFactory(
@@ -24,13 +24,18 @@ public class AmqpBindingFactory implements BindingFactory<RabbitListener> {
             List<Exchange> exchanges,
             List<Binding> bindings,
             StringValueResolver stringValueResolver) {
-        this.context = RabbitListenerUtil.RabbitListenerUtilContext.create(queues, exchanges, bindings);
+        this.context = RabbitListenerUtilContext.create(queues, exchanges, bindings);
         this.stringValueResolver = stringValueResolver;
     }
 
     @Override
     public String getChannelName(RabbitListener annotation) {
         return RabbitListenerUtil.getChannelName(annotation, stringValueResolver);
+    }
+
+    @Override
+    public String getChannelId(RabbitListener annotation) {
+        return RabbitListenerUtil.getChannelId(annotation, stringValueResolver);
     }
 
     @Override

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/RabbitListenerUtil.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/RabbitListenerUtil.java
@@ -34,8 +34,8 @@ import java.util.stream.Stream;
  * Note: bindings, queues, and queuesToDeclare are mutually exclusive
  * <ul>
  * <li> queues (string) point to queue beans (default exchange + routing key)
- * <li> queuesToDeclare (object) will create queues on broker & matching beans (default exchange + routing key)
- * <li> queueBinding (object) will create queue and exchange on broker & matching beans (exchange must match if present)
+ * <li> queuesToDeclare (object) will create queues on broker and matching beans (default exchange + routing key)
+ * <li> queueBinding (object) will create queue and exchange on broker and matching beans (exchange must match if present)
  * </ul>
  * <br/>
  * How does rabbitmq work?

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/RabbitListenerUtilContext.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/RabbitListenerUtilContext.java
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.springwolf.plugins.amqp.asyncapi.scanners.bindings;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.core.Queue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public record RabbitListenerUtilContext(
+        Map<String, Queue> queueMap, Map<String, Exchange> exchangeMap, Map<String, Binding> bindingMap) {
+
+    public static RabbitListenerUtilContext create(
+            List<Queue> queues, List<Exchange> exchanges, List<Binding> bindings) {
+        Map<String, Queue> queueMap =
+                queues.stream().collect(Collectors.toMap(Queue::getName, Function.identity(), (e1, e2) -> e1));
+        Map<String, Exchange> exchangeMap =
+                exchanges.stream().collect(Collectors.toMap(Exchange::getName, Function.identity(), (e1, e2) -> e1));
+        Map<String, Binding> bindingMap = bindings.stream()
+                .filter(Binding::isDestinationQueue)
+                .collect(Collectors.toMap(Binding::getDestination, Function.identity(), (e1, e2) -> e1));
+        return new RabbitListenerUtilContext(queueMap, exchangeMap, bindingMap);
+    }
+}

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/channels/RabbitQueueBeanScanner.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/channels/RabbitQueueBeanScanner.java
@@ -1,30 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.springwolf.plugins.amqp.asyncapi.scanners.channels;
 
-import io.github.springwolf.asyncapi.v3.bindings.amqp.AMQPChannelBinding;
 import io.github.springwolf.asyncapi.v3.model.channel.ChannelObject;
 import io.github.springwolf.core.asyncapi.scanners.ChannelsScanner;
 import io.github.springwolf.plugins.amqp.asyncapi.scanners.bindings.RabbitListenerUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Queue;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @RequiredArgsConstructor
 public class RabbitQueueBeanScanner implements ChannelsScanner {
     private final List<Queue> queues;
+    private final List<Binding> bindings;
 
     @Override
     public Map<String, ChannelObject> scan() {
-        return queues.stream()
-                .map(RabbitListenerUtil::buildChannelObject)
-                .collect(Collectors.toMap(
-                        o -> ((AMQPChannelBinding) o.getBindings().get(RabbitListenerUtil.BINDING_NAME))
-                                .getQueue()
-                                .getName(),
-                        c -> c,
-                        (a, b) -> a));
+        return Stream.concat(
+                        queues.stream().map(RabbitListenerUtil::buildChannelObject),
+                        bindings.stream()
+                                .map(RabbitListenerUtil::buildChannelObject)
+                                .flatMap(List::stream))
+                .collect(Collectors.toMap(ChannelObject::getChannelId, c -> c, (a, b) -> a));
     }
 }

--- a/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/configuration/SpringwolfAmqpScannerConfiguration.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/main/java/io/github/springwolf/plugins/amqp/configuration/SpringwolfAmqpScannerConfiguration.java
@@ -193,7 +193,7 @@ public class SpringwolfAmqpScannerConfiguration {
             havingValue = "true",
             matchIfMissing = true)
     @Order(value = ChannelPriority.AUTO_DISCOVERED)
-    public RabbitQueueBeanScanner rabbitQueueBeanScanner(List<Queue> queues) {
-        return new RabbitQueueBeanScanner(queues);
+    public RabbitQueueBeanScanner rabbitQueueBeanScanner(List<Queue> queues, List<Binding> bindings) {
+        return new RabbitQueueBeanScanner(queues, bindings);
     }
 }

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/RabbitListenerUtilContextTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/RabbitListenerUtilContextTest.java
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.springwolf.plugins.amqp.asyncapi.scanners.bindings;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.TopicExchange;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Nested
+class RabbitListenerUtilContextTest {
+    @Test
+    void testEmptyContext() {
+        // when
+        RabbitListenerUtilContext context = RabbitListenerUtilContext.create(List.of(), List.of(), List.of());
+
+        // then
+        assertEquals(Map.of(), context.queueMap());
+        assertEquals(Map.of(), context.exchangeMap());
+        assertEquals(Map.of(), context.bindingMap());
+    }
+
+    @Test
+    void testWithSingleTopic() {
+        org.springframework.amqp.core.Queue queue =
+                new org.springframework.amqp.core.Queue("queue-1", false, true, true);
+        TopicExchange exchange = new TopicExchange("exchange-name", false, true);
+        Binding binding = BindingBuilder.bind(queue).to(exchange).with("routing-key");
+
+        // when
+        RabbitListenerUtilContext context =
+                RabbitListenerUtilContext.create(List.of(queue), List.of(exchange), List.of(binding));
+
+        // then
+        assertEquals(Map.of("queue-1", queue), context.queueMap());
+        assertEquals(Map.of("exchange-name", exchange), context.exchangeMap());
+        assertEquals(Map.of("queue-1", binding), context.bindingMap());
+    }
+
+    @Test
+    void testWithMultipleBeansForOneTopic() {
+        org.springframework.amqp.core.Queue queueBean =
+                new org.springframework.amqp.core.Queue("queue-1", false, true, true);
+        TopicExchange exchangeBean = new TopicExchange("exchange-name", false, true);
+        Binding bindingBean = BindingBuilder.bind(queueBean).to(exchangeBean).with("routing-key");
+
+        // In this test, annotation values are different compared to the beans.
+        // This might happen due to ill user configuration, but like Spring AMQP Springwolf tries to handle it
+        org.springframework.amqp.core.Queue queueAnnotation =
+                new org.springframework.amqp.core.Queue("queue-1", false, false, false);
+        TopicExchange exchangeAnnotation = new TopicExchange("exchange-name", true, false);
+        Binding bindingAnnotation =
+                BindingBuilder.bind(queueAnnotation).to(exchangeAnnotation).with("routing-key");
+
+        // when
+        RabbitListenerUtilContext context = RabbitListenerUtilContext.create(
+                List.of(queueBean, queueAnnotation),
+                List.of(exchangeBean, exchangeAnnotation),
+                List.of(bindingBean, bindingAnnotation));
+
+        // then
+        assertThat(context.queueMap()).hasSize(1);
+        assertThat(context.queueMap().get("queue-1")).isIn(queueBean, queueAnnotation);
+        assertThat(context.exchangeMap()).hasSize(1);
+        assertThat(context.exchangeMap().get("exchange-name")).isIn(exchangeBean, exchangeAnnotation);
+        assertThat(context.bindingMap()).hasSize(1);
+        assertThat(context.bindingMap().get("queue-1")).isIn(bindingBean, bindingAnnotation);
+    }
+}

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/RabbitListenerUtilTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/bindings/RabbitListenerUtilTest.java
@@ -56,6 +56,7 @@ class RabbitListenerUtilTest {
                         case "${queue-1}-id" -> "queue-1-id";
                         case "${routing-key}" -> "routing-key";
                         case "${exchange-name}" -> "exchange-name";
+                        case "${exchange-name}_${routing-key}" -> "exchange-name_routing-key";
                         default -> arg;
                     };
                 })
@@ -491,7 +492,7 @@ class RabbitListenerUtilTest {
             String channelName = RabbitListenerUtil.getChannelId(annotation, stringValueResolver);
 
             // then
-            assertEquals("exchange-name", channelName);
+            assertEquals("exchange-name_routing-key", channelName);
         }
 
         @Test
@@ -503,7 +504,7 @@ class RabbitListenerUtilTest {
             String channelName = RabbitListenerUtil.getChannelName(annotation, stringValueResolver);
 
             // then
-            assertEquals("exchange-name", channelName);
+            assertEquals("exchange-name_routing-key", channelName);
         }
 
         @Test

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/channels/RabbitQueueBeanScannerTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/channels/RabbitQueueBeanScannerTest.java
@@ -2,10 +2,12 @@
 package io.github.springwolf.plugins.amqp.asyncapi.scanners.channels;
 
 import io.github.springwolf.asyncapi.v3.bindings.amqp.AMQPChannelBinding;
+import io.github.springwolf.asyncapi.v3.bindings.amqp.AMQPChannelExchangeProperties;
 import io.github.springwolf.asyncapi.v3.bindings.amqp.AMQPChannelQueueProperties;
 import io.github.springwolf.asyncapi.v3.bindings.amqp.AMQPChannelType;
 import io.github.springwolf.asyncapi.v3.model.channel.ChannelObject;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Queue;
 
 import java.util.List;
@@ -19,7 +21,8 @@ class RabbitQueueBeanScannerTest {
     void scan() {
         // given
         var queue = new Queue("name");
-        var scanner = new RabbitQueueBeanScanner(List.of(queue));
+        var binding = new Binding("destination", Binding.DestinationType.QUEUE, "exchange", "routingKey", null);
+        var scanner = new RabbitQueueBeanScanner(List.of(queue), List.of(binding));
 
         // when
         var result = scanner.scan();
@@ -40,6 +43,32 @@ class RabbitQueueBeanScannerTest {
                                                         .autoDelete(false)
                                                         .durable(true)
                                                         .exclusive(false)
+                                                        .build())
+                                                .build()))
+                                .build(),
+                        "exchange",
+                        ChannelObject.builder()
+                                .channelId("exchange")
+                                .address("routingKey")
+                                .bindings(Map.of(
+                                        "amqp",
+                                        AMQPChannelBinding.builder()
+                                                .is(AMQPChannelType.ROUTING_KEY)
+                                                .exchange(AMQPChannelExchangeProperties.builder()
+                                                        .name("exchange")
+                                                        .build())
+                                                .build()))
+                                .build(),
+                        "destination",
+                        ChannelObject.builder()
+                                .channelId("destination")
+                                .address("destination")
+                                .bindings(Map.of(
+                                        "amqp",
+                                        AMQPChannelBinding.builder()
+                                                .is(AMQPChannelType.QUEUE)
+                                                .queue(AMQPChannelQueueProperties.builder()
+                                                        .name("destination")
                                                         .build())
                                                 .build()))
                                 .build()));

--- a/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/channels/RabbitQueueBeanScannerTest.java
+++ b/springwolf-plugins/springwolf-amqp-plugin/src/test/java/io/github/springwolf/plugins/amqp/asyncapi/scanners/channels/RabbitQueueBeanScannerTest.java
@@ -46,9 +46,9 @@ class RabbitQueueBeanScannerTest {
                                                         .build())
                                                 .build()))
                                 .build(),
-                        "exchange",
+                        "exchange_routingKey",
                         ChannelObject.builder()
-                                .channelId("exchange")
+                                .channelId("exchange_routingKey")
                                 .address("routingKey")
                                 .bindings(Map.of(
                                         "amqp",

--- a/springwolf-plugins/springwolf-stomp-plugin/src/main/java/io/github/springwolf/plugins/stomp/asyncapi/scanners/operation/annotations/SendToCustomizer.java
+++ b/springwolf-plugins/springwolf-stomp-plugin/src/main/java/io/github/springwolf/plugins/stomp/asyncapi/scanners/operation/annotations/SendToCustomizer.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.springwolf.plugins.stomp.asyncapi.scanners.operation.annotations;
 
-import io.github.springwolf.asyncapi.v3.model.ReferenceUtil;
 import io.github.springwolf.asyncapi.v3.model.channel.ChannelReference;
 import io.github.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import io.github.springwolf.asyncapi.v3.model.operation.Operation;
@@ -25,7 +24,7 @@ public class SendToCustomizer implements OperationCustomizer {
     public void customize(Operation operation, Method method) {
         SendTo annotation = AnnotationUtil.findFirstAnnotation(SendTo.class, method);
         if (annotation != null) {
-            String channelId = ReferenceUtil.toValidId(bindingFactory.getChannelName(annotation));
+            String channelId = bindingFactory.getChannelId(annotation);
             String payloadName = payloadService.extractSchema(method).name();
 
             operation.setReply(OperationReply.builder()

--- a/springwolf-plugins/springwolf-stomp-plugin/src/main/java/io/github/springwolf/plugins/stomp/asyncapi/scanners/operation/annotations/SendToUserCustomizer.java
+++ b/springwolf-plugins/springwolf-stomp-plugin/src/main/java/io/github/springwolf/plugins/stomp/asyncapi/scanners/operation/annotations/SendToUserCustomizer.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package io.github.springwolf.plugins.stomp.asyncapi.scanners.operation.annotations;
 
-import io.github.springwolf.asyncapi.v3.model.ReferenceUtil;
 import io.github.springwolf.asyncapi.v3.model.channel.ChannelReference;
 import io.github.springwolf.asyncapi.v3.model.channel.message.MessageReference;
 import io.github.springwolf.asyncapi.v3.model.operation.Operation;
@@ -25,7 +24,7 @@ public class SendToUserCustomizer implements OperationCustomizer {
     public void customize(Operation operation, Method method) {
         SendToUser annotation = AnnotationUtil.findFirstAnnotation(SendToUser.class, method);
         if (annotation != null) {
-            String channelId = ReferenceUtil.toValidId(bindingFactory.getChannelName(annotation));
+            String channelId = bindingFactory.getChannelId(annotation);
             String payloadName = payloadService.extractSchema(method).name();
 
             operation.setReply(OperationReply.builder()

--- a/springwolf-plugins/springwolf-stomp-plugin/src/test/java/io/github/springwolf/plugins/stomp/asyncapi/scanners/operation/annotations/SendToCustomizerTest.java
+++ b/springwolf-plugins/springwolf-stomp-plugin/src/test/java/io/github/springwolf/plugins/stomp/asyncapi/scanners/operation/annotations/SendToCustomizerTest.java
@@ -31,6 +31,7 @@ class SendToCustomizerTest {
     void customize() throws NoSuchMethodException {
         // given
         Operation operation = new Operation();
+        when(bindingFactory.getChannelId(any())).thenReturn(CHANNEL_ID);
         when(bindingFactory.getChannelName(any())).thenReturn(CHANNEL_ID);
         when(payloadService.extractSchema(any())).thenReturn(new PayloadSchemaObject(MESSAGE_ID, MESSAGE_ID, null));
 

--- a/springwolf-plugins/springwolf-stomp-plugin/src/test/java/io/github/springwolf/plugins/stomp/asyncapi/scanners/operation/annotations/SendToUserCustomizerTest.java
+++ b/springwolf-plugins/springwolf-stomp-plugin/src/test/java/io/github/springwolf/plugins/stomp/asyncapi/scanners/operation/annotations/SendToUserCustomizerTest.java
@@ -31,6 +31,7 @@ class SendToUserCustomizerTest {
     void customize() throws NoSuchMethodException {
         // given
         Operation operation = new Operation();
+        when(bindingFactory.getChannelId(any())).thenReturn(CHANNEL_ID);
         when(bindingFactory.getChannelName(any())).thenReturn(CHANNEL_ID);
         when(payloadService.extractSchema(any())).thenReturn(new PayloadSchemaObject(MESSAGE_ID, MESSAGE_ID, null));
 


### PR DESCRIPTION
Extracted from https://github.com/springwolf/springwolf-core/pull/886

This is missing the link between exchanges to the target queues, as requested in the amqp binding spec