### PR TITLE
feat(sns): add SNS headers when sending message from springwolf ui

### DIFF
--- a/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/springwolf/plugins/sns/controller/SpringwolfSnsController.java
+++ b/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/springwolf/plugins/sns/controller/SpringwolfSnsController.java
@@ -6,7 +6,6 @@ import io.github.springwolf.core.controller.PublishingPayloadCreator;
 import io.github.springwolf.core.controller.dtos.MessageDto;
 import io.github.springwolf.plugins.sns.producer.SpringwolfSnsProducer;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,6 +29,6 @@ public class SpringwolfSnsController extends PublishingBaseController {
     @Override
     protected void publishMessage(String topic, MessageDto message, Object payload) {
         log.debug("Publishing to sns topic {}: {}", topic, message);
-        producer.send(topic, MessageBuilder.withPayload(payload).build());
+        producer.send(topic, message.getHeaders(), payload);
     }
 }

--- a/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/springwolf/plugins/sns/producer/SpringwolfSnsProducer.java
+++ b/springwolf-plugins/springwolf-sns-plugin/src/main/java/io/github/springwolf/plugins/sns/producer/SpringwolfSnsProducer.java
@@ -2,10 +2,14 @@
 package io.github.springwolf.plugins.sns.producer;
 
 import io.awspring.cloud.sns.core.SnsTemplate;
+import io.github.springwolf.core.controller.dtos.MessageDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -21,11 +25,24 @@ public class SpringwolfSnsProducer {
         return template.isPresent();
     }
 
-    public void send(String channelName, Message<?> payload) {
+    public void send(String channelName, Map<String, MessageDto.HeaderValue> headers, Object payload) {
         if (template.isPresent()) {
-            template.get().send(channelName, payload);
+            Message<?> message = MessageBuilder.withPayload(payload)
+                    .copyHeaders(mapHeaders(headers))
+                    .build();
+            template.get().send(channelName, message);
         } else {
             log.warn("SNS producer is not configured");
         }
+    }
+
+    private static Map<String, String> mapHeaders(Map<String, MessageDto.HeaderValue> headers) {
+        return headers.entrySet().stream()
+                .collect(
+                        HashMap::new,
+                        (m, e) -> m.put(
+                                e.getKey(),
+                                e.getValue() == null ? null : e.getValue().stringValue()),
+                        HashMap::putAll);
     }
 }

--- a/springwolf-plugins/springwolf-sns-plugin/src/test/java/io/github/springwolf/plugins/sns/producer/SpringwolfSnsProducerTest.java
+++ b/springwolf-plugins/springwolf-sns-plugin/src/test/java/io/github/springwolf/plugins/sns/producer/SpringwolfSnsProducerTest.java
@@ -2,39 +2,59 @@
 package io.github.springwolf.plugins.sns.producer;
 
 import io.awspring.cloud.sns.core.SnsTemplate;
+import io.github.springwolf.core.controller.dtos.MessageDto;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.MessageHeaders;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 class SpringwolfSnsProducerTest {
-    private SpringwolfSnsProducer springwolfSqsProducer;
+    private SpringwolfSnsProducer springwolfSnsProducer;
 
     private SnsTemplate template;
+    private final ArgumentCaptor<Message<Object>> messageCaptor = ArgumentCaptor.forClass(Message.class);
 
     @BeforeEach
     void setUp() {
         template = mock(SnsTemplate.class);
 
-        springwolfSqsProducer = new SpringwolfSnsProducer(Collections.singletonList(template));
+        springwolfSnsProducer = new SpringwolfSnsProducer(Collections.singletonList(template));
     }
 
     @Test
     void send_defaultExchangeAndChannelNameAsRoutingKey() {
         Map<String, Object> payload = new HashMap<>();
-        Message<Map<String, Object>> message =
-                MessageBuilder.withPayload(payload).build();
-        springwolfSqsProducer.send("channel-name", message);
+        Map<String, MessageDto.HeaderValue> headers = new HashMap<>() {
+            {
+                put("header1", new MessageDto.HeaderValue("value1"));
+                put("header2", new MessageDto.HeaderValue("value2"));
+                put("nullHeader1", new MessageDto.HeaderValue(null));
+                put("nullHeader2", null);
+            }
+        };
+        springwolfSnsProducer.send("channel-name", headers, payload);
 
-        verify(template).send(eq("channel-name"), same(message));
+        verify(template).send(eq("channel-name"), messageCaptor.capture());
+
+        Object producedPayload = messageCaptor.getValue().getPayload();
+        Assertions.assertThat(producedPayload).isSameAs(payload);
+        MessageHeaders producedHeaders = messageCaptor.getValue().getHeaders();
+        Assertions.assertThat(producedHeaders).containsAllEntriesOf(new HashMap<>() {
+            {
+                put("header1", "value1");
+                put("header2", "value2");
+            }
+        });
+        Assertions.assertThat(producedHeaders).doesNotContainKeys("nullHeader1", "nullHeader2");
     }
 }

