### PR TITLE
refactor(core): simplify OperationsInClassScanner interface

### DIFF
--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/operations/DefaultOperationsService.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/operations/DefaultOperationsService.java
@@ -27,12 +27,12 @@ public class DefaultOperationsService implements OperationsService {
      */
     @Override
     public Map<String, Operation> findOperations() {
-        List<Map.Entry<String, Operation>> foundOperations = new ArrayList<>();
+        List<Operation> foundOperations = new ArrayList<>();
 
         for (OperationsScanner scanner : operationScanners) {
             try {
                 Map<String, Operation> channels = scanner.scan();
-                foundOperations.addAll(channels.entrySet());
+                foundOperations.addAll(channels.values());
             } catch (Exception e) {
                 log.error("An error was encountered during operation scanning with {}: {}", scanner, e.getMessage(), e);
             }

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationMerger.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationMerger.java
@@ -25,18 +25,18 @@ public class OperationMerger {
      * If an operation is null, the next non-null operation is used
      * Messages within operations are merged
      *
-     * @param operationEntries Ordered pairs of operation name to Operation
+     * @param operations Ordered pairs of operation name to Operation
      * @return A map of operationId to a single Operation
      */
-    public static Map<String, Operation> mergeOperations(List<Map.Entry<String, Operation>> operationEntries) {
+    public static Map<String, Operation> mergeOperations(List<Operation> operations) {
         Map<String, Operation> mergedOperations = new HashMap<>();
 
-        for (Map.Entry<String, Operation> entry : operationEntries) {
-            if (!mergedOperations.containsKey(entry.getKey())) {
-                mergedOperations.put(entry.getKey(), entry.getValue());
+        for (Operation operation : operations) {
+            if (!mergedOperations.containsKey(operation.getOperationId())) {
+                mergedOperations.put(operation.getOperationId(), operation);
             } else {
-                Operation operation = mergeOperation(mergedOperations.get(entry.getKey()), entry.getValue());
-                mergedOperations.put(entry.getKey(), operation);
+                Operation mergedOperation = mergeOperation(mergedOperations.get(operation.getOperationId()), operation);
+                mergedOperations.put(operation.getOperationId(), mergedOperation);
             }
         }
 

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationsInClassScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationsInClassScanner.java
@@ -3,9 +3,8 @@ package io.github.springwolf.core.asyncapi.scanners.operations;
 
 import io.github.springwolf.asyncapi.v3.model.operation.Operation;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 public interface OperationsInClassScanner {
-    Stream<Map.Entry<String, Operation>> scan(Class<?> clazz);
+    Stream<Operation> scan(Class<?> clazz);
 }

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationsInClassScannerAdapter.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationsInClassScannerAdapter.java
@@ -21,12 +21,12 @@ public class OperationsInClassScannerAdapter implements OperationsScanner {
     public Map<String, Operation> scan() {
         Set<Class<?>> components = classScanner.scan();
 
-        List<Map.Entry<String, Operation>> operations = mapToOperations(components);
+        List<Operation> operations = mapToOperations(components);
 
         return OperationMerger.mergeOperations(operations);
     }
 
-    private List<Map.Entry<String, Operation>> mapToOperations(Set<Class<?>> components) {
+    private List<Operation> mapToOperations(Set<Class<?>> components) {
         return components.stream().flatMap(classProcessor::scan).toList();
     }
 }

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/AsyncAnnotationClassLevelOperationsScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/AsyncAnnotationClassLevelOperationsScanner.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -32,7 +31,7 @@ public class AsyncAnnotationClassLevelOperationsScanner<ClassAnnotation extends 
     private final List<OperationCustomizer> customizers;
 
     @Override
-    public Stream<Map.Entry<String, Operation>> scan(Class<?> clazz) {
+    public Stream<Operation> scan(Class<?> clazz) {
         Set<MethodAndAnnotation<ClassAnnotation>> methodAndAnnotation = AnnotationScannerUtil.findAnnotatedMethods(
                         clazz, classAnnotationClass, AllMethods.class, (cl, m) -> {
                             ClassAnnotation classAnnotation =
@@ -48,7 +47,7 @@ public class AsyncAnnotationClassLevelOperationsScanner<ClassAnnotation extends 
         return mapClassToOperation(clazz, methodAndAnnotation);
     }
 
-    private Stream<Map.Entry<String, Operation>> mapClassToOperation(
+    private Stream<Operation> mapClassToOperation(
             Class<?> component, Set<MethodAndAnnotation<ClassAnnotation>> annotatedMethods) {
         ClassAnnotation classAnnotation = AnnotationUtil.findFirstAnnotationOrThrow(classAnnotationClass, component);
         AsyncOperation asyncOperation = asyncAnnotationProvider.getAsyncOperation(classAnnotation);
@@ -58,6 +57,6 @@ public class AsyncAnnotationClassLevelOperationsScanner<ClassAnnotation extends 
         Operation operation = asyncAnnotationOperationsService.buildOperation(asyncOperation, methods);
         annotatedMethods.forEach(
                 method -> customizers.forEach(customizer -> customizer.customize(operation, method.method())));
-        return Stream.of(Map.entry(operation.getOperationId(), operation));
+        return Stream.of(operation);
     }
 }

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/AsyncAnnotationMethodLevelOperationsScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/AsyncAnnotationMethodLevelOperationsScanner.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -27,19 +26,18 @@ public class AsyncAnnotationMethodLevelOperationsScanner<MethodAnnotation extend
     private final List<OperationCustomizer> customizers;
 
     @Override
-    public Stream<Map.Entry<String, Operation>> scan(Class<?> clazz) {
+    public Stream<Operation> scan(Class<?> clazz) {
         return AnnotationScannerUtil.findAnnotatedMethods(clazz, this.asyncAnnotationProvider.getAnnotation())
                 .map(this::mapMethodToOperation);
     }
 
-    private Map.Entry<String, Operation> mapMethodToOperation(
-            MethodAndAnnotation<MethodAnnotation> methodAndAnnotation) {
+    private Operation mapMethodToOperation(MethodAndAnnotation<MethodAnnotation> methodAndAnnotation) {
         AsyncOperation operationAnnotation =
                 this.asyncAnnotationProvider.getAsyncOperation(methodAndAnnotation.annotation());
 
         Operation operation = asyncAnnotationOperationService.buildOperation(
                 operationAnnotation, Set.of(methodAndAnnotation.method()));
         customizers.forEach(customizer -> customizer.customize(operation, methodAndAnnotation.method()));
-        return Map.entry(operation.getOperationId(), operation);
+        return operation;
     }
 }

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationClassLevelOperationsScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationClassLevelOperationsScanner.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -30,12 +29,12 @@ public class SpringAnnotationClassLevelOperationsScanner<
     private final List<OperationCustomizer> customizers;
 
     @Override
-    public Stream<Map.Entry<String, Operation>> scan(Class<?> clazz) {
+    public Stream<Operation> scan(Class<?> clazz) {
         return AnnotationScannerUtil.findAnnotatedMethods(
                 clazz, classAnnotationClass, methodAnnotationClass, this::mapClassToOperation);
     }
 
-    private Stream<Map.Entry<String, Operation>> mapClassToOperation(
+    private Stream<Operation> mapClassToOperation(
             Class<?> component, Set<MethodAndAnnotation<MethodAnnotation>> annotatedMethods) {
         ClassAnnotation classAnnotation = AnnotationUtil.findFirstAnnotationOrThrow(classAnnotationClass, component);
 
@@ -44,6 +43,6 @@ public class SpringAnnotationClassLevelOperationsScanner<
         Operation operation = springAnnotationOperationsService.buildOperation(classAnnotation, component, methods);
         annotatedMethods.forEach(
                 method -> customizers.forEach(customizer -> customizer.customize(operation, method.method())));
-        return Stream.of(Map.entry(operation.getOperationId(), operation));
+        return Stream.of(operation);
     }
 }

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationMethodLevelOperationsScanner.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationMethodLevelOperationsScanner.java
@@ -15,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -30,17 +29,17 @@ public class SpringAnnotationMethodLevelOperationsScanner<MethodAnnotation exten
     private final List<OperationCustomizer> customizers;
 
     @Override
-    public Stream<Map.Entry<String, Operation>> scan(Class<?> clazz) {
+    public Stream<Operation> scan(Class<?> clazz) {
         return AnnotationScannerUtil.findAnnotatedMethods(clazz, methodAnnotationClass)
                 .map(this::mapMethodToOperation);
     }
 
-    private Map.Entry<String, Operation> mapMethodToOperation(MethodAndAnnotation<MethodAnnotation> method) {
+    private Operation mapMethodToOperation(MethodAndAnnotation<MethodAnnotation> method) {
         PayloadSchemaObject payloadSchema = payloadMethodParameterService.extractSchema(method.method());
         SchemaObject headerSchema = headerClassExtractor.extractHeader(method.method(), payloadSchema);
 
         Operation operation = springAnnotationOperationService.buildOperation(method, payloadSchema, headerSchema);
         customizers.forEach(customizer -> customizer.customize(operation, method.method()));
-        return Map.entry(operation.getOperationId(), operation);
+        return operation;
     }
 }

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/operations/DefaultOperationsServiceIntegrationTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/operations/DefaultOperationsServiceIntegrationTest.java
@@ -46,12 +46,13 @@ class DefaultOperationsServiceIntegrationTest {
     static class SimpleOperationScanner implements OperationsScanner {
         @Override
         public Map<String, Operation> scan() {
-            return Map.of(
-                    "foo",
-                    Operation.builder()
-                            .channel(ChannelReference.fromChannel("foo"))
-                            .action(OperationAction.RECEIVE)
-                            .build());
+            Operation operation = Operation.builder()
+                    .operationId("foo")
+                    .channel(ChannelReference.fromChannel("foo"))
+                    .action(OperationAction.RECEIVE)
+                    .build();
+
+            return Map.of(operation.getOperationId(), operation);
         }
     }
 
@@ -61,26 +62,28 @@ class DefaultOperationsServiceIntegrationTest {
         @Component
         static class SendOperationScanner implements OperationsScanner {
             static final Operation sentOperation = Operation.builder()
+                    .operationId("send")
                     .channel(ChannelReference.fromChannel(topicName))
                     .action(OperationAction.SEND)
                     .build();
 
             @Override
             public Map<String, Operation> scan() {
-                return Map.of("send", sentOperation);
+                return Map.of(sentOperation.getOperationId(), sentOperation);
             }
         }
 
         @Component
         static class ReceiveOperationScanner implements OperationsScanner {
             static final Operation receiveOperation = Operation.builder()
+                    .operationId("receive")
                     .channel(ChannelReference.fromChannel(topicName))
                     .action(OperationAction.RECEIVE)
                     .build();
 
             @Override
             public Map<String, Operation> scan() {
-                return Map.of("receive", receiveOperation);
+                return Map.of(receiveOperation.getOperationId(), receiveOperation);
             }
         }
     }

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationMergerTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationMergerTest.java
@@ -20,14 +20,14 @@ class OperationMergerTest {
     @Test
     void shouldNotMergeDifferentoperationIds() {
         // given
-        String operationId1 = "operation1";
-        String operationId2 = "operation2";
-        Operation publisherOperation = Operation.builder().build();
-        Operation subscriberOperation = Operation.builder().build();
+        Operation publisherOperation =
+                Operation.builder().operationId("operation1").build();
+        Operation subscriberOperation =
+                Operation.builder().operationId("operation2").build();
 
         // when
-        Map<String, Operation> mergedOperations = OperationMerger.mergeOperations(Arrays.asList(
-                Map.entry(operationId1, publisherOperation), Map.entry(operationId2, subscriberOperation)));
+        Map<String, Operation> mergedOperations =
+                OperationMerger.mergeOperations(Arrays.asList(publisherOperation, subscriberOperation));
 
         // then
         assertThat(mergedOperations).hasSize(2);
@@ -49,9 +49,8 @@ class OperationMergerTest {
                 .build();
 
         // when
-        Map<String, Operation> mergedOperations = OperationMerger.mergeOperations(Arrays.asList(
-                Map.entry(publishOperation.getOperationId(), publishOperation),
-                Map.entry(subscribeOperation.getOperationId(), subscribeOperation)));
+        Map<String, Operation> mergedOperations =
+                OperationMerger.mergeOperations(Arrays.asList(publishOperation, subscribeOperation));
 
         // then
         assertThat(mergedOperations).hasSize(1);
@@ -71,9 +70,8 @@ class OperationMergerTest {
                 .build();
 
         // when
-        Map<String, Operation> mergedOperations = OperationMerger.mergeOperations(Arrays.asList(
-                Map.entry(senderOperation.getOperationId(), senderOperation),
-                Map.entry(receiverOperation.getOperationId(), receiverOperation)));
+        Map<String, Operation> mergedOperations =
+                OperationMerger.mergeOperations(Arrays.asList(senderOperation, receiverOperation));
 
         // then
         assertThat(mergedOperations).hasSize(1).hasEntrySatisfying(operationId, it -> {
@@ -122,10 +120,8 @@ class OperationMergerTest {
                 .build();
 
         // when
-        Map<String, Operation> mergedOperations = OperationMerger.mergeOperations(List.of(
-                Map.entry(senderOperation1.getOperationId(), senderOperation1),
-                Map.entry(senderOperation2.getOperationId(), senderOperation2),
-                Map.entry(senderOperation3.getOperationId(), senderOperation3)));
+        Map<String, Operation> mergedOperations =
+                OperationMerger.mergeOperations(List.of(senderOperation1, senderOperation2, senderOperation3));
 
         // then expectedMessage only includes message1 and message2.
         // Message3 is not included as it is identical in terms of payload type (Message#name) to message 2
@@ -174,17 +170,17 @@ class OperationMergerTest {
                 .build();
         Operation publishOperation1 = Operation.builder()
                 .action(OperationAction.SEND)
-                .title("publisher1")
+                .operationId("publisher1")
                 .build();
         Operation publishOperation2 = Operation.builder()
                 .action(OperationAction.SEND)
-                .title("publisher2")
+                .operationId("publisher1")
                 .messages(List.of(MessageReference.toChannelMessage(channelId, message2)))
                 .build();
 
         // when
-        Map<String, Operation> mergedOperations = OperationMerger.mergeOperations(
-                Arrays.asList(Map.entry("publisher1", publishOperation1), Map.entry("publisher1", publishOperation2)));
+        Map<String, Operation> mergedOperations =
+                OperationMerger.mergeOperations(Arrays.asList(publishOperation1, publishOperation2));
         // then expectedMessage message2
         var expectedMessage = MessageReference.toChannelMessage(channelId, message2);
 

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationsInClassScannerAdapterTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/OperationsInClassScannerAdapterTest.java
@@ -35,35 +35,32 @@ class OperationsInClassScannerAdapterTest {
     void processClassTest() {
         // given
         when(classScanner.scan()).thenReturn(Set.of(String.class));
-        Map.Entry<String, Operation> operation1 =
-                Map.entry("operation1", Operation.builder().build());
-        Map.Entry<String, Operation> operation2 =
-                Map.entry("operation2", Operation.builder().build());
+        Operation operation1 = Operation.builder().operationId("operation1").build();
+        Operation operation2 = Operation.builder().operationId("operation2").build();
         when(classProcessor.scan(any())).thenReturn(Stream.of(operation1, operation2));
 
         // when
         Map<String, Operation> operations = operationsInClassScannerAdapter.scan();
 
         // then
-        assertThat(operations).containsExactly(operation2, operation1);
+        assertThat(operations).containsExactlyEntriesOf(Map.of("operation1", operation1, "operation2", operation2));
     }
 
     @Test
     void sameOperationsAreMergedTest() {
         // given
         when(classScanner.scan()).thenReturn(Set.of(String.class));
-        Map.Entry<String, Operation> operation1 =
-                Map.entry("operation1", Operation.builder().build());
-        Map.Entry<String, Operation> operation2 =
-                Map.entry("operation1", Operation.builder().build());
+        Operation operation1 =
+                Operation.builder().operationId("operation1").description("op1").build();
+        Operation operation2 =
+                Operation.builder().operationId("operation1").description("op2").build();
         when(classProcessor.scan(any())).thenReturn(Stream.of(operation1, operation2));
 
         // when
         Map<String, Operation> operations = operationsInClassScannerAdapter.scan();
 
         // then
-        assertThat(operations)
-                .containsExactly(Map.entry("operation1", Operation.builder().build()));
+        assertThat(operations).hasSize(1);
     }
 
     @Test

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/AsyncAnnotationClassLevelOperationsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/AsyncAnnotationClassLevelOperationsScannerTest.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,7 +60,7 @@ class AsyncAnnotationClassLevelOperationsScannerTest {
         // when
         Map<String, Operation> actualOperations = operationsScanner
                 .scan(ClassWithListenerAnnotation.class)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(Collectors.toMap(Operation::getOperationId, Function.identity()));
 
         // then
         assertThat(actualOperations).hasSize(1);

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/AsyncAnnotationMethodLevelOperationsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/AsyncAnnotationMethodLevelOperationsScannerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,7 +59,7 @@ class AsyncAnnotationMethodLevelOperationsScannerTest {
         // when
         Map<String, Operation> actualOperations = operationsScanner
                 .scan(ClassWithListenerAnnotation.class)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(Collectors.toMap(Operation::getOperationId, Function.identity()));
 
         // then
         assertThat(actualOperations).containsExactly(Map.entry("operationId", operation));

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationClassLevelOperationsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationClassLevelOperationsScannerTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -37,11 +36,11 @@ class SpringAnnotationClassLevelOperationsScannerTest {
                 .thenReturn(operation);
 
         // when
-        List<Map.Entry<String, Operation>> operations =
+        List<Operation> operations =
                 scanner.scan(ClassWithTestListenerAnnotation.class).toList();
 
         // then
-        assertThat(operations).containsExactly(Map.entry("operationId", operation));
+        assertThat(operations).containsExactly(operation);
     }
 
     @Test

--- a/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationMethodLevelOperationsScannerTest.java
+++ b/springwolf-core/src/test/java/io/github/springwolf/core/asyncapi/scanners/operations/annotations/SpringAnnotationMethodLevelOperationsScannerTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -41,11 +40,11 @@ class SpringAnnotationMethodLevelOperationsScannerTest {
                 .thenReturn(operation);
 
         // when
-        List<Map.Entry<String, Operation>> operations =
+        List<Operation> operations =
                 scanner.scan(ClassWithTestListenerAnnotation.class).toList();
 
         // then
-        assertThat(operations).containsExactly(Map.entry("operationId", operation));
+        assertThat(operations).containsExactly(operation);
     }
 
     @Test

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/operations/CloudStreamFunctionOperationsScanner.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/main/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/operations/CloudStreamFunctionOperationsScanner.java
@@ -56,11 +56,11 @@ public class CloudStreamFunctionOperationsScanner implements OperationsScanner {
         elements.addAll(componentClassScanner.scan());
         elements.addAll(beanMethodsScanner.getBeanMethods());
 
-        List<Map.Entry<String, Operation>> operations = elements.stream()
+        List<Operation> operations = elements.stream()
                 .map(functionalChannelBeanBuilder::build)
                 .flatMap(Set::stream)
                 .filter(this::isChannelBean)
-                .map(this::toOperationEntry)
+                .map(this::buildOperation)
                 .toList();
 
         return OperationMerger.mergeOperations(operations);
@@ -68,12 +68,6 @@ public class CloudStreamFunctionOperationsScanner implements OperationsScanner {
 
     private boolean isChannelBean(FunctionalChannelBeanData beanData) {
         return cloudStreamBindingsProperties.getBindings().containsKey(beanData.cloudStreamBinding());
-    }
-
-    private Map.Entry<String, Operation> toOperationEntry(FunctionalChannelBeanData beanData) {
-        Operation operation = buildOperation(beanData);
-
-        return Map.entry(operation.getOperationId(), operation);
     }
 
     private Operation buildOperation(FunctionalChannelBeanData beanData) {


### PR DESCRIPTION
Possible because Operation@operationId added.
Continuation of 0eaa374f0a9e5cd9f33daeaec7a52bb4150a6a4e