### PR TITLE
Fix functional beans that use inheritance

### DIFF
--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/common/FunctionalChannelBeanBuilderTest.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/common/FunctionalChannelBeanBuilderTest.java
@@ -318,6 +318,97 @@ class FunctionalChannelBeanBuilderTest {
                 public void accept(KStream<Void, String> voidStringKStream) {}
             }
         }
+
+        @Nested
+        class InheritanceTypes {
+
+            @Test
+            void testBiConsumerChildBean() throws NoSuchMethodException {
+                Method method = getMethod(this.getClass(), "biConsumerChildBean");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data)
+                        .containsExactly(new FunctionalChannelBeanData(
+                                "biConsumerChildBean", method, String.class, CONSUMER, "biConsumerChildBean-in-0"));
+            }
+
+            @Test
+            void testBiConsumerChildChildBean() throws NoSuchMethodException {
+                Method method = getMethod(this.getClass(), "biConsumerChildChildBean");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data)
+                        .containsExactly(new FunctionalChannelBeanData(
+                                "biConsumerChildChildBean",
+                                method,
+                                String.class,
+                                CONSUMER,
+                                "biConsumerChildChildBean-in-0"));
+            }
+
+            @Test
+            void testConsumerChildClassBean() throws NoSuchMethodException {
+                Method method = getMethod(this.getClass(), "consumerChildClassBean");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data)
+                        .containsExactly(new FunctionalChannelBeanData(
+                                "consumerChildClassBean",
+                                method,
+                                String.class,
+                                CONSUMER,
+                                "consumerChildClassBean-in-0"));
+            }
+
+            @Test
+            void testConsumerChildChildClassBean() throws NoSuchMethodException {
+                Method method = getMethod(this.getClass(), "consumerChildChildClassBean");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data)
+                        .containsExactly(new FunctionalChannelBeanData(
+                                "consumerChildChildClassBean",
+                                method,
+                                String.class,
+                                CONSUMER,
+                                "consumerChildChildClassBean-in-0"));
+            }
+
+            interface BiConsumerChild extends BiConsumer<String, String> {}
+
+            interface BiConsumerChildChild extends BiConsumerChild {}
+
+            static class ConsumerChildClass implements Consumer<String> {
+                @Override
+                public void accept(final String s) {}
+            }
+
+            static class ConsumerChildChildClass extends ConsumerChildClass {}
+
+            @Bean
+            private BiConsumerChild biConsumerChildBean() {
+                return (input, headers) -> System.out.println(input);
+            }
+
+            @Bean
+            private BiConsumerChildChild biConsumerChildChildBean() {
+                return (input, headers) -> System.out.println(input);
+            }
+
+            @Bean
+            private ConsumerChildClass consumerChildClassBean() {
+                return new ConsumerChildClass();
+            }
+
+            @Bean
+            private ConsumerChildChildClass consumerChildChildClassBean() {
+                return new ConsumerChildChildClass();
+            }
+        }
     }
 
     private static Method getMethod(Class<?> clazz, String methodName) throws NoSuchMethodException {

--- a/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/common/FunctionalChannelBeanBuilderTest.java
+++ b/springwolf-plugins/springwolf-cloud-stream-plugin/src/test/java/io/github/springwolf/plugins/cloudstream/asyncapi/scanners/common/FunctionalChannelBeanBuilderTest.java
@@ -334,6 +334,42 @@ class FunctionalChannelBeanBuilderTest {
             }
 
             @Test
+            void testBiConsumerRawChildBean() throws NoSuchMethodException {
+                Method method = getMethod(this.getClass(), "biConsumerRawChildBean");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data).isEmpty();
+            }
+
+            @Test
+            void testSupplierRawChildBean() throws NoSuchMethodException {
+                Method method = getMethod(this.getClass(), "supplierRawChild");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data).isEmpty();
+            }
+
+            @Test
+            void testFunctionRawChildBean() throws NoSuchMethodException {
+                Method method = getMethod(this.getClass(), "functionRawChild");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data).isEmpty();
+            }
+
+            @Test
+            void testBiFunctionRawChildBean() throws NoSuchMethodException {
+                Method method = getMethod(this.getClass(), "biFunctionRawChild");
+
+                Set<FunctionalChannelBeanData> data = functionalChannelBeanBuilder.build(method);
+
+                Assertions.assertThat(data).isEmpty();
+            }
+
+            @Test
             void testBiConsumerChildChildBean() throws NoSuchMethodException {
                 Method method = getMethod(this.getClass(), "biConsumerChildChildBean");
 
@@ -380,6 +416,14 @@ class FunctionalChannelBeanBuilderTest {
 
             interface BiConsumerChild extends BiConsumer<String, String> {}
 
+            interface BiConsumerRawChild extends BiConsumer {}
+
+            interface SupplierRawChild extends Supplier {}
+
+            interface FunctionRawChild extends Function {}
+
+            interface BiFunctionRawChild extends BiFunction {}
+
             interface BiConsumerChildChild extends BiConsumerChild {}
 
             static class ConsumerChildClass implements Consumer<String> {
@@ -392,6 +436,26 @@ class FunctionalChannelBeanBuilderTest {
             @Bean
             private BiConsumerChild biConsumerChildBean() {
                 return (input, headers) -> System.out.println(input);
+            }
+
+            @Bean
+            private BiConsumerRawChild biConsumerRawChildBean() {
+                return (input, headers) -> System.out.println(input);
+            }
+
+            @Bean
+            private SupplierRawChild supplierRawChild() {
+                return () -> null;
+            }
+
+            @Bean
+            private FunctionRawChild functionRawChild() {
+                return (input) -> null;
+            }
+
+            @Bean
+            private BiFunctionRawChild biFunctionRawChild() {
+                return (input, headers) -> null;
             }
 
             @Bean


### PR DESCRIPTION
Since a bean with a functional interface could be a child interface or child class, the whole class-hierarchy should be considered.

Fixes #1260