--- a/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/springwolf/plugins/sqs/controller/SpringwolfSqsController.java
+++ b/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/springwolf/plugins/sqs/controller/SpringwolfSqsController.java
@@ -6,8 +6,6 @@ import io.github.springwolf.core.controller.PublishingPayloadCreator;
 import io.github.springwolf.core.controller.dtos.MessageDto;
 import io.github.springwolf.plugins.sqs.producer.SpringwolfSqsProducer;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,9 +29,6 @@ public class SpringwolfSqsController extends PublishingBaseController {
     @Override
     protected void publishMessage(String topic, MessageDto messageDto, Object payload) {
         log.debug("Publishing to sqs queue {}: {}", topic, messageDto);
-        Message<Object> message = MessageBuilder.withPayload(payload)
-                .copyHeaders(messageDto.getHeaders())
-                .build();
-        producer.send(topic, message);
+        producer.send(topic, messageDto.getHeaders(), payload);
     }
 }

--- a/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/springwolf/plugins/sqs/producer/SpringwolfSqsProducer.java
+++ b/springwolf-plugins/springwolf-sqs-plugin/src/main/java/io/github/springwolf/plugins/sqs/producer/SpringwolfSqsProducer.java
@@ -2,10 +2,14 @@
 package io.github.springwolf.plugins.sqs.producer;
 
 import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.github.springwolf.core.controller.dtos.MessageDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -21,11 +25,24 @@ public class SpringwolfSqsProducer {
         return template.isPresent();
     }
 
-    public void send(String channelName, Message<?> message) {
+    public void send(String channelName, Map<String, MessageDto.HeaderValue> headers, Object payload) {
         if (template.isPresent()) {
+            Message<?> message = MessageBuilder.withPayload(payload)
+                    .copyHeaders(mapHeaders(headers))
+                    .build();
             template.get().send(channelName, message);
         } else {
             log.warn("SQS producer is not configured");
         }
+    }
+
+    private static Map<String, String> mapHeaders(Map<String, MessageDto.HeaderValue> headers) {
+        return headers.entrySet().stream()
+                .collect(
+                        HashMap::new,
+                        (m, e) -> m.put(
+                                e.getKey(),
+                                e.getValue() == null ? null : e.getValue().stringValue()),
+                        HashMap::putAll);
     }
 }

--- a/springwolf-plugins/springwolf-sqs-plugin/src/test/java/io/github/springwolf/plugins/sqs/producer/SpringwolfSqsProducerTest.java
+++ b/springwolf-plugins/springwolf-sqs-plugin/src/test/java/io/github/springwolf/plugins/sqs/producer/SpringwolfSqsProducerTest.java
@@ -2,17 +2,19 @@
 package io.github.springwolf.plugins.sqs.producer;
 
 import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.github.springwolf.core.controller.dtos.MessageDto;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.MessageHeaders;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -20,6 +22,7 @@ class SpringwolfSqsProducerTest {
     private SpringwolfSqsProducer springwolfSqsProducer;
 
     private SqsTemplate template;
+    private final ArgumentCaptor<Message<Object>> messageCaptor = ArgumentCaptor.forClass(Message.class);
 
     @BeforeEach
     void setUp() {
@@ -31,10 +34,27 @@ class SpringwolfSqsProducerTest {
     @Test
     void send_defaultExchangeAndChannelNameAsRoutingKey() {
         Map<String, Object> payload = new HashMap<>();
-        Message<?> message = MessageBuilder.withPayload(payload).build();
+        Map<String, MessageDto.HeaderValue> headers = new HashMap<>() {
+            {
+                put("header1", new MessageDto.HeaderValue("value1"));
+                put("header2", new MessageDto.HeaderValue("value2"));
+                put("nullHeader1", new MessageDto.HeaderValue(null));
+                put("nullHeader2", null);
+            }
+        };
+        springwolfSqsProducer.send("channel-name", headers, payload);
 
-        springwolfSqsProducer.send("channel-name", message);
+        verify(template).send(eq("channel-name"), messageCaptor.capture());
 
-        verify(template).send(eq("channel-name"), same(message));
+        Object producedPayload = messageCaptor.getValue().getPayload();
+        Assertions.assertThat(producedPayload).isSameAs(payload);
+        MessageHeaders producedHeaders = messageCaptor.getValue().getHeaders();
+        Assertions.assertThat(producedHeaders).containsAllEntriesOf(new HashMap<>() {
+            {
+                put("header1", "value1");
+                put("header2", "value2");
+            }
+        });
+        Assertions.assertThat(producedHeaders).doesNotContainKeys("nullHeader1", "nullHeader2");
     }
 }


### PR DESCRIPTION
**Why ?**

Because when we send message from springwolf UI, headers are not send

**What does PR contain ?**

The headers defined in Springwolf's SNS UI are sent with the message (like previous PR for SQS).
Uniformity of header management between the SQS/SNS/JMS/... plugins.
