### PR TITLE
(refactor): improve exception message

### DIFF
--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/components/examples/walkers/DefaultSchemaWalker.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/components/examples/walkers/DefaultSchemaWalker.java
@@ -338,8 +338,7 @@ public class DefaultSchemaWalker<T, R> implements SchemaWalker<R> {
             Schema<?> resolvedSchema = definitions.get(schemaName);
             if (resolvedSchema == null) {
                 throw new ExampleGeneratingException(
-                    String.format("Missing schema (name = %s) during example generation", schemaName)
-                );
+                        String.format("Missing schema (name = %s) during example generation", schemaName));
             }
             return Optional.of(resolvedSchema);
         }

--- a/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/components/examples/walkers/DefaultSchemaWalker.java
+++ b/springwolf-core/src/main/java/io/github/springwolf/core/asyncapi/components/examples/walkers/DefaultSchemaWalker.java
@@ -337,7 +337,9 @@ public class DefaultSchemaWalker<T, R> implements SchemaWalker<R> {
             String schemaName = ReferenceUtil.getLastSegment(ref);
             Schema<?> resolvedSchema = definitions.get(schemaName);
             if (resolvedSchema == null) {
-                throw new ExampleGeneratingException("Missing schema during example generation: " + schemaName);
+                throw new ExampleGeneratingException(
+                    String.format("Missing schema (name = %s) during example generation", schemaName)
+                );
             }
             return Optional.of(resolvedSchema);
         }


### PR DESCRIPTION
It has been unclear that the text after a colon is a schema's name.  
This PR makes this clear